### PR TITLE
fix: stabilise CDP connection by centralising reconnect in server.ts

### DIFF
--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -21,16 +21,12 @@ export class CDPClient implements CDPConnection {
   private messageId = 0;
   private pendingRequests = new Map<number, PendingRequest>();
   private eventHandlers = new Map<string, Set<CDPEventHandler>>();
-  private reconnectAttempts = 0;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
   private connectingPromise: Promise<void> | null = null;
   private suppressReconnect = false;
   private _isConnected = false;
   private target: MetroTarget | null = null;
 
-  private readonly maxReconnectAttempts = 10;
-  private readonly reconnectDelays = [1000, 2000, 4000, 8000, 16000];
   private readonly requestTimeout = 10000;
   private readonly keepAliveInterval = 15000;
 
@@ -38,7 +34,6 @@ export class CDPClient implements CDPConnection {
    * Connect to a CDP target.
    */
   async connect(target: MetroTarget): Promise<void> {
-    this.clearReconnectTimer();
     this.stopKeepAlive();
     this.target = target;
     this.suppressReconnect = false;
@@ -65,10 +60,10 @@ export class CDPClient implements CDPConnection {
     return new Promise((resolve, reject) => {
       try {
         this.ws = new WebSocket(url);
+        const socketForThisConnection = this.ws;
 
         this.ws.onopen = () => {
           this._isConnected = true;
-          this.reconnectAttempts = 0;
           this.startKeepAlive();
           logger.info(`Connected to ${this.target?.title || 'unknown'}`);
           resolve();
@@ -79,15 +74,17 @@ export class CDPClient implements CDPConnection {
         };
 
         this.ws.onclose = () => {
+          // Ignore close events from a replaced socket — a new connection is already in progress
+          if (this.ws !== socketForThisConnection) return;
           this._isConnected = false;
           this.stopKeepAlive();
           this.rejectAllPending('WebSocket closed');
           if (!this.suppressReconnect) {
-            this.scheduleReconnect();
+            this.emit('disconnected', {});
           }
         };
 
-        this.ws.onerror = (event) => {
+        this.ws.onerror = () => {
           logger.error('WebSocket error');
           if (!this._isConnected) {
             reject(new Error('Failed to connect to CDP target'));
@@ -159,20 +156,12 @@ export class CDPClient implements CDPConnection {
   disconnect(): void {
     this.suppressReconnect = true;
     this.stopKeepAlive();
-    this.clearReconnectTimer();
     if (this.ws) {
       this.ws.close();
       this.ws = null;
     }
     this._isConnected = false;
     this.rejectAllPending('Disconnected');
-  }
-
-  private clearReconnectTimer(): void {
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
   }
 
   private startKeepAlive(): void {
@@ -237,33 +226,6 @@ export class CDPClient implements CDPConnection {
       pending.reject(new Error(reason));
     }
     this.pendingRequests.clear();
-  }
-
-  private scheduleReconnect(): void {
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      logger.error('Max reconnection attempts reached');
-      return;
-    }
-
-    const delayIndex = Math.min(this.reconnectAttempts, this.reconnectDelays.length - 1);
-    const delay = this.reconnectDelays[delayIndex];
-    this.reconnectAttempts++;
-
-    logger.info(`Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
-
-    this.reconnectTimer = setTimeout(async () => {
-      if (this.target && !this.suppressReconnect && !this.connectingPromise) {
-        try {
-          this.connectingPromise = this.doConnect(this.target.webSocketDebuggerUrl);
-          await this.connectingPromise;
-          this.connectingPromise = null;
-          this.emit('reconnected', {});
-        } catch {
-          this.connectingPromise = null;
-          // doConnect failure will trigger onclose → scheduleReconnect
-        }
-      }
-    }, delay);
   }
 
   private emit(event: string, params: Record<string, unknown>): void {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -69,6 +69,18 @@ export const networkPlugin = definePlugin({
       }
     });
 
+    // When the CDP connection drops, flush any in-flight requests to the buffer so they
+    // are visible rather than silently lost.
+    ctx.cdp.on('disconnected', () => {
+      const now = Date.now();
+      for (const [, req] of pendingRequests) {
+        req.endTime = now;
+        req.error = 'Connection lost';
+        buffer.push(req);
+      }
+      pendingRequests.clear();
+    });
+
     ctx.registerTool('get_network_requests', {
       description: 'Get recent network requests from the React Native app.',
       parameters: z.object({

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,12 +75,36 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   const cdpClient = new CDPClient();
   const formatUtils = createFormatUtils();
 
+  // Server-side reconnect state — single source of truth for all reconnect logic.
+  const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000];
+  const MAX_RECONNECT_ATTEMPTS = 10;
+  let reconnectAttempts = 0;
+  let isReconnecting = false;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function waitForReconnect(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (!isReconnecting) { resolve(); return; }
+      const check = setInterval(() => {
+        if (!isReconnecting) { clearInterval(check); resolve(); }
+      }, 100);
+    });
+  }
+
   // Enable required CDP domains on every connection (initial and reconnect).
   cdpClient.on('reconnected', async () => {
+    reconnectAttempts = 0;
+    isReconnecting = false;
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
     await Promise.all([
       cdpClient.send('Runtime.enable').catch(() => {}),
       cdpClient.send('Network.enable').catch(() => {}),
     ]);
+  });
+
+  // Drive all reconnection through connectToMetro() so we always get a fresh target URL.
+  cdpClient.on('disconnected', () => {
+    scheduleReconnect();
   });
 
   // Create the plugin context factory
@@ -159,9 +183,13 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       evalInApp: async (expression: string, options?: EvalOptions) => {
         async function tryEval() {
           if (!cdpClient.isConnected()) {
-            // Wait for any in-progress connection first, then reconnect if still not connected
-            const connected = await cdpClient.waitForConnection();
-            if (!connected) await connectToMetro();
+            if (isReconnecting) {
+              // A reconnect is already in flight — wait for it rather than starting another
+              await waitForReconnect();
+            } else {
+              const connected = await cdpClient.waitForConnection();
+              if (!connected) await connectToMetro();
+            }
           }
           if (!cdpClient.isConnected()) {
             throw new Error('Not connected to Metro. Use list_devices to check connection status.');
@@ -185,7 +213,11 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
             err.message === 'Not connected to CDP target' ||
             err.message === 'Not connected to Metro. Use list_devices to check connection status.'
           )) {
-            await connectToMetro();
+            if (isReconnecting) {
+              await waitForReconnect();
+            } else {
+              await connectToMetro();
+            }
             return await tryEval();
           }
           throw err;
@@ -245,8 +277,14 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     }
   }
 
-  // Connect to Metro
+  // Connect to Metro — always re-discovers targets to get a fresh webSocketDebuggerUrl.
+  // Idempotent: concurrent callers wait for the in-flight attempt to finish.
   async function connectToMetro(): Promise<boolean> {
+    if (isReconnecting) {
+      await waitForReconnect();
+      return cdpClient.isConnected();
+    }
+    isReconnecting = true;
     try {
       let servers;
       if (config.metro.autoDiscover) {
@@ -275,7 +313,33 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     } catch (err) {
       logger.warn('Could not connect to Metro:', err);
       return false;
+    } finally {
+      isReconnecting = false;
     }
+  }
+
+  // Schedule a reconnect with exponential backoff, driven from server.ts so we always
+  // re-fetch a fresh target URL from Metro's /json endpoint.
+  function scheduleReconnect(): void {
+    if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      logger.error('Max reconnection attempts reached, giving up');
+      return;
+    }
+    if (reconnectTimer !== null || isReconnecting) return; // already scheduled or in progress
+
+    const delay = RECONNECT_DELAYS[Math.min(reconnectAttempts, RECONNECT_DELAYS.length - 1)];
+    reconnectAttempts++;
+    logger.info(`Reconnecting to Metro in ${delay}ms (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`);
+
+    isReconnecting = true;
+    reconnectTimer = setTimeout(async () => {
+      reconnectTimer = null;
+      isReconnecting = false;
+      const success = await connectToMetro();
+      if (!success) {
+        scheduleReconnect();
+      }
+    }, delay);
   }
 
   // Start MCP transport


### PR DESCRIPTION
Three root causes were fixed:

1. Race condition causing "another connection started" — CDPClient's
   internal scheduleReconnect() and evalInApp()'s connectToMetro() call
   could both fire simultaneously, opening two WebSocket connections to
   Metro. Removed CDPClient's internal reconnect machinery entirely.
   CDPClient now emits a 'disconnected' event instead; all reconnect
   logic lives in server.ts with a single isReconnecting guard that
   prevents concurrent attempts.

2. Stale WebSocket URL on reconnect — the old scheduleReconnect() reused
   this.target.webSocketDebuggerUrl from the initial connection. Metro
   may assign a new URL after app reload or session change. The new
   server-side scheduleReconnect() always calls connectToMetro() which
   re-fetches targets from Metro's /json endpoint before connecting.

3. Network requests lost on disconnect — in-flight HTTP requests stored
   in network.ts pendingRequests Map never received loadingFinished/
   loadingFailed events after a CDP drop. A 'disconnected' handler now
   flushes them to the circular buffer with error: 'Connection lost' so
   they remain visible in get_network_requests.

Also added a stale-close guard in doConnect() so a replaced socket's
onclose event cannot trigger a spurious 'disconnected' emission when a
new connection is already being established.

https://claude.ai/code/session_017ss2gnc1XTXUdLhtiHkhrZ