### PR TITLE
Add profiler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 | **navigation** | 4 | React Navigation / Expo Router state |
 | **accessibility** | 3 | Accessibility auditing |
 | **commands** | 2 | Custom app commands |
+| **profiler** | 5 | CPU profiling (Hermes CDP) + React render tracking |
 | **maestro** | 2 | Maestro test flow generation |
 | **appium** | 3 | Appium/WebdriverIO Jest test generation |
 
-**Total: 50 tools, 7 resources, 7 prompts** — see the [full tools reference](docs/tools.md).
+**Total: 55 tools, 9 resources, 7 prompts** — see the [full tools reference](docs/tools.md).
 
 ## App Integration (Optional)
 
@@ -98,7 +99,7 @@ Register custom commands and expose state to the MCP server — no package neede
 
 ```typescript
 if (__DEV__) {
-  global.__METRO_MCP__ = {
+  globalThis.__METRO_MCP__ = {
     commands: {
       // Run custom actions from the MCP client
       login: async ({ email, password }) => {
@@ -121,7 +122,7 @@ if (__DEV__) {
 
 Use `list_commands` and `run_command` to call these from the MCP client.
 
-For enhanced features like real-time Redux action tracking, navigation events, and performance marks, see the [optional client SDK](docs/sdk.md).
+For enhanced features like real-time Redux action tracking, navigation events, performance marks, and React render profiling, see the [optional client SDK](docs/sdk.md) and [profiling guide](docs/profiling.md).
 
 ## Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,5 +38,21 @@ export default defineConfig({
   network: {
     interceptFetch: false,  // Opt-in: inject JS to wrap fetch()
   },
+  profiler: {
+    newArchitecture: true,  // Set to false for legacy bridge apps
+  },
 });
 ```
+
+## Profiler Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `profiler.newArchitecture` | `true` | Controls which profiling path is used. When `true` (default), `__REACT_DEVTOOLS_GLOBAL_HOOK__` is used as the primary path — works on all architectures including Bridgeless/Fusebox. When `false`, CDP `Profiler.*` domain calls are attempted first (suitable for legacy bridge apps). |
+
+### Which value should I use?
+
+- **Expo SDK 50+ / RN 0.74+ (New Architecture / Bridgeless)**: keep `true` (default)
+- **Legacy bridge apps on older RN / Hermes**: set to `false` — the CDP Profiler domain may be available and provides a lower-overhead CPU call-graph
+
+The server also auto-detects Fusebox targets via the `prefersFuseboxFrontend` CDP capability and skips CDP fallbacks automatically, regardless of this setting.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,170 @@
+# Profiling
+
+metro-mcp provides two complementary profiling approaches that work together:
+
+| | CDP CPU Profiler | React `<Profiler>` |
+|---|---|---|
+| **What it measures** | Every JS function on the thread | React render phases only |
+| **Granularity** | Individual functions and call stacks | Component subtree totals |
+| **Shows** | Redux, navigation, your utils, React internals — everything | `actualDuration` vs `baseDuration` per component tree |
+| **Tells you** | *Which function* is slow and exactly *where* in the call stack | *Which component tree* is slow to render and whether `memo`/`useMemo` is helping |
+| **App changes** | None required | Requires `<Profiler onRender={trackRender}>` |
+
+Use the `debug-performance` prompt to run both together automatically.
+
+---
+
+## CDP CPU Profiler
+
+Hermes exposes a sampling CPU profiler via the Chrome DevTools Protocol. metro-mcp enables this with three tools.
+
+### Tools
+
+**`start_profiling`**
+
+Starts sampling the JS call stack. Takes an optional `samplingInterval` in microseconds (default: `1000` = 1ms).
+
+```
+Lower interval → more precise, higher overhead
+100–500 µs   high precision
+1000 µs      balanced (default)
+10000+ µs    low overhead
+```
+
+**`stop_profiling`**
+
+Stops profiling and returns an analysis of the captured call-graph:
+
+```json
+{
+  "durationMs": 2340,
+  "sampleCount": 2340,
+  "samplingRateMs": 1.0,
+  "topFunctions": [
+    {
+      "functionName": "processData",
+      "location": "src/utils/data.ts:142",
+      "selfTime": "290ms (12.4%)",
+      "totalTime": "443ms (18.9%)"
+    }
+  ]
+}
+```
+
+- **selfTime** — time spent in this function specifically (not counting callees). The primary metric for finding hotspots.
+- **totalTime** — time in this function including everything it calls.
+
+Params: `topN` (default 20), `includeNative` (default false — excludes Hermes internals).
+
+**`get_profile_status`**
+
+Returns whether profiling is active and whether a previous profile is available.
+
+### Workflow
+
+```
+start_profiling
+  → perform the interaction you want to measure
+stop_profiling
+  → read metro://profiler/flamegraph for a visual breakdown
+```
+
+---
+
+## React `<Profiler>`
+
+React's built-in [`<Profiler>`](https://react.dev/reference/react/Profiler) component measures how long component subtrees take to render. metro-mcp collects this data via a single `trackRender` callback from the client SDK.
+
+### Setup
+
+Install metro-mcp as a dev dependency in your app:
+
+```bash
+npm install --save-dev metro-mcp
+# or
+bun add -d metro-mcp
+```
+
+Import `trackRender` and pass it to any `<Profiler>` component:
+
+```tsx
+import { Profiler } from 'react';
+import { trackRender } from 'metro-mcp/client';
+
+// Wrap a specific subtree you want to measure
+<Profiler id="sidebar" onRender={trackRender}>
+  <Sidebar />
+</Profiler>
+
+// Or wrap multiple areas independently
+<Profiler id="feed" onRender={trackRender}>
+  <FeedList />
+</Profiler>
+```
+
+The `id` string identifies the profiler in the results. Use it to name the component or screen you're measuring.
+
+> `<Profiler>` fires on every render commit, so data accumulates continuously. Use `get_react_renders` with `clear=true` to reset the buffer before the interaction you want to isolate.
+
+### Tool
+
+**`get_react_renders`**
+
+Returns all collected renders sorted by `actualDuration` descending:
+
+```json
+[
+  {
+    "id": "sidebar",
+    "phase": "update",
+    "actualDuration": 42.3,
+    "baseDuration": 89.1,
+    "memoSavingsPercent": 52.5,
+    "startTime": 1234567.89,
+    "commitTime": 1234610.19
+  }
+]
+```
+
+- **actualDuration** — milliseconds React spent rendering this commit. Lower is better.
+- **baseDuration** — estimated cost to re-render the full subtree with no memoization. Represents worst-case.
+- **memoSavingsPercent** — `(baseDuration - actualDuration) / baseDuration × 100`. High value means `memo`/`useMemo` is working well. Low value means there's room to add memoization.
+
+Use `clear=true` to reset the buffer after reading.
+
+---
+
+## Resources
+
+Both profiling approaches feed into shared resources.
+
+**`metro://profiler/flamegraph`** — Human-readable text output combining both sources:
+
+```
+=== CPU Flamegraph (by total time) ===
+Duration: 2340ms | Samples: 2340
+
+▼ renderApp                     45.2% ████████████████████████  1058ms total
+  ▼ FlatList._render            23.1% ████████████               541ms total
+    ■ processData               12.4% ██████                     290ms self
+
+=== Ranked by Self Time ===
+ #  Function                        Self%    Self ms  Total%   Total ms  Location
+ 1  processData                     12.4%    290ms    18.9%     443ms    src/utils/data.ts:142
+
+=== React Renders — Ranked by Actual Duration ===
+ #  Component                  Phase          Actual     Base  Savings  Chart
+ 1  sidebar                    update         42.3ms   89.1ms       52%  ████████████
+```
+
+**`metro://profiler/data`** — Raw JSON with the full CDP Profile object (nodes, samples, timeDeltas) and pre-computed stats, plus all React render records. Useful for agent analysis or exporting to other tools.
+
+---
+
+## Tips
+
+- **Start with the CPU profiler** if you don't know where the slowness is — it will show you which code is actually executing.
+- **Use `<Profiler>`** once you've identified a slow screen and want to measure the impact of adding `memo` or `useMemo`.
+- **Compare actualDuration vs baseDuration** — a large gap means memoization is already working. A small gap means the component can't skip rendering and you need to investigate with the CPU profiler.
+- **Re-render count** in `get_react_renders` summary is often more telling than duration — a component rendering 50 times is a bigger problem than one rendering once slowly.
+- Keep `<Profiler>` wrappers in `__DEV__` blocks. They add overhead and are disabled in production builds by default, but it's good practice to guard them explicitly.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -9,7 +9,7 @@ You can register commands and expose custom state directly on a global — no pa
 ```typescript
 // In your app entry point (dev only)
 if (__DEV__) {
-  global.__METRO_MCP__ = {
+  globalThis.__METRO_MCP__ = {
     commands: {
       login: async ({ email, password }) => {
         return await authService.login(email, password);

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,6 +107,23 @@ All tools use the CDP fiber tree first, falling back to `simctl`/`adb`, then IDB
 - **`list_commands`** — List custom commands registered by the app.
 - **`run_command`** — Execute a custom command with parameters.
 
+## Profiler
+
+See the [profiling guide](profiling.md) for a full explanation of CDP CPU profiling vs React `<Profiler>`.
+
+- **`start_profiling`** — Start Hermes CPU profiling via CDP. Param: `samplingInterval` in µs (default 1000). Captures all JS execution — React, Redux, navigation, your code.
+- **`stop_profiling`** — Stop profiling and return top functions ranked by self time and total time. Params: `topN` (default 20), `includeNative` (default false).
+- **`get_profile_status`** — Check whether profiling is active and whether a previous profile is available.
+- **`get_flamegraph`** — Return the current profiling results as a human-readable text flamegraph: CPU call tree + ranked chart + React render chart.
+- **`get_react_renders`** — Read render timings from `<Profiler onRender={trackRender}>` components. Returns renders sorted by `actualDuration` with `memoSavingsPercent`. Requires `trackRender` from `metro-mcp/client`. Param: `clear` (bool).
+
+### Profiler Resources
+
+| URI | Description |
+|-----|-------------|
+| `metro://profiler/flamegraph` | CPU call tree with time bars + ranked self-time chart + React render chart (text) |
+| `metro://profiler/data` | Raw JSON: full CDP Profile object + React render records with memo savings |
+
 ## Maestro
 
 - **`generate_maestro_flow`** — Generate Maestro YAML from a test description.
@@ -141,6 +158,8 @@ All tools support modifiers to reduce context window usage:
 | `metro://redux/state` | Redux state snapshot |
 | `metro://navigation` | Navigation state |
 | `metro://bundle/status` | Metro bundle status |
+| `metro://profiler/flamegraph` | CPU flamegraph + React render chart (text) |
+| `metro://profiler/data` | Raw JSON profiling data for agent analysis |
 
 ## Prompts
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dev": "bun run --watch src/index.ts",
     "clean": "rm -rf dist",
     "build": "bun run clean && bun run build:js && bun run build:bin && bun run build:types",
-    "build:js": "bun build src/index.ts src/client/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod",
+    "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.js --target browser --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.cjs --target browser --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod",
     "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target bun --external @modelcontextprotocol/sdk --external zod && chmod +x dist/bin/metro-mcp.js",
     "build:types": "bunx tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit"

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,7 +2,7 @@
  * metro-mcp Client SDK
  *
  * Optional dev dependency for enhanced features.
- * All features register on global.__METRO_MCP__ which the server
+ * All features register on globalThis.__METRO_MCP__ which the server
  * discovers via Runtime.evaluate.
  *
  * Usage:
@@ -25,7 +25,6 @@ import { LifecycleTracker } from './lifecycle.js';
 import { ClientBuffer } from './client-buffer.js';
 
 declare const __DEV__: boolean;
-declare const global: Record<string, unknown>;
 
 export interface MetroMCPGlobal {
   commands: Record<string, (params: Record<string, unknown>) => unknown>;
@@ -51,6 +50,8 @@ export interface MetroMCPGlobal {
   lifecycle?: {
     events: ClientBuffer<unknown>;
   };
+  renders?: unknown[];
+  clearRenders?: () => void;
 }
 
 export class MetroMCPClient {
@@ -70,8 +71,8 @@ export class MetroMCPClient {
     this.stateManager = new StateSubscriptionManager();
     this.lifecycleTracker = new LifecycleTracker();
 
-    // Register on global
-    (global as Record<string, unknown>).__METRO_MCP__ = this.mcpGlobal;
+    // Register on globalThis
+    (globalThis as Record<string, unknown>).__METRO_MCP__ = this.mcpGlobal;
   }
 
   // ── Custom Commands ──
@@ -157,7 +158,8 @@ export class MetroMCPClient {
 // Also export individual pieces for tree-shaking
 export { createReduxMiddleware } from './middleware/redux.js';
 export { createNavigationTracking } from './middleware/navigation.js';
-export { PerformanceTracker } from './performance.js';
+export { PerformanceTracker, trackRender } from './performance.js';
+export type { RenderRecord } from './performance.js';
 export { StructuredLogger } from './logger.js';
 export { StateSubscriptionManager } from './state.js';
 export { LifecycleTracker } from './lifecycle.js';
@@ -167,7 +169,7 @@ export function registerCommand(
   name: string,
   handler: (params: Record<string, unknown>) => unknown
 ): void {
-  const g = global as Record<string, unknown>;
+  const g = globalThis as Record<string, unknown>;
   if (!g.__METRO_MCP__) {
     g.__METRO_MCP__ = { commands: {} };
   }

--- a/src/client/performance.ts
+++ b/src/client/performance.ts
@@ -1,6 +1,57 @@
 /**
- * Performance marks and measures.
+ * Performance marks and measures, plus React Profiler render tracking.
  */
+
+export interface RenderRecord {
+  id: string;
+  phase: 'mount' | 'update' | 'nested-update';
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+}
+
+const MAX_RENDERS = 200;
+
+interface MetroMCPRenders {
+  renders: RenderRecord[];
+  clearRenders: () => void;
+}
+
+function getOrInitRenders(): MetroMCPRenders {
+  const g = globalThis as Record<string, unknown>;
+  if (!g.__METRO_MCP__) g.__METRO_MCP__ = {};
+  const mcp = g.__METRO_MCP__ as Record<string, unknown>;
+  if (!mcp.renders) {
+    const renders: RenderRecord[] = [];
+    const clearRenders = () => { renders.length = 0; };
+    mcp.renders = renders;
+    mcp.clearRenders = clearRenders;
+  }
+  return { renders: mcp.renders as RenderRecord[], clearRenders: mcp.clearRenders as () => void };
+}
+
+/**
+ * Drop-in onRender callback for React's <Profiler> component.
+ *
+ * Usage:
+ *   import { trackRender } from 'metro-mcp/client';
+ *   <Profiler id="sidebar" onRender={trackRender}>
+ *     <Sidebar />
+ *   </Profiler>
+ */
+export function trackRender(
+  id: string,
+  phase: 'mount' | 'update' | 'nested-update',
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number
+): void {
+  const { renders } = getOrInitRenders();
+  renders.push({ id, phase, actualDuration, baseDuration, startTime, commitTime });
+  if (renders.length > MAX_RENDERS) renders.splice(0, renders.length - MAX_RENDERS);
+}
 
 export interface PerformanceMeasure {
   name: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,9 @@ const DEFAULT_CONFIG: Required<MetroMCPConfig> = {
   network: {
     interceptFetch: false,
   },
+  profiler: {
+    newArchitecture: true,
+  },
 };
 
 /**
@@ -92,5 +95,8 @@ function mergeConfig(target: Required<MetroMCPConfig>, source: MetroMCPConfig): 
   }
   if (source.network) {
     if (source.network.interceptFetch !== undefined) target.network.interceptFetch = source.network.interceptFetch;
+  }
+  if (source.profiler) {
+    if (source.profiler.newArchitecture !== undefined) target.profiler.newArchitecture = source.profiler.newArchitecture;
   }
 }

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -48,9 +48,6 @@ export class CDPClient implements CDPConnection {
     this.emit('reconnected', {});
   }
 
-  /**
-   * Wait for an in-progress connection attempt to finish, if any.
-   */
   async waitForConnection(): Promise<boolean> {
     if (this._isConnected) return true;
     if (this.connectingPromise) {

--- a/src/metro/types.ts
+++ b/src/metro/types.ts
@@ -13,6 +13,12 @@ export interface MetroTarget {
   deviceName?: string;
   reactNative?: {
     logicalDeviceId?: string;
+    capabilities?: {
+      nativePageReloads?: boolean;
+      nativeSourceCodeFetching?: boolean;
+      /** true = New Architecture / Fusebox inspector. CDP Profiler domain is not forwarded in this mode. */
+      prefersFuseboxFrontend?: boolean;
+    };
   };
   vm?: string;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,6 +8,8 @@ export interface CDPConnection {
   on(event: string, handler: (params: Record<string, unknown>) => void): void;
   off(event: string, handler: (params: Record<string, unknown>) => void): void;
   isConnected(): boolean;
+  /** Returns metadata about the currently connected CDP target, or null if not connected. */
+  getTarget(): { description?: string; reactNative?: { capabilities?: { prefersFuseboxFrontend?: boolean } } } | null;
 }
 
 // ── Format Utilities ──
@@ -119,6 +121,15 @@ export interface MetroMCPConfig {
   };
   network?: {
     interceptFetch?: boolean;
+  };
+  profiler?: {
+    /**
+     * Whether the app uses the New Architecture (Bridgeless/Fusebox).
+     * When true (default), the React DevTools hook is used as the primary profiling
+     * path and CDP Profiler domain fallbacks are skipped.
+     * Set to false for legacy bridge apps that expose the CDP Profiler domain.
+     */
+    newArchitecture?: boolean;
   };
 }
 

--- a/src/plugins/profiler.ts
+++ b/src/plugins/profiler.ts
@@ -1,0 +1,687 @@
+import { z } from 'zod';
+import { definePlugin } from '../plugin.js';
+
+// ── CDP CPU profiler types ────────────────────────────────────────────────────
+
+interface CallFrame {
+  functionName: string;
+  scriptId: string;
+  url: string;
+  lineNumber: number;
+  columnNumber: number;
+}
+
+interface ProfileNode {
+  id: number;
+  callFrame: CallFrame;
+  hitCount: number;
+  children?: number[];
+}
+
+interface CpuProfile {
+  nodes: ProfileNode[];
+  startTime: number;
+  endTime: number;
+  samples?: number[];
+  timeDeltas?: number[];
+}
+
+// ── React DevTools hook types ─────────────────────────────────────────────────
+
+interface CommitComponent {
+  name: string;
+  actualMs: number;
+  selfMs: number;
+}
+
+interface CommitData {
+  timestamp: number;
+  duration: number;
+  components: CommitComponent[];
+}
+
+type DevToolsProfile = CommitData[];
+
+// ── React render record (trackRender / <Profiler>) ────────────────────────────
+
+interface RenderRecord {
+  id: string;
+  phase: 'mount' | 'update' | 'nested-update';
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+}
+
+// ── CDP CPU analysis ──────────────────────────────────────────────────────────
+
+interface FunctionStat {
+  functionName: string;
+  url: string;
+  lineNumber: number;
+  selfMs: number;
+  selfPercent: number;
+  totalMs: number;
+  totalPercent: number;
+}
+
+interface CpuAnalysis {
+  durationMs: number;
+  sampleCount: number;
+  topFunctions: FunctionStat[];
+  totalSamplesMap: Map<number, number>;
+  selfSamplesMap: Map<number, number>;
+}
+
+const SKIP_FN_NAMES = new Set(['(root)', '(idle)', '(program)']);
+
+function analyzeCpuProfile(profile: CpuProfile, topN: number, includeNative: boolean): CpuAnalysis {
+  const durationMs = (profile.endTime - profile.startTime) / 1000;
+  const samples = profile.samples ?? [];
+
+  const parentMap = new Map<number, number>();
+  for (const node of profile.nodes) {
+    for (const childId of node.children ?? []) parentMap.set(childId, node.id);
+  }
+
+  const selfSamplesMap = new Map<number, number>();
+  const totalSamplesMap = new Map<number, number>();
+
+  for (const nodeId of samples) {
+    selfSamplesMap.set(nodeId, (selfSamplesMap.get(nodeId) ?? 0) + 1);
+    let current: number | undefined = nodeId;
+    const visited = new Set<number>();
+    while (current !== undefined && !visited.has(current)) {
+      visited.add(current);
+      totalSamplesMap.set(current, (totalSamplesMap.get(current) ?? 0) + 1);
+      current = parentMap.get(current);
+    }
+  }
+
+  const total = samples.length || 1;
+  const stats: FunctionStat[] = [];
+
+  for (const node of profile.nodes) {
+    const self = selfSamplesMap.get(node.id) ?? 0;
+    const tot = totalSamplesMap.get(node.id) ?? 0;
+    if (self === 0 && tot === 0) continue;
+    const fnName = node.callFrame.functionName || '(anonymous)';
+    if (SKIP_FN_NAMES.has(fnName)) continue;
+    if (!includeNative && (!node.callFrame.url || node.callFrame.url.startsWith('native '))) continue;
+    stats.push({
+      functionName: fnName,
+      url: node.callFrame.url ?? '',
+      lineNumber: node.callFrame.lineNumber + 1,
+      selfMs: parseFloat(((self / total) * durationMs).toFixed(2)),
+      selfPercent: parseFloat(((self / total) * 100).toFixed(1)),
+      totalMs: parseFloat(((tot / total) * durationMs).toFixed(2)),
+      totalPercent: parseFloat(((tot / total) * 100).toFixed(1)),
+    });
+  }
+
+  stats.sort((a, b) => b.selfMs - a.selfMs);
+  return { durationMs: parseFloat(durationMs.toFixed(2)), sampleCount: samples.length, topFunctions: stats.slice(0, topN), totalSamplesMap, selfSamplesMap };
+}
+
+// ── Text renderers ────────────────────────────────────────────────────────────
+
+const BAR_WIDTH = 24;
+const MAX_DEPTH = 8;
+const MIN_PERCENT = 0.5;
+
+function bar(value: number, max: number): string {
+  const filled = max > 0 ? Math.max(1, Math.round((value / max) * BAR_WIDTH)) : 0;
+  return '█'.repeat(filled).padEnd(BAR_WIDTH);
+}
+
+function barPct(pct: number): string {
+  return '█'.repeat(Math.max(1, Math.round((pct / 100) * BAR_WIDTH))).padEnd(BAR_WIDTH);
+}
+
+function trunc(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
+function memoSavings(r: RenderRecord): number | null {
+  return r.baseDuration > 0
+    ? parseFloat((((r.baseDuration - r.actualDuration) / r.baseDuration) * 100).toFixed(1))
+    : null;
+}
+
+function buildCpuFlamegraph(profile: CpuProfile, analysis: CpuAnalysis): string {
+  const { durationMs, sampleCount, totalSamplesMap, selfSamplesMap, topFunctions } = analysis;
+  const nodeMap = new Map<number, ProfileNode>(profile.nodes.map((n) => [n.id, n]));
+  const lines: string[] = [];
+
+  lines.push('=== CPU Flamegraph (by total time) ===');
+  lines.push(`Duration: ${durationMs}ms | Samples: ${sampleCount}`);
+  lines.push('');
+
+  function renderNode(nodeId: number, depth: number): void {
+    if (depth > MAX_DEPTH) return;
+    const node = nodeMap.get(nodeId);
+    if (!node) return;
+    const fnName = node.callFrame.functionName || '(anonymous)';
+    if (SKIP_FN_NAMES.has(fnName) && depth === 0) {
+      for (const c of node.children ?? []) renderNode(c, depth);
+      return;
+    }
+    const total = totalSamplesMap.get(nodeId) ?? 0;
+    const self = selfSamplesMap.get(nodeId) ?? 0;
+    const totalPct = sampleCount > 0 ? (total / sampleCount) * 100 : 0;
+    const selfPct = sampleCount > 0 ? (self / sampleCount) * 100 : 0;
+    if (totalPct < MIN_PERCENT && depth > 0) return;
+    const indent = '  '.repeat(depth);
+    const hasChildren = (node.children ?? []).some((c) => sampleCount > 0 && ((totalSamplesMap.get(c) ?? 0) / sampleCount) * 100 >= MIN_PERCENT);
+    const label = trunc(fnName, 30).padEnd(30);
+    const ms = parseFloat((((hasChildren ? total : self) / (sampleCount || 1)) * durationMs).toFixed(1));
+    const pct = hasChildren ? totalPct : selfPct;
+    lines.push(`${indent}${hasChildren ? '▼' : '■'} ${label} ${pct.toFixed(1).padStart(5)}% ${barPct(pct)} ${ms}ms ${hasChildren ? 'total' : 'self'}`);
+    for (const c of node.children ?? []) renderNode(c, depth + 1);
+  }
+
+  if (profile.nodes.length > 0) renderNode(profile.nodes[0].id, 0);
+  else lines.push('(no profile data)');
+
+  lines.push('');
+  lines.push('=== Ranked by Self Time ===');
+  if (topFunctions.length === 0) {
+    lines.push('(no data)');
+  } else {
+    const hdr = ` #  ${'Function'.padEnd(30)} ${'Self%'.padStart(6)}  ${'Self ms'.padStart(8)}  ${'Total%'.padStart(6)}  ${'Total ms'.padStart(9)}  Location`;
+    lines.push(hdr);
+    lines.push('-'.repeat(hdr.length));
+    topFunctions.forEach((f, i) =>
+      lines.push(` ${String(i + 1).padStart(2)}  ${trunc(f.functionName, 30).padEnd(30)} ${`${f.selfPercent}%`.padStart(6)}  ${`${f.selfMs}ms`.padStart(8)}  ${`${f.totalPercent}%`.padStart(6)}  ${`${f.totalMs}ms`.padStart(9)}  ${f.url ? `${f.url}:${f.lineNumber}` : '(unknown)'}`)
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function buildDevToolsChart(profile: DevToolsProfile): string {
+  const lines: string[] = [];
+  const totalDuration = profile.reduce((s, c) => s + c.duration, 0);
+
+  lines.push('=== React DevTools Profile ===');
+  lines.push(`${profile.length} commit${profile.length !== 1 ? 's' : ''} | ${totalDuration.toFixed(1)}ms total`);
+  lines.push('');
+
+  // Aggregate by component name across all commits
+  const byName = new Map<string, { totalActual: number; totalSelf: number; commits: number }>();
+  for (const commit of profile) {
+    for (const comp of commit.components) {
+      const entry = byName.get(comp.name) ?? { totalActual: 0, totalSelf: 0, commits: 0 };
+      entry.totalActual += comp.actualMs;
+      entry.totalSelf += comp.selfMs;
+      entry.commits++;
+      byName.set(comp.name, entry);
+    }
+  }
+
+  const sorted = [...byName.entries()]
+    .map(([name, s]) => ({ name, ...s, avgActual: s.totalActual / s.commits, avgSelf: s.totalSelf / s.commits }))
+    .sort((a, b) => b.totalActual - a.totalActual);
+
+  const maxTotal = sorted[0]?.totalActual ?? 1;
+
+  lines.push('=== Components by Total Actual Duration ===');
+  const hdr = ` #  ${'Component'.padEnd(30)} ${'Commits'.padStart(8)}  ${'Total'.padStart(9)}  ${'Avg'.padStart(8)}  ${'Self avg'.padStart(9)}  Chart`;
+  lines.push(hdr);
+  lines.push('-'.repeat(hdr.length + BAR_WIDTH));
+
+  sorted.forEach((s, i) =>
+    lines.push(
+      ` ${String(i + 1).padStart(2)}  ${trunc(s.name, 30).padEnd(30)} ${String(s.commits).padStart(8)}  ${`${s.totalActual.toFixed(1)}ms`.padStart(9)}  ${`${s.avgActual.toFixed(1)}ms`.padStart(8)}  ${`${s.avgSelf.toFixed(1)}ms`.padStart(9)}  ${bar(s.totalActual, maxTotal)}`
+    )
+  );
+
+  return lines.join('\n');
+}
+
+function buildRenderChart(renders: RenderRecord[]): string {
+  const lines: string[] = [];
+  const sorted = [...renders].sort((a, b) => b.actualDuration - a.actualDuration);
+  const maxActual = sorted[0]?.actualDuration ?? 1;
+
+  lines.push('=== React Renders — Ranked by Actual Duration ===');
+  const hdr = ` #  ${'Component'.padEnd(26)} ${'Phase'.padEnd(14)} ${'Actual'.padStart(8)}  ${'Base'.padStart(8)}  Savings  Chart`;
+  lines.push(hdr);
+  lines.push('-'.repeat(hdr.length + BAR_WIDTH));
+  sorted.forEach((r, i) => {
+    const savings = memoSavings(r);
+    lines.push(` ${String(i + 1).padStart(2)}  ${trunc(r.id, 26).padEnd(26)} ${r.phase.padEnd(14)} ${`${r.actualDuration.toFixed(1)}ms`.padStart(8)}  ${`${r.baseDuration.toFixed(1)}ms`.padStart(8)}  ${savings !== null ? `${savings.toFixed(0)}%`.padStart(7) : '    n/a'}  ${bar(r.actualDuration, maxActual)}`);
+  });
+
+  const byId = new Map<string, { totalActual: number; count: number; phases: Set<string> }>();
+  for (const r of renders) {
+    const e = byId.get(r.id) ?? { totalActual: 0, count: 0, phases: new Set() };
+    e.totalActual += r.actualDuration; e.count++; e.phases.add(r.phase);
+    byId.set(r.id, e);
+  }
+  const summaries = [...byId.entries()]
+    .map(([id, s]) => ({ id, avg: s.totalActual / s.count, count: s.count, phases: [...s.phases].join(', ') }))
+    .sort((a, b) => b.avg - a.avg);
+
+  lines.push('');
+  lines.push('=== Summary by Component ===');
+  const sHdr = ` ${'Component'.padEnd(28)} ${'Renders'.padStart(8)}  ${'Avg actual'.padStart(11)}  Phases`;
+  lines.push(sHdr);
+  lines.push('-'.repeat(sHdr.length));
+  for (const s of summaries)
+    lines.push(` ${trunc(s.id, 28).padEnd(28)} ${String(s.count).padStart(8)}  ${`${s.avg.toFixed(1)}ms`.padStart(11)}  ${s.phases}`);
+
+  return lines.join('\n');
+}
+
+// ── Eval expressions ──────────────────────────────────────────────────────────
+
+const DEVTOOLS_START_EXPR = `(function() {
+  var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) return { error: 'no-hook' };
+
+  // Path 1: renderer has startProfiling (React DevTools backend connected)
+  var count = 0;
+  if (hook.renderers && typeof hook.renderers.forEach === 'function') {
+    hook.renderers.forEach(function(r) {
+      if (typeof r.startProfiling === 'function') { r.startProfiling(true); count++; }
+    });
+  }
+  if (count > 0) return { ok: true, method: 'startProfiling', count: count };
+
+  // Path 2: patch onCommitFiberRoot — works without DevTools backend.
+  // React calls this on every commit; fiber.actualDuration is tracked in dev builds.
+  if (typeof hook.onCommitFiberRoot === 'undefined') return { error: 'no-hook-method' };
+  var orig = hook.onCommitFiberRoot;
+  var commits = [];
+  hook.onCommitFiberRoot = function(rendererID, root, priorityLevel) {
+    if (orig) try { orig.call(this, rendererID, root, priorityLevel); } catch(e) {}
+    if (commits.length >= MAX_COMMITS) return;
+    var components = [];
+    var stack = root && root.current ? [root.current] : [];
+    var depth = 0;
+    while (stack.length > 0 && depth < 2000) {
+      depth++;
+      var fiber = stack.pop();
+      var ad = fiber.actualDuration;
+      if (typeof ad === 'number' && ad > 0.01) {
+        var name = null;
+        var type = fiber.type;
+        if (typeof type === 'function') { name = type.displayName || type.name || null; }
+        else if (typeof type === 'string') { name = type; }
+        if (name) components.push({ name: name, actualMs: ad, selfMs: fiber.selfBaseDuration || 0 });
+      }
+      if (fiber.sibling) stack.push(fiber.sibling);
+      if (fiber.child) stack.push(fiber.child);
+    }
+    if (components.length > 0) {
+      components.sort(function(a, b) { return b.actualMs - a.actualMs; });
+      commits.push({ timestamp: Date.now(), duration: (root && root.current && root.current.actualDuration) || 0, components: components });
+    }
+  };
+  var MAX_COMMITS = 500;
+  globalThis.__METRO_MCP_PROFILER__ = { commits: commits, orig: orig, max: MAX_COMMITS };
+  return { ok: true, method: 'commit-hook', count: 1 };
+})()`;
+
+const DEVTOOLS_STOP_EXPR = `(function() {
+  var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+
+  // Path 1: renderer had startProfiling (DevTools backend path)
+  if (hook && hook.renderers && typeof hook.renderers.forEach === 'function') {
+    var rdCommits = [];
+    hook.renderers.forEach(function(renderer) {
+      if (typeof renderer.stopProfiling !== 'function') return;
+      renderer.stopProfiling();
+      if (typeof renderer.getProfilingData !== 'function') return;
+      var data; try { data = renderer.getProfilingData(); } catch(e) { return; }
+      if (!data || !data.commitData) return;
+      var infoMap = data.displayInfoMap;
+      data.commitData.forEach(function(commit) {
+        var components = [];
+        var fiberActual = commit.fiberActualDurations;
+        var fiberSelf = commit.fiberSelfDurations;
+        if (fiberActual && typeof fiberActual.forEach === 'function') {
+          fiberActual.forEach(function(actualMs, fiberId) {
+            var selfMs = (fiberSelf && fiberSelf.get ? fiberSelf.get(fiberId) : 0) || 0;
+            var name = String(fiberId);
+            if (infoMap && infoMap.get) { var info = infoMap.get(fiberId); if (info) name = info.displayName || info.type || name; }
+            if (actualMs > 0.01) components.push({ name: name, actualMs: actualMs, selfMs: selfMs });
+          });
+        }
+        components.sort(function(a, b) { return b.actualMs - a.actualMs; });
+        rdCommits.push({ timestamp: commit.timestamp || 0, duration: commit.duration || 0, components: components });
+      });
+    });
+    if (rdCommits.length > 0) return rdCommits;
+  }
+
+  // Path 2: commit-hook patch
+  var profiler = globalThis.__METRO_MCP_PROFILER__;
+  if (!profiler) return null;
+  if (hook) hook.onCommitFiberRoot = profiler.orig;
+  var data = profiler.commits.slice();
+  globalThis.__METRO_MCP_PROFILER__ = undefined;
+  return data;
+})()`;
+
+const READ_RENDERS_EXPR = `(function() {
+  var mcp = globalThis.__METRO_MCP__;
+  return (mcp && Array.isArray(mcp.renders)) ? mcp.renders.slice() : null;
+})()`;
+
+const READ_AND_CLEAR_EXPR = `(function() {
+  var mcp = globalThis.__METRO_MCP__;
+  if (!mcp || !Array.isArray(mcp.renders)) return null;
+  var data = mcp.renders.slice();
+  if (typeof mcp.clearRenders === 'function') mcp.clearRenders();
+  return data;
+})()`;
+
+const NOT_SETUP_MSG =
+  'No render data available. Add <Profiler id="..." onRender={trackRender}> to your app and import trackRender from metro-mcp/client.';
+
+const CONSOLE_PROFILE_TITLE = 'metro-mcp';
+
+// ── Plugin ────────────────────────────────────────────────────────────────────
+
+export const profilerPlugin = definePlugin({
+  name: 'profiler',
+  version: '0.1.0',
+  description: 'CPU profiling via React DevTools hook (primary) or CDP Profiler domain, plus React render tracking',
+
+  async setup(ctx) {
+    type ProfilingMode = 'devtools-hook' | 'cdp' | 'console' | null;
+
+    let profilingMode: ProfilingMode = null;
+    let lastCpuProfile: CpuProfile | null = null;
+    let lastCpuAnalysis: CpuAnalysis | null = null;
+    let lastDevToolsProfile: DevToolsProfile | null = null;
+
+    const profilerConfig = (ctx.config as Record<string, unknown>).profiler as { newArchitecture?: boolean } | undefined;
+    const newArchitecture = profilerConfig?.newArchitecture ?? true;
+
+    function isFuseboxTarget(): boolean {
+      return ctx.cdp.getTarget()?.reactNative?.capabilities?.prefersFuseboxFrontend === true;
+    }
+
+    function shouldSkipCdpFallback(): boolean {
+      return newArchitecture || isFuseboxTarget();
+    }
+
+    let pendingConsoleProfile: {
+      resolve: (profile: CpuProfile) => void;
+      reject: (err: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    } | null = null;
+
+    // Only needed for legacy arch CDP fallback path
+    if (!newArchitecture) {
+      ctx.cdp.on('Profiler.consoleProfileFinished', (params: Record<string, unknown>) => {
+        const { title, profile } = params as { id: string; profile: CpuProfile; title?: string };
+        if (title === CONSOLE_PROFILE_TITLE && pendingConsoleProfile) {
+          clearTimeout(pendingConsoleProfile.timer);
+          pendingConsoleProfile.resolve(profile);
+          pendingConsoleProfile = null;
+        }
+      });
+    }
+
+    async function buildFlamegraphText(): Promise<string> {
+      const sections: string[] = [];
+      if (lastDevToolsProfile && lastDevToolsProfile.length > 0) {
+        sections.push(buildDevToolsChart(lastDevToolsProfile));
+      } else if (lastCpuProfile && lastCpuAnalysis) {
+        sections.push(buildCpuFlamegraph(lastCpuProfile, lastCpuAnalysis));
+      } else {
+        sections.push('(no profile — call start_profiling, interact, then stop_profiling)');
+      }
+      sections.push('');
+      try {
+        const raw = (await ctx.evalInApp(READ_RENDERS_EXPR)) as RenderRecord[] | null;
+        sections.push(raw && raw.length > 0 ? buildRenderChart(raw) : `=== React Renders ===\n${raw === null ? NOT_SETUP_MSG : 'No renders recorded yet.'}`);
+      } catch {
+        sections.push(`=== React Renders ===\n${NOT_SETUP_MSG}`);
+      }
+      return sections.join('\n');
+    }
+
+    ctx.registerTool('start_profiling', {
+      description:
+        'Start profiling the running React Native app. ' +
+        'Primary path: injects into the React DevTools hook (__REACT_DEVTOOLS_GLOBAL_HOOK__) via evalInApp — ' +
+        'captures all component render durations without requiring <Profiler> wrappers, works on all architectures. ' +
+        'Fallback (legacy arch only): CDP Profiler domain for JS CPU call-graph sampling. ' +
+        'Perform the interaction you want to measure, then call stop_profiling.',
+      parameters: z.object({
+        samplingInterval: z
+          .number().int().min(100).max(100_000).default(1_000)
+          .describe('CDP fallback only: sampling interval in microseconds (default 1000).'),
+      }),
+      handler: async ({ samplingInterval }) => {
+        if (profilingMode !== null) return 'A profiling session is already active. Call stop_profiling first.';
+
+        try {
+          const result = (await ctx.evalInApp(DEVTOOLS_START_EXPR)) as { ok?: boolean; count?: number; method?: string; error?: string } | null;
+          if (result?.ok) {
+            profilingMode = 'devtools-hook';
+            const method = result.method === 'commit-hook' ? 'fiber commit hook (no DevTools backend required)' : `renderer.startProfiling (${result.count} renderer${result.count !== 1 ? 's' : ''})`;
+            return `Profiling started via ${method}. Perform the interaction you want to measure, then call stop_profiling.`;
+          }
+          if (result?.error === 'no-hook') {
+            ctx.logger.debug('React DevTools hook not found, trying CDP fallback');
+          } else if (result?.error === 'no-hook-method') {
+            ctx.logger.debug('DevTools hook found but onCommitFiberRoot unavailable, trying CDP fallback');
+          }
+        } catch (e) {
+          ctx.logger.debug(`DevTools hook injection failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+
+        if (shouldSkipCdpFallback()) {
+          return (
+            'CPU profiling unavailable: __REACT_DEVTOOLS_GLOBAL_HOOK__ is not present in this JS environment. ' +
+            'This can happen if the app has not yet rendered or is running in a context where React is not active.\n\n' +
+            'Try calling any tool that interacts with the app first (e.g. get_component_tree), then retry start_profiling.'
+          );
+        }
+
+        try {
+          await ctx.cdp.send('Profiler.enable');
+          await ctx.cdp.send('Profiler.setSamplingInterval', { interval: samplingInterval });
+          await ctx.cdp.send('Profiler.start');
+          profilingMode = 'cdp';
+          return `Profiling started via CDP (sampling every ${samplingInterval} µs). Perform the interaction you want to measure, then call stop_profiling.`;
+        } catch (cdpErr) {
+          const msg = cdpErr instanceof Error ? cdpErr.message : String(cdpErr);
+          if (!msg.includes('Unsupported method') && !msg.includes('not supported')) {
+            return `Failed to start profiling: ${msg}`;
+          }
+        }
+
+        try {
+          await ctx.evalInApp(`console.profile(${JSON.stringify(CONSOLE_PROFILE_TITLE)})`);
+          profilingMode = 'console';
+          return 'Profiling started via console.profile(). Perform the interaction you want to measure, then call stop_profiling.';
+        } catch (consoleErr) {
+          return `Failed to start profiling: all paths exhausted — ${consoleErr instanceof Error ? consoleErr.message : String(consoleErr)}`;
+        }
+      },
+    });
+
+    ctx.registerTool('stop_profiling', {
+      description:
+        'Stop profiling and return an analysis of the captured data. ' +
+        'DevTools hook mode: returns top components by total render duration across all commits. ' +
+        'CDP mode: returns top JS functions by self time and total time. ' +
+        'Must call start_profiling first.',
+      parameters: z.object({
+        topN: z.number().int().min(1).max(100).default(20)
+          .describe('Number of top entries to return.'),
+        includeNative: z.boolean().default(false)
+          .describe('CDP mode only: include native/internal Hermes frames.'),
+      }),
+      handler: async ({ topN, includeNative }) => {
+        if (profilingMode === null) return 'No profiling session in progress. Call start_profiling first.';
+
+        try {
+          if (profilingMode === 'devtools-hook') {
+            const raw = (await ctx.evalInApp(DEVTOOLS_STOP_EXPR)) as DevToolsProfile | null;
+            profilingMode = null;
+
+            if (!raw || raw.length === 0) {
+              return { mode: 'devtools-hook', commitCount: 0, message: 'No commits recorded — profiling window may be too short.' };
+            }
+
+            lastDevToolsProfile = raw;
+
+            // Aggregate by component name
+            const byName = new Map<string, { totalActual: number; totalSelf: number; commits: number }>();
+            for (const commit of raw) {
+              for (const comp of commit.components) {
+                const e = byName.get(comp.name) ?? { totalActual: 0, totalSelf: 0, commits: 0 };
+                e.totalActual += comp.actualMs; e.totalSelf += comp.selfMs; e.commits++;
+                byName.set(comp.name, e);
+              }
+            }
+
+            const topComponents = [...byName.entries()]
+              .map(([name, s]) => ({ name, commits: s.commits, totalActualMs: parseFloat(s.totalActual.toFixed(2)), avgActualMs: parseFloat((s.totalActual / s.commits).toFixed(2)), avgSelfMs: parseFloat((s.totalSelf / s.commits).toFixed(2)) }))
+              .sort((a, b) => b.totalActualMs - a.totalActualMs)
+              .slice(0, topN);
+
+            const totalDuration = raw.reduce((s, c) => s + c.duration, 0);
+            return { mode: 'devtools-hook', commitCount: raw.length, totalDurationMs: parseFloat(totalDuration.toFixed(2)), topComponents };
+          }
+
+          // ── CDP / console ──────────────────────────────────────────────────
+          let profile: CpuProfile;
+
+          if (profilingMode === 'cdp') {
+            const result = (await ctx.cdp.send('Profiler.stop')) as { profile: CpuProfile };
+            await ctx.cdp.send('Profiler.disable').catch(() => {});
+            profile = result.profile;
+          } else {
+            const profilePromise = new Promise<CpuProfile>((resolve, reject) => {
+              const timer = setTimeout(() => {
+                pendingConsoleProfile = null;
+                reject(new Error('Timed out waiting for profileEnd data (10s).'));
+              }, 10_000);
+              pendingConsoleProfile = { resolve, reject, timer };
+            });
+            await ctx.evalInApp(`console.profileEnd(${JSON.stringify(CONSOLE_PROFILE_TITLE)})`);
+            profile = await profilePromise;
+          }
+
+          profilingMode = null;
+          lastCpuProfile = profile;
+          lastCpuAnalysis = analyzeCpuProfile(profile, topN, includeNative);
+
+          const { durationMs, sampleCount, topFunctions } = lastCpuAnalysis;
+          if (sampleCount === 0) return { mode: 'cdp', durationMs, sampleCount: 0, message: 'No samples collected.', topFunctions: [] };
+
+          return {
+            mode: 'cdp',
+            durationMs,
+            sampleCount,
+            samplingRateMs: parseFloat((durationMs / sampleCount).toFixed(3)),
+            topFunctions: topFunctions.map((f) => ({
+              functionName: f.functionName,
+              location: f.url ? `${f.url}:${f.lineNumber}` : '(unknown)',
+              selfTime: `${f.selfMs}ms (${f.selfPercent}%)`,
+              totalTime: `${f.totalMs}ms (${f.totalPercent}%)`,
+            })),
+          };
+        } catch (err) {
+          profilingMode = null;
+          return `Failed to stop profiling: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    });
+
+    ctx.registerTool('get_profile_status', {
+      description: 'Check whether profiling is active, which mode is in use, and whether a previous profile is available.',
+      parameters: z.object({}),
+      handler: async () => ({
+        isProfiling: profilingMode !== null,
+        profilingMode,
+        hasDevToolsProfile: lastDevToolsProfile !== null,
+        hasCpuProfile: lastCpuProfile !== null,
+        lastDevToolsCommits: lastDevToolsProfile?.length ?? null,
+        lastCpuDurationMs: lastCpuProfile ? parseFloat(((lastCpuProfile.endTime - lastCpuProfile.startTime) / 1000).toFixed(2)) : null,
+        newArchitectureMode: newArchitecture,
+      }),
+    });
+
+    ctx.registerTool('get_flamegraph', {
+      description:
+        'Return the current profiling results as a human-readable text chart. ' +
+        'Shows React DevTools component profile (if captured), CPU flamegraph (if CDP profile captured), ' +
+        'and React render data from <Profiler> components (if set up). ' +
+        'Call stop_profiling first to populate the profile data.',
+      parameters: z.object({}),
+      handler: buildFlamegraphText,
+    });
+
+    ctx.registerTool('get_react_renders', {
+      description:
+        'Read React render timing data collected via <Profiler onRender={trackRender}>. ' +
+        'Returns all recorded renders sorted by actualDuration descending, with memoization savings from baseDuration. ' +
+        'Requires importing trackRender from metro-mcp/client. Use clear=true to reset the buffer.',
+      parameters: z.object({
+        clear: z.boolean().default(false).describe('Clear the render buffer after reading.'),
+      }),
+      handler: async ({ clear }) => {
+        try {
+          const raw = (await ctx.evalInApp(clear ? READ_AND_CLEAR_EXPR : READ_RENDERS_EXPR)) as RenderRecord[] | null;
+          if (!raw) return NOT_SETUP_MSG;
+          if (raw.length === 0) return clear ? 'Render buffer cleared (was already empty).' : 'No renders recorded yet.';
+          return [...raw].sort((a, b) => b.actualDuration - a.actualDuration).map((r) => ({
+            id: r.id, phase: r.phase,
+            actualDuration: parseFloat(r.actualDuration.toFixed(2)),
+            baseDuration: parseFloat(r.baseDuration.toFixed(2)),
+            memoSavingsPercent: memoSavings(r),
+            startTime: r.startTime, commitTime: r.commitTime,
+          }));
+        } catch (err) {
+          return `Failed to read render data: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    });
+
+    // ── Resources ─────────────────────────────────────────────────────────────
+
+    ctx.registerResource('metro://profiler/flamegraph', {
+      name: 'profiler-flamegraph',
+      description: 'Human-readable profiling output: React DevTools component chart or CPU flamegraph, plus React render chart from <Profiler> components.',
+      mimeType: 'text/plain',
+      handler: buildFlamegraphText,
+    });
+
+    ctx.registerResource('metro://profiler/data', {
+      name: 'profiler-data',
+      description: 'Raw JSON profiling data: React DevTools commit data or CDP Profile object, plus React render records.',
+      mimeType: 'application/json',
+      handler: async () => {
+        let renders: RenderRecord[] = [];
+        try {
+          const raw = (await ctx.evalInApp(READ_RENDERS_EXPR)) as RenderRecord[] | null;
+          if (Array.isArray(raw)) renders = raw;
+        } catch { /* renders stays empty */ }
+
+        return JSON.stringify({
+          mode: lastDevToolsProfile ? 'devtools-hook' : lastCpuProfile ? 'cdp' : null,
+          devtools: lastDevToolsProfile ?? null,
+          cpu: lastCpuProfile && lastCpuAnalysis ? {
+            durationMs: lastCpuAnalysis.durationMs,
+            sampleCount: lastCpuAnalysis.sampleCount,
+            nodes: lastCpuProfile.nodes,
+            samples: lastCpuProfile.samples,
+            timeDeltas: lastCpuProfile.timeDeltas,
+            analysis: { topFunctions: lastCpuAnalysis.topFunctions },
+          } : null,
+          renders: renders.map((r) => ({ ...r, memoSavingsPercent: memoSavings(r) })),
+        }, null, 2);
+      },
+    });
+  },
+});

--- a/src/plugins/prompts.ts
+++ b/src/plugins/prompts.ts
@@ -43,17 +43,27 @@ export const promptsPlugin = definePlugin({
     });
 
     ctx.registerPrompt('debug-performance', {
-      description: 'Analyze performance: network timing, render analysis',
+      description: 'Profile JS CPU usage and React render performance, then summarize findings with a flamegraph',
       handler: async () => [
         {
           role: 'user',
           content: `I need to analyze my React Native app's performance. Please:
-1. Get network requests with timing data (get_network_requests)
-2. Check for slow requests (search_network — look for responses > 1s)
-3. Check console logs for performance warnings (get_console_logs with search for "slow" or "performance")
-4. Get the component tree to check for deep nesting (get_component_tree with structureOnly=true)
-5. Check for re-render indicators in logs
-6. Summarize performance findings and recommendations`,
+1. Check the current profiler status (get_profile_status)
+2. Clear any existing React render data (get_react_renders with clear=true)
+3. Start CPU profiling (start_profiling with default samplingInterval)
+4. Tell me to perform the interaction I want to profile, then wait for me to confirm it's done
+5. After I confirm:
+   a. Stop CPU profiling and get the analysis (stop_profiling)
+   b. Read React render timings (get_react_renders)
+   c. Read the flamegraph resource (metro://profiler/flamegraph) for a combined visual breakdown
+   d. Check for slow network requests (search_network — look for responses > 1s)
+   e. Check console logs for perf warnings (get_console_logs with search="slow" or "perf")
+6. Summarize:
+   - Top JS CPU hotspots by self time — which function and file is burning the most CPU
+   - Slowest React component renders and whether memoization (memo/useMemo) is helping — compare actualDuration vs baseDuration
+   - Components that re-render frequently (high count in the summary)
+   - Any slow network requests contributing to perceived slowness
+   - Concrete, prioritised recommendations`,
         },
       ],
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import { accessibilityPlugin } from './plugins/accessibility.js';
 import { commandsPlugin } from './plugins/commands.js';
 import { maestroPlugin } from './plugins/maestro.js';
 import { appiumPlugin } from './plugins/appium.js';
+import { profilerPlugin } from './plugins/profiler.js';
 import { promptsPlugin } from './plugins/prompts.js';
 
 const logger = createLogger('server');
@@ -58,6 +59,7 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   commandsPlugin,
   maestroPlugin,
   appiumPlugin,
+  profilerPlugin,
   promptsPlugin,
 ];
 


### PR DESCRIPTION
  ### Added
  - **Profiler plugin** — CPU and render profiling for React Native apps without requiring the React DevTools
  browser extension
    - `start_profiling` / `stop_profiling` tools capture per-component render durations across all commits by
  patching `__REACT_DEVTOOLS_GLOBAL_HOOK__` at runtime; works on New Architecture (Bridgeless/Fusebox) and legacy
  bridge
    - `get_flamegraph` tool and `metro://profiler/flamegraph` resource render a ranked component chart with time
  bars
    - `metro://profiler/data` resource exposes raw commit data as JSON for agent analysis
    - `get_react_renders` tool reads timings from `<Profiler onRender={trackRender}>` wrappers with memoization
  savings %
    - `get_profile_status` reports active profiling mode and previous profile availability
    - Auto-detects Fusebox targets and skips unsupported CDP fallbacks
    - New `profiler.newArchitecture` config option (default `true`)
  - **`trackRender`** client SDK export — drop-in `onRender` callback for React `<Profiler>`, records to
  `globalThis.__METRO_MCP__.renders` (capped at 200 entries)

  ### Changed
  - `debug-performance` prompt updated to walk through CPU profiling + React render analysis + network checks
  - Client SDK bundle target changed to `browser` to fix `import.meta` crash on Hermes
  - All `global` references in client SDK changed to `globalThis` for Hermes compatibility

  ### Fixed
  - `CDPConnection` interface now exposes `getTarget()` for target capability detection
  - `MetroTarget` type extended with `reactNative.capabilities.prefersFuseboxFrontend`