### PR TITLE
Fix Metro connection stability with ws ping/pong and /events WebSocket

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,12 @@
       "name": "metro-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "ws": "^8.20.0",
         "zod": "^3.24.4",
       },
       "devDependencies": {
         "@types/bun": "^1.2.10",
+        "@types/ws": "^8.18.1",
         "typescript": "^5.8.3",
       },
     },
@@ -22,6 +24,8 @@
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -202,6 +206,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,8 +11,9 @@
 
 - **`get_network_requests`** — Get buffered HTTP requests with method, URL, status, timing.
 - **`get_request_details`** — Get full headers for a specific request by URL.
-- **`get_response_body`** — Fetch the response body for a specific request on demand (not included in list output to avoid noise).
+- **`get_response_body`** — Get the response body for a specific request. Bodies under 1 MB are eagerly cached and survive reconnections; larger bodies are fetched on demand from the current CDP session.
 - **`search_network`** — Filter by URL pattern, method, status code, or errors only.
+- **`clear_network_requests`** — Clear the network request buffer.
 
 ## Errors
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "dev": "bun run --watch src/index.ts",
     "clean": "rm -rf dist",
     "build": "bun run clean && bun run build:js && bun run build:bin && bun run build:types",
-    "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.js --target browser --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.cjs --target browser --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod",
-    "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target bun --external @modelcontextprotocol/sdk --external zod && chmod +x dist/bin/metro-mcp.js",
+    "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external zod --external ws && bun build src/client/index.ts --outfile dist/client/index.js --target browser --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.cjs --target browser --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod",
+    "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target bun --external @modelcontextprotocol/sdk --external zod --external ws && chmod +x dist/bin/metro-mcp.js",
     "build:types": "bunx tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit"
   },
@@ -61,10 +61,12 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "ws": "^8.20.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {
     "@types/bun": "^1.2.10",
+    "@types/ws": "^8.18.1",
     "typescript": "^5.8.3"
   },
   "engines": {

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -1,3 +1,4 @@
+import WebSocket from 'ws';
 import type { CDPConnection } from '../plugin.js';
 import type { CDPRequest, CDPResponse, MetroTarget } from './types.js';
 import { createLogger } from '../utils/logger.js';
@@ -15,6 +16,10 @@ interface PendingRequest {
 /**
  * CDP WebSocket client that connects to a Hermes debugger target.
  * Implements the CDPConnection interface used by plugins.
+ *
+ * Uses the `ws` library (same as Metro's InspectorProxy) for native
+ * WebSocket ping/pong support. Metro sends pings every 5s and terminates
+ * connections after 60s of no pong — `ws` auto-responds to pings.
  */
 export class CDPClient implements CDPConnection {
   private ws: WebSocket | null = null;
@@ -26,6 +31,7 @@ export class CDPClient implements CDPConnection {
   private suppressReconnect = false;
   private _isConnected = false;
   private target: MetroTarget | null = null;
+  private pongReceived = false;
 
   private readonly requestTimeout = 10000;
   private readonly keepAliveInterval = 10000;
@@ -62,24 +68,23 @@ export class CDPClient implements CDPConnection {
         this.ws = new WebSocket(url);
         const socketForThisConnection = this.ws;
 
-        this.ws.onopen = () => {
+        this.ws.on('open', () => {
           this._isConnected = true;
+          this.pongReceived = true;
           this.startKeepAlive();
           logger.info(`Connected to ${this.target?.title || 'unknown'}`);
           resolve();
-        };
+        });
 
-        this.ws.onmessage = (event) => {
-          this.handleMessage(event.data as string);
-        };
+        this.ws.on('message', (data) => {
+          this.handleMessage(data.toString());
+        });
 
-        this.ws.onclose = (event) => {
+        this.ws.on('close', (code, reason) => {
           // Ignore close events from a replaced socket — a new connection is already in progress
           if (this.ws !== socketForThisConnection) return;
 
-          const code = (event as CloseEvent).code;
-          const reason = (event as CloseEvent).reason || 'no reason';
-          logger.info(`WebSocket closed (code=${code}, reason="${reason}", wasConnected=${this._isConnected})`);
+          logger.info(`WebSocket closed (code=${code}, reason="${reason.toString() || 'no reason'}", wasConnected=${this._isConnected})`);
 
           this._isConnected = false;
           this.stopKeepAlive();
@@ -87,14 +92,26 @@ export class CDPClient implements CDPConnection {
           if (!this.suppressReconnect) {
             this.emit('disconnected', {});
           }
-        };
+        });
 
-        this.ws.onerror = () => {
+        this.ws.on('error', () => {
           logger.error(`WebSocket error (connected=${this._isConnected})`);
           if (!this._isConnected) {
             reject(new Error('Failed to connect to CDP target'));
           }
-        };
+        });
+
+        // Metro's InspectorProxy sends pings every 5s — ws auto-responds with pong.
+        // Log for diagnostics.
+        this.ws.on('ping', () => {
+          logger.debug('Received ping from Metro');
+        });
+
+        // Track pong responses to our own pings (sent by startKeepAlive).
+        this.ws.on('pong', () => {
+          this.pongReceived = true;
+          logger.debug('Received pong from Metro');
+        });
       } catch (err) {
         reject(err);
       }
@@ -173,24 +190,21 @@ export class CDPClient implements CDPConnection {
     this.stopKeepAlive();
     let missedKeepAlives = 0;
     this.keepAliveTimer = setInterval(() => {
-      if (this._isConnected) {
-        // Re-enable Runtime domain as a lightweight keepalive — idempotent and always supported.
-        // Track consecutive failures to detect a silently dead connection.
-        this.send('Runtime.enable')
-          .then(() => {
-            missedKeepAlives = 0;
-          })
-          .catch(() => {
-            missedKeepAlives++;
-            if (missedKeepAlives >= 3) {
-              logger.warn(`${missedKeepAlives} consecutive keepalive failures — closing connection`);
-              // Force-close so the reconnect logic kicks in with a fresh target URL
-              if (this.ws) {
-                try { this.ws.close(); } catch {}
-              }
-            }
-          });
+      if (!this._isConnected || !this.ws) return;
+
+      if (!this.pongReceived) {
+        missedKeepAlives++;
+        if (missedKeepAlives >= 3) {
+          logger.warn(`${missedKeepAlives} consecutive pongs missed — closing connection`);
+          try { this.ws.close(); } catch {}
+          return;
+        }
+      } else {
+        missedKeepAlives = 0;
       }
+
+      this.pongReceived = false;
+      this.ws.ping();
     }, this.keepAliveInterval);
   }
 

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -77,9 +77,8 @@ export class CDPClient implements CDPConnection {
           // Ignore close events from a replaced socket — a new connection is already in progress
           if (this.ws !== socketForThisConnection) return;
 
-          const closeEvent = event as CloseEvent;
-          const code = closeEvent.code ?? 'unknown';
-          const reason = closeEvent.reason || 'no reason';
+          const code = (event as CloseEvent).code;
+          const reason = (event as CloseEvent).reason || 'no reason';
           logger.info(`WebSocket closed (code=${code}, reason="${reason}", wasConnected=${this._isConnected})`);
 
           this._isConnected = false;
@@ -90,7 +89,7 @@ export class CDPClient implements CDPConnection {
           }
         };
 
-        this.ws.onerror = (event) => {
+        this.ws.onerror = () => {
           logger.error(`WebSocket error (connected=${this._isConnected})`);
           if (!this._isConnected) {
             reject(new Error('Failed to connect to CDP target'));

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -60,7 +60,7 @@ export class CDPClient implements CDPConnection {
   private doConnect(url: string): Promise<void> {
     // Close existing socket before opening a new one
     if (this.ws) {
-      try { this.ws.close(); } catch {}
+      try { this.ws.removeAllListeners(); this.ws.close(); } catch {}
       this.ws = null;
     }
     return new Promise((resolve, reject) => {
@@ -77,7 +77,10 @@ export class CDPClient implements CDPConnection {
         });
 
         this.ws.on('message', (data) => {
-          this.handleMessage(data.toString());
+          const text = Array.isArray(data) ? Buffer.concat(data).toString()
+            : Buffer.isBuffer(data) ? data.toString()
+            : Buffer.from(data).toString();
+          this.handleMessage(text);
         });
 
         this.ws.on('close', (code, reason) => {

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -2,6 +2,7 @@ import WebSocket from 'ws';
 import type { CDPConnection } from '../plugin.js';
 import type { CDPRequest, CDPResponse, MetroTarget } from './types.js';
 import { createLogger } from '../utils/logger.js';
+import { wsDataToString } from '../utils/ws.js';
 
 const logger = createLogger('cdp');
 
@@ -77,10 +78,7 @@ export class CDPClient implements CDPConnection {
         });
 
         this.ws.on('message', (data) => {
-          const text = Array.isArray(data) ? Buffer.concat(data).toString()
-            : Buffer.isBuffer(data) ? data.toString()
-            : Buffer.from(data).toString();
-          this.handleMessage(text);
+          this.handleMessage(wsDataToString(data));
         });
 
         this.ws.on('close', (code, reason) => {

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -28,7 +28,7 @@ export class CDPClient implements CDPConnection {
   private target: MetroTarget | null = null;
 
   private readonly requestTimeout = 10000;
-  private readonly keepAliveInterval = 15000;
+  private readonly keepAliveInterval = 10000;
 
   /**
    * Connect to a CDP target.
@@ -73,9 +73,15 @@ export class CDPClient implements CDPConnection {
           this.handleMessage(event.data as string);
         };
 
-        this.ws.onclose = () => {
+        this.ws.onclose = (event) => {
           // Ignore close events from a replaced socket — a new connection is already in progress
           if (this.ws !== socketForThisConnection) return;
+
+          const closeEvent = event as CloseEvent;
+          const code = closeEvent.code ?? 'unknown';
+          const reason = closeEvent.reason || 'no reason';
+          logger.info(`WebSocket closed (code=${code}, reason="${reason}", wasConnected=${this._isConnected})`);
+
           this._isConnected = false;
           this.stopKeepAlive();
           this.rejectAllPending('WebSocket closed');
@@ -84,8 +90,8 @@ export class CDPClient implements CDPConnection {
           }
         };
 
-        this.ws.onerror = () => {
-          logger.error('WebSocket error');
+        this.ws.onerror = (event) => {
+          logger.error(`WebSocket error (connected=${this._isConnected})`);
           if (!this._isConnected) {
             reject(new Error('Failed to connect to CDP target'));
           }
@@ -166,10 +172,25 @@ export class CDPClient implements CDPConnection {
 
   private startKeepAlive(): void {
     this.stopKeepAlive();
+    let missedKeepAlives = 0;
     this.keepAliveTimer = setInterval(() => {
       if (this._isConnected) {
-        // Re-enable Runtime domain as a lightweight keepalive — idempotent and always supported
-        this.send('Runtime.enable').catch(() => {});
+        // Re-enable Runtime domain as a lightweight keepalive — idempotent and always supported.
+        // Track consecutive failures to detect a silently dead connection.
+        this.send('Runtime.enable')
+          .then(() => {
+            missedKeepAlives = 0;
+          })
+          .catch(() => {
+            missedKeepAlives++;
+            if (missedKeepAlives >= 3) {
+              logger.warn(`${missedKeepAlives} consecutive keepalive failures — closing connection`);
+              // Force-close so the reconnect logic kicks in with a fresh target URL
+              if (this.ws) {
+                try { this.ws.close(); } catch {}
+              }
+            }
+          });
       }
     }, this.keepAliveInterval);
   }

--- a/src/metro/events.ts
+++ b/src/metro/events.ts
@@ -1,44 +1,35 @@
 import WebSocket from 'ws';
+import type { MetroEvent } from '../plugin.js';
 import { createLogger } from '../utils/logger.js';
+import { wsDataToString } from '../utils/ws.js';
 
 const logger = createLogger('metro-events');
 
 type MetroEventHandler = (event: MetroEvent) => void;
-
-export interface MetroEvent {
-  type: string;
-  [key: string]: unknown;
-}
 
 /**
  * Client for Metro's `/events` WebSocket endpoint.
  *
  * This endpoint broadcasts all Metro reporter events (build progress,
  * bundling errors, etc.) with no registration needed — just connect
- * and receive. Independent of the CDP connection.
+ * and receive. Reconnection is driven by the server (via connectToMetro)
+ * so the events client always uses the same discovered host/port as CDP.
  */
 export class MetroEventsClient {
   private ws: WebSocket | null = null;
   private handlers = new Map<string, Set<MetroEventHandler>>();
   private _isConnected = false;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private url: string | null = null;
 
   connect(host: string, port: number): void {
-    this.url = `ws://${host}:${port}/events`;
-    this.doConnect();
-  }
-
-  private doConnect(): void {
-    if (!this.url) return;
-
     if (this.ws) {
       try { this.ws.removeAllListeners(); this.ws.close(); } catch {}
       this.ws = null;
     }
 
+    const url = `ws://${host}:${port}/events`;
+
     try {
-      this.ws = new WebSocket(this.url);
+      this.ws = new WebSocket(url);
 
       this.ws.on('open', () => {
         this._isConnected = true;
@@ -46,11 +37,8 @@ export class MetroEventsClient {
       });
 
       this.ws.on('message', (data) => {
-        const text = Buffer.isBuffer(data) ? data.toString()
-          : Array.isArray(data) ? Buffer.concat(data).toString()
-          : Buffer.from(data).toString();
-
         try {
+          const text = wsDataToString(data);
           const event = JSON.parse(text) as MetroEvent;
           if (event.type) {
             this.emit(event.type, event);
@@ -62,25 +50,14 @@ export class MetroEventsClient {
 
       this.ws.on('close', () => {
         this._isConnected = false;
-        this.scheduleReconnect();
       });
 
       this.ws.on('error', () => {
-        if (!this._isConnected) {
-          this.scheduleReconnect();
-        }
+        logger.debug('Metro events WebSocket error');
       });
     } catch {
-      this.scheduleReconnect();
+      // Connection failed — server will retry via connectToMetro
     }
-  }
-
-  private scheduleReconnect(): void {
-    if (this.reconnectTimer) return;
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null;
-      this.doConnect();
-    }, 5000);
   }
 
   on(event: string, handler: MetroEventHandler): void {
@@ -99,10 +76,6 @@ export class MetroEventsClient {
   }
 
   disconnect(): void {
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
     if (this.ws) {
       try { this.ws.removeAllListeners(); this.ws.close(); } catch {}
       this.ws = null;

--- a/src/metro/events.ts
+++ b/src/metro/events.ts
@@ -1,0 +1,125 @@
+import WebSocket from 'ws';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('metro-events');
+
+type MetroEventHandler = (event: MetroEvent) => void;
+
+export interface MetroEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Client for Metro's `/events` WebSocket endpoint.
+ *
+ * This endpoint broadcasts all Metro reporter events (build progress,
+ * bundling errors, etc.) with no registration needed — just connect
+ * and receive. Independent of the CDP connection.
+ */
+export class MetroEventsClient {
+  private ws: WebSocket | null = null;
+  private handlers = new Map<string, Set<MetroEventHandler>>();
+  private _isConnected = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private url: string | null = null;
+
+  connect(host: string, port: number): void {
+    this.url = `ws://${host}:${port}/events`;
+    this.doConnect();
+  }
+
+  private doConnect(): void {
+    if (!this.url) return;
+
+    if (this.ws) {
+      try { this.ws.removeAllListeners(); this.ws.close(); } catch {}
+      this.ws = null;
+    }
+
+    try {
+      this.ws = new WebSocket(this.url);
+
+      this.ws.on('open', () => {
+        this._isConnected = true;
+        logger.info('Connected to Metro events');
+      });
+
+      this.ws.on('message', (data) => {
+        const text = Buffer.isBuffer(data) ? data.toString()
+          : Array.isArray(data) ? Buffer.concat(data).toString()
+          : Buffer.from(data).toString();
+
+        try {
+          const event = JSON.parse(text) as MetroEvent;
+          if (event.type) {
+            this.emit(event.type, event);
+          }
+        } catch {
+          logger.debug('Failed to parse Metro event');
+        }
+      });
+
+      this.ws.on('close', () => {
+        this._isConnected = false;
+        this.scheduleReconnect();
+      });
+
+      this.ws.on('error', () => {
+        if (!this._isConnected) {
+          this.scheduleReconnect();
+        }
+      });
+    } catch {
+      this.scheduleReconnect();
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.doConnect();
+    }, 5000);
+  }
+
+  on(event: string, handler: MetroEventHandler): void {
+    if (!this.handlers.has(event)) {
+      this.handlers.set(event, new Set());
+    }
+    this.handlers.get(event)!.add(handler);
+  }
+
+  off(event: string, handler: MetroEventHandler): void {
+    this.handlers.get(event)?.delete(handler);
+  }
+
+  isConnected(): boolean {
+    return this._isConnected;
+  }
+
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      try { this.ws.removeAllListeners(); this.ws.close(); } catch {}
+      this.ws = null;
+    }
+    this._isConnected = false;
+  }
+
+  private emit(type: string, event: MetroEvent): void {
+    const handlers = this.handlers.get(type);
+    if (handlers) {
+      for (const handler of handlers) {
+        try {
+          handler(event);
+        } catch (err) {
+          logger.error(`Error in event handler for ${type}:`, err);
+        }
+      }
+    }
+  }
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -65,9 +65,14 @@ export interface EvalOptions {
 
 // ── Metro Events ──
 
+export interface MetroEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
 export interface MetroEventsConnection {
-  on(event: string, handler: (event: { type: string; [key: string]: unknown }) => void): void;
-  off(event: string, handler: (event: { type: string; [key: string]: unknown }) => void): void;
+  on(event: string, handler: (event: MetroEvent) => void): void;
+  off(event: string, handler: (event: MetroEvent) => void): void;
   isConnected(): boolean;
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -63,10 +63,20 @@ export interface EvalOptions {
   timeout?: number;
 }
 
+// ── Metro Events ──
+
+export interface MetroEventsConnection {
+  on(event: string, handler: (event: { type: string; [key: string]: unknown }) => void): void;
+  off(event: string, handler: (event: { type: string; [key: string]: unknown }) => void): void;
+  isConnected(): boolean;
+}
+
 // ── Plugin Context ──
 
 export interface PluginContext {
   cdp: CDPConnection;
+  /** Metro `/events` WebSocket — build progress, bundling errors, etc. */
+  events: MetroEventsConnection;
   registerTool<T extends z.ZodType>(name: string, config: ToolConfig<T>): void;
   registerResource(uri: string, config: ResourceConfig): void;
   registerPrompt(name: string, config: PromptConfig): void;

--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -49,6 +49,17 @@ export const consolePlugin = definePlugin({
       });
     });
 
+    // Mark when Metro starts rebuilding — a reload is imminent.
+    ctx.events.on('bundle_transform_progressed', (event) => {
+      if (event.transformedFileCount === 1) {
+        buffer.push({
+          timestamp: Date.now(),
+          level: 'info',
+          message: '── Metro rebuilding ── (file change detected)',
+        });
+      }
+    });
+
     // Insert a visible boundary marker when the CDP connection is re-established,
     // so it's clear where a gap in logs may have occurred.
     ctx.cdp.on('reconnected', () => {

--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -49,6 +49,16 @@ export const consolePlugin = definePlugin({
       });
     });
 
+    // Insert a visible boundary marker when the CDP connection is re-established,
+    // so it's clear where a gap in logs may have occurred.
+    ctx.cdp.on('reconnected', () => {
+      buffer.push({
+        timestamp: Date.now(),
+        level: 'info',
+        message: '── CDP reconnected ── (logs during the disconnection gap may be missing)',
+      });
+    });
+
     ctx.registerTool('get_console_logs', {
       description: 'Get recent console output from the React Native app. Filter by log level and search text.',
       parameters: z.object({

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -28,6 +28,17 @@ const BUNDLE_ERROR_PATTERNS = [
   /Unexpected token/,
 ];
 
+function parseErrorLocation(message: string): { file?: string; lineNumber?: number; column?: number } {
+  const fileMatch = message.match(/(?:in |from )([^\s:]+(?:\.tsx?|\.jsx?|\.json))/);
+  const lineMatch = message.match(/(?:line |:)(\d+)/);
+  const colMatch = message.match(/:(\d+):(\d+)/);
+  return {
+    file: fileMatch?.[1],
+    lineNumber: lineMatch ? parseInt(lineMatch[1]) : undefined,
+    column: colMatch ? parseInt(colMatch[2]) : undefined,
+  };
+}
+
 export const errorsPlugin = definePlugin({
   name: 'errors',
 
@@ -37,22 +48,19 @@ export const errorsPlugin = definePlugin({
     const buffer = new CircularBuffer<ErrorEntry>(100);
     const bundleErrors = new CircularBuffer<BundleError>(100);
 
+    // CDP console errors are a fallback — the Metro /events path below
+    // is more reliable but may not be connected yet during startup.
     ctx.cdp.on('Runtime.consoleAPICalled', (params) => {
       if (params.type === 'error') {
         const args = (params.args as Array<Record<string, unknown>>) || [];
         const message = args.map((a) => a.value || a.description || '').join(' ');
         for (const pattern of BUNDLE_ERROR_PATTERNS) {
           if (pattern.test(message)) {
-            const fileMatch = message.match(/(?:in |from )([^\s:]+(?:\.tsx?|\.jsx?|\.json))/);
-            const lineMatch = message.match(/(?:line |:)(\d+)/);
-            const colMatch = message.match(/:(\d+):(\d+)/);
             bundleErrors.push({
               timestamp: Date.now(),
               type: pattern.source.replace(/[\\^$]/g, ''),
               message,
-              file: fileMatch?.[1],
-              lineNumber: lineMatch ? parseInt(lineMatch[1]) : undefined,
-              column: colMatch ? parseInt(colMatch[2]) : undefined,
+              ...parseErrorLocation(message),
             });
             break;
           }
@@ -60,20 +68,13 @@ export const errorsPlugin = definePlugin({
       }
     });
 
-    // Metro /events WebSocket delivers structured build errors directly,
-    // more reliably than pattern-matching console output.
     ctx.events.on('bundling_error', (event) => {
       const message = (event.message as string) || 'Unknown bundling error';
-      const fileMatch = message.match(/(?:in |from )([^\s:]+(?:\.tsx?|\.jsx?|\.json))/);
-      const lineMatch = message.match(/(?:line |:)(\d+)/);
-      const colMatch = message.match(/:(\d+):(\d+)/);
       bundleErrors.push({
         timestamp: Date.now(),
         type: 'BundlingError',
         message,
-        file: fileMatch?.[1],
-        lineNumber: lineMatch ? parseInt(lineMatch[1]) : undefined,
-        column: colMatch ? parseInt(colMatch[2]) : undefined,
+        ...parseErrorLocation(message),
       });
     });
 

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -60,6 +60,23 @@ export const errorsPlugin = definePlugin({
       }
     });
 
+    // Metro /events WebSocket delivers structured build errors directly,
+    // more reliably than pattern-matching console output.
+    ctx.events.on('bundling_error', (event) => {
+      const message = (event.message as string) || 'Unknown bundling error';
+      const fileMatch = message.match(/(?:in |from )([^\s:]+(?:\.tsx?|\.jsx?|\.json))/);
+      const lineMatch = message.match(/(?:line |:)(\d+)/);
+      const colMatch = message.match(/:(\d+):(\d+)/);
+      bundleErrors.push({
+        timestamp: Date.now(),
+        type: 'BundlingError',
+        message,
+        file: fileMatch?.[1],
+        lineNumber: lineMatch ? parseInt(lineMatch[1]) : undefined,
+        column: colMatch ? parseInt(colMatch[2]) : undefined,
+      });
+    });
+
     ctx.cdp.on('Runtime.exceptionThrown', async (params) => {
       const message = extractCDPExceptionMessage(
         params.exceptionDetails as Record<string, unknown>,

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -6,9 +6,14 @@ import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('network');
 
-/** Maximum encoded body size (bytes) to eagerly cache. Responses larger than this
- *  will only be fetchable while the same CDP session is active. */
+/** Maximum *decoded* body size (bytes) to keep cached. */
 const MAX_BODY_CACHE_SIZE = 1024 * 1024; // 1 MB
+/** Maximum concurrent getResponseBody CDP calls to avoid flooding the pipeline. */
+const MAX_CONCURRENT_BODY_FETCHES = 4;
+
+function decodeResponseBody(raw: { body: string; base64Encoded: boolean }): string {
+  return raw.base64Encoded ? Buffer.from(raw.body, 'base64').toString('utf8') : raw.body;
+}
 
 interface NetworkRequest {
   id: string;
@@ -26,8 +31,6 @@ interface NetworkRequest {
   size?: number;
   /** Connection session this request belongs to. Incremented on each reconnect. */
   session: number;
-  /** Whether the response body was eagerly cached (available after reconnect). */
-  bodyCached: boolean;
 }
 
 export const networkPlugin = definePlugin({
@@ -43,6 +46,27 @@ export const networkPlugin = definePlugin({
      *  can tell which requests belong to the current CDP session vs a stale one. */
     let currentSession = 0;
 
+    /** Simple concurrency limiter for eager body fetches to avoid flooding CDP. */
+    let activeFetches = 0;
+
+    function fetchAndCacheBody(req: NetworkRequest): void {
+      if (activeFetches >= MAX_CONCURRENT_BODY_FETCHES) return;
+      activeFetches++;
+      ctx.cdp.send('Network.getResponseBody', { requestId: req.id })
+        .then((result) => {
+          const body = decodeResponseBody(result as { body: string; base64Encoded: boolean });
+          if (body.length <= MAX_BODY_CACHE_SIZE) {
+            req.responseBody = body;
+          }
+        })
+        .catch((err) => {
+          logger.debug(`Could not cache body for ${req.method} ${req.url}: ${err}`);
+        })
+        .finally(() => {
+          activeFetches--;
+        });
+    }
+
     // ── CDP Network domain ─────────────────────────────────────────────────────
 
     ctx.cdp.on('Network.requestWillBeSent', (params) => {
@@ -53,7 +77,6 @@ export const networkPlugin = definePlugin({
         requestHeaders: (params.request as Record<string, unknown>)?.headers as Record<string, string>,
         startTime: Date.now(),
         session: currentSession,
-        bodyCached: false,
       };
       pendingRequests.set(request.id, request);
     });
@@ -75,24 +98,7 @@ export const networkPlugin = definePlugin({
         req.size = params.encodedDataLength as number;
         pendingRequests.delete(req.id);
         buffer.push(req);
-
-        // Eagerly cache the response body so it survives reconnections.
-        // Only cache bodies within the size limit to avoid excessive memory use.
-        const encodedSize = req.size ?? 0;
-        if (encodedSize <= MAX_BODY_CACHE_SIZE) {
-          ctx.cdp.send('Network.getResponseBody', { requestId: req.id })
-            .then((result) => {
-              const r = result as { body: string; base64Encoded: boolean };
-              req.responseBody = r.base64Encoded
-                ? Buffer.from(r.body, 'base64').toString('utf8')
-                : r.body;
-              req.bodyCached = true;
-            })
-            .catch((err) => {
-              // Body not available from debugger – this is expected for some requests
-              logger.debug(`Could not cache body for ${req.method} ${req.url}: ${err}`);
-            });
-        }
+        fetchAndCacheBody(req);
       }
     });
 
@@ -194,8 +200,8 @@ export const networkPlugin = definePlugin({
         const req = index === -1 ? matches[matches.length - 1] : matches[index];
         if (!req) return `Request index ${index} out of range (${matches.length} matches)`;
 
-        // 1. Use eagerly cached body if available (survives reconnections)
-        if (req.bodyCached && req.responseBody !== undefined) {
+        // Use cached body if available (survives reconnections)
+        if (req.responseBody !== undefined) {
           try {
             return { url: req.url, status: req.status, body: JSON.parse(req.responseBody) };
           } catch {
@@ -203,22 +209,16 @@ export const networkPlugin = definePlugin({
           }
         }
 
-        // 2. Request is from a previous session and body wasn't cached — no way to fetch it
+        // Request is from a previous session and body wasn't cached — no way to fetch it
         if (req.session !== currentSession) {
-          return `Response body unavailable for "${req.url}": this request was captured in a previous CDP session (session ${req.session}, current ${currentSession}). The debugger cache was lost on reconnect and the body was too large to eagerly cache (${req.size ? formatBytes(req.size) : 'unknown size'}, limit ${formatBytes(MAX_BODY_CACHE_SIZE)}).`;
+          return `Response body unavailable for "${req.url}": this request was captured in a previous CDP session (session ${req.session}, current ${currentSession}). The debugger cache was lost on reconnect and the body was not cached (${req.size ? formatBytes(req.size) : 'unknown size'}, limit ${formatBytes(MAX_BODY_CACHE_SIZE)}).`;
         }
 
-        // 3. Try live fetch from current session
+        // Try live fetch from current session
         try {
           const result = await ctx.cdp.send('Network.getResponseBody', { requestId: req.id }) as { body: string; base64Encoded: boolean };
-          const body = result.base64Encoded
-            ? Buffer.from(result.body, 'base64').toString('utf8')
-            : result.body;
-
-          // Cache for future use
+          const body = decodeResponseBody(result);
           req.responseBody = body;
-          req.bodyCached = true;
-
           try {
             return { url: req.url, status: req.status, body: JSON.parse(body) };
           } catch {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -126,20 +126,6 @@ export const networkPlugin = definePlugin({
       currentSession++;
     });
 
-    // When Metro starts rebuilding, try to cache any pending request bodies
-    // before the CDP connection drops during reload.
-    ctx.events.on('bundle_transform_progressed', (event) => {
-      if (event.transformedFileCount === 1 && pendingRequests.size > 0) {
-        const now = Date.now();
-        for (const [, req] of pendingRequests) {
-          req.endTime = now;
-          req.error = 'Bundle reload';
-          buffer.push(req);
-        }
-        pendingRequests.clear();
-      }
-    });
-
     // ── Request tracking tools ─────────────────────────────────────────────────
 
     ctx.registerTool('get_network_requests', {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -126,6 +126,20 @@ export const networkPlugin = definePlugin({
       currentSession++;
     });
 
+    // When Metro starts rebuilding, try to cache any pending request bodies
+    // before the CDP connection drops during reload.
+    ctx.events.on('bundle_transform_progressed', (event) => {
+      if (event.transformedFileCount === 1 && pendingRequests.size > 0) {
+        const now = Date.now();
+        for (const [, req] of pendingRequests) {
+          req.endTime = now;
+          req.error = 'Bundle reload';
+          buffer.push(req);
+        }
+        pendingRequests.clear();
+      }
+    });
+
     // ── Request tracking tools ─────────────────────────────────────────────────
 
     ctx.registerTool('get_network_requests', {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -2,6 +2,13 @@ import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { CircularBuffer } from '../utils/buffer.js';
 import { formatTimestamp, formatBytes } from '../utils/format.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('network');
+
+/** Maximum encoded body size (bytes) to eagerly cache. Responses larger than this
+ *  will only be fetchable while the same CDP session is active. */
+const MAX_BODY_CACHE_SIZE = 1024 * 1024; // 1 MB
 
 interface NetworkRequest {
   id: string;
@@ -17,6 +24,10 @@ interface NetworkRequest {
   endTime?: number;
   error?: string;
   size?: number;
+  /** Connection session this request belongs to. Incremented on each reconnect. */
+  session: number;
+  /** Whether the response body was eagerly cached (available after reconnect). */
+  bodyCached: boolean;
 }
 
 export const networkPlugin = definePlugin({
@@ -28,6 +39,10 @@ export const networkPlugin = definePlugin({
     const buffer = new CircularBuffer<NetworkRequest>(200);
     const pendingRequests = new Map<string, NetworkRequest>();
 
+    /** Monotonically increasing session counter – bumped on every reconnect so we
+     *  can tell which requests belong to the current CDP session vs a stale one. */
+    let currentSession = 0;
+
     // ── CDP Network domain ─────────────────────────────────────────────────────
 
     ctx.cdp.on('Network.requestWillBeSent', (params) => {
@@ -37,6 +52,8 @@ export const networkPlugin = definePlugin({
         method: (params.request as Record<string, unknown>)?.method as string || 'GET',
         requestHeaders: (params.request as Record<string, unknown>)?.headers as Record<string, string>,
         startTime: Date.now(),
+        session: currentSession,
+        bodyCached: false,
       };
       pendingRequests.set(request.id, request);
     });
@@ -58,6 +75,24 @@ export const networkPlugin = definePlugin({
         req.size = params.encodedDataLength as number;
         pendingRequests.delete(req.id);
         buffer.push(req);
+
+        // Eagerly cache the response body so it survives reconnections.
+        // Only cache bodies within the size limit to avoid excessive memory use.
+        const encodedSize = req.size ?? 0;
+        if (encodedSize <= MAX_BODY_CACHE_SIZE) {
+          ctx.cdp.send('Network.getResponseBody', { requestId: req.id })
+            .then((result) => {
+              const r = result as { body: string; base64Encoded: boolean };
+              req.responseBody = r.base64Encoded
+                ? Buffer.from(r.body, 'base64').toString('utf8')
+                : r.body;
+              req.bodyCached = true;
+            })
+            .catch((err) => {
+              // Body not available from debugger – this is expected for some requests
+              logger.debug(`Could not cache body for ${req.method} ${req.url}: ${err}`);
+            });
+        }
       }
     });
 
@@ -79,6 +114,10 @@ export const networkPlugin = definePlugin({
         buffer.push(req);
       }
       pendingRequests.clear();
+    });
+
+    ctx.cdp.on('reconnected', () => {
+      currentSession++;
     });
 
     // ── Request tracking tools ─────────────────────────────────────────────────
@@ -143,7 +182,8 @@ export const networkPlugin = definePlugin({
     ctx.registerTool('get_response_body', {
       description:
         'Get the response body for a specific network request. ' +
-        'Bodies are fetched on demand via CDP and are not included in get_network_requests or search_network output.',
+        'Bodies are eagerly cached when small enough, so they survive reconnections. ' +
+        'Larger bodies are fetched on demand and only available in the current CDP session.',
       parameters: z.object({
         url: z.string().describe('URL or partial URL to find the request'),
         index: z.number().default(-1).describe('Index of the request if multiple match (-1 for last)'),
@@ -154,12 +194,31 @@ export const networkPlugin = definePlugin({
         const req = index === -1 ? matches[matches.length - 1] : matches[index];
         if (!req) return `Request index ${index} out of range (${matches.length} matches)`;
 
+        // 1. Use eagerly cached body if available (survives reconnections)
+        if (req.bodyCached && req.responseBody !== undefined) {
+          try {
+            return { url: req.url, status: req.status, body: JSON.parse(req.responseBody) };
+          } catch {
+            return { url: req.url, status: req.status, body: req.responseBody };
+          }
+        }
+
+        // 2. Request is from a previous session and body wasn't cached — no way to fetch it
+        if (req.session !== currentSession) {
+          return `Response body unavailable for "${req.url}": this request was captured in a previous CDP session (session ${req.session}, current ${currentSession}). The debugger cache was lost on reconnect and the body was too large to eagerly cache (${req.size ? formatBytes(req.size) : 'unknown size'}, limit ${formatBytes(MAX_BODY_CACHE_SIZE)}).`;
+        }
+
+        // 3. Try live fetch from current session
         try {
           const result = await ctx.cdp.send('Network.getResponseBody', { requestId: req.id }) as { body: string; base64Encoded: boolean };
           const body = result.base64Encoded
             ? Buffer.from(result.body, 'base64').toString('utf8')
             : result.body;
-          // Try to pretty-print JSON bodies
+
+          // Cache for future use
+          req.responseBody = body;
+          req.bodyCached = true;
+
           try {
             return { url: req.url, status: req.status, body: JSON.parse(body) };
           } catch {
@@ -195,6 +254,17 @@ export const networkPlugin = definePlugin({
           error: r.error,
           duration: r.endTime ? `${r.endTime - r.startTime}ms` : 'pending',
         }));
+      },
+    });
+
+    ctx.registerTool('clear_network_requests', {
+      description: 'Clear the network request buffer. Useful after a reload or when old requests are no longer relevant.',
+      parameters: z.object({}),
+      handler: async () => {
+        const count = buffer.size;
+        buffer.clear();
+        pendingRequests.clear();
+        return `Cleared ${count} network requests.`;
       },
     });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import type {
   EvalOptions,
 } from './plugin.js';
 import { CDPClient } from './metro/connection.js';
+import { MetroEventsClient } from './metro/events.js';
 import { scanMetroPorts, selectBestTarget, fetchTargets } from './metro/discovery.js';
 import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
@@ -76,6 +77,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   );
 
   const cdpClient = new CDPClient();
+  const eventsClient = new MetroEventsClient();
   const formatUtils = createFormatUtils();
 
   // Server-side reconnect state — single source of truth for all reconnect logic.
@@ -117,6 +119,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     const pluginLogger = createLogger(plugin.name);
     return {
       cdp: cdpClient,
+      events: eventsClient,
       registerTool: <T extends z.ZodType>(name: string, toolConfig: ToolConfig<T>) => {
         try {
           mcpServer.tool(
@@ -314,6 +317,12 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       }
 
       await cdpClient.connect(target);
+
+      // Connect to Metro's /events WebSocket for build events (independent of CDP)
+      if (!eventsClient.isConnected()) {
+        eventsClient.connect(server.host, server.port);
+      }
+
       return true;
     } catch (err) {
       logger.warn('Could not connect to Metro:', err);

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,8 +79,10 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   const formatUtils = createFormatUtils();
 
   // Server-side reconnect state — single source of truth for all reconnect logic.
-  const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000];
-  const MAX_RECONNECT_ATTEMPTS = 10;
+  // Start with a very short delay (500ms) to recover quickly from brief disconnects
+  // like hot reloads, then ramp up for longer outages.
+  const RECONNECT_DELAYS = [500, 1000, 2000, 4000, 8000, 16000];
+  const MAX_RECONNECT_ATTEMPTS = 15;
   let reconnectAttempts = 0;
   let isReconnecting = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -317,12 +317,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       }
 
       await cdpClient.connect(target);
-
-      // Connect to Metro's /events WebSocket for build events (independent of CDP)
-      if (!eventsClient.isConnected()) {
-        eventsClient.connect(server.host, server.port);
-      }
-
+      eventsClient.connect(server.host, server.port);
       return true;
     } catch (err) {
       logger.warn('Could not connect to Metro:', err);

--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -1,0 +1,8 @@
+import type { RawData } from 'ws';
+
+/** Convert ws message data (Buffer | ArrayBuffer | Buffer[]) to a UTF-8 string. */
+export function wsDataToString(data: RawData): string {
+  if (Buffer.isBuffer(data)) return data.toString();
+  if (Array.isArray(data)) return Buffer.concat(data).toString();
+  return Buffer.from(data).toString();
+}


### PR DESCRIPTION
## Summary

- **WebSocket ping/pong keepalive**: Switch from browser `WebSocket` to the `ws` library (same as Metro uses) for explicit ping/pong support. Metro's InspectorProxy sends pings every 5s and terminates after 60s of no pong — the `ws` library handles this natively. Replaces the heavy `Runtime.enable` CDP keepalive with lightweight `ws.ping()`.
- **Eager response body caching**: Cache response bodies (up to 1MB) on `Network.loadingFinished` so they survive CDP reconnections. Solves the stale request ID problem where `getResponseBody` fails after reconnect. Includes concurrency limiter (max 4 concurrent fetches) to avoid flooding the CDP pipeline.
- **Metro `/events` WebSocket**: Connect to Metro's `/events` endpoint for structured build error reporting (`bundling_error` events) and early reload detection (`bundle_transform_progressed`). Inserts rebuild markers into console log buffer so gaps are visible.
- **Faster reconnection**: Initial reconnect delay reduced to 500ms (from 1s) with up to 15 attempts using exponential backoff `[500, 1000, 2000, 4000, 8000, 16000]ms`, reducing data loss during brief disconnects like hot reloads.
- **Session tracking**: Monotonically increasing session counter on network requests gives clear error messages when a body from a previous CDP session can't be fetched.
- **Dead connection detection**: 3 consecutive missed pongs trigger force-close and reconnect with fresh target URL from Metro's `/json` endpoint.

## Changed files

| File | Change |
|------|--------|
| `package.json` | Add `ws` + `@types/ws`, `--external ws` in build scripts |
| `src/metro/connection.ts` | Switch to `ws` library, ping/pong handlers, lighter keepalive |
| `src/metro/events.ts` | New — Metro `/events` WebSocket client |
| `src/utils/ws.ts` | New — shared `wsDataToString` utility |
| `src/plugin.ts` | Add `MetroEvent`, `MetroEventsConnection` types, `events` on `PluginContext` |
| `src/server.ts` | Wire up events client, coordinated reconnection |
| `src/plugins/network.ts` | Eager body caching, session tracking, `clear_network_requests` tool |
| `src/plugins/errors.ts` | `bundling_error` event handling, extracted `parseErrorLocation` helper |
| `src/plugins/console.ts` | Rebuild markers via events, reconnect boundary markers |
| `docs/tools.md` | Updated tool descriptions |

## Test plan

- [ ] `bun run build` passes cleanly
- [ ] `bun run typecheck` passes
- [ ] Connect to a live Metro server and verify ping/pong debug logs in stderr
- [ ] Kill and restart Metro — verify reconnection within expected backoff delays
- [ ] Trigger a bundle error and verify it appears in `get_bundle_errors`
- [ ] Make network requests, reconnect, and verify cached response bodies are still accessible via `get_response_body`
- [ ] Verify `clear_network_requests` tool works

https://claude.ai/code/session_018JkNnLN8vz92twy9YXUfqE