### PR TITLE
Migrate from Bun-specific APIs to Node.js standard library

### DIFF
--- a/bin/metro-mcp.ts
+++ b/bin/metro-mcp.ts
@@ -1,2 +1,2 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 import '../src/index.js';

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "clean": "rm -rf dist",
     "build": "bun run clean && bun run build:js && bun run build:bin && bun run build:types",
     "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external zod --external ws && bun build src/client/index.ts --outfile dist/client/index.js --target browser --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.cjs --target browser --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod",
-    "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target bun --external @modelcontextprotocol/sdk --external zod --external ws && chmod +x dist/bin/metro-mcp.js",
+    "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target node --external @modelcontextprotocol/sdk --external zod --external ws && chmod +x dist/bin/metro-mcp.js",
     "build:types": "bunx tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 import { loadConfig } from './config.js';
 import { startServer } from './server.js';
 import { createLogger } from './utils/logger.js';

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 
@@ -37,10 +39,9 @@ export const simulatorPlugin = definePlugin({
         }
 
         // Read file and return as base64
-        const file = Bun.file(tmpFile);
-        if (await file.exists()) {
-          const buffer = await file.arrayBuffer();
-          const base64 = Buffer.from(buffer).toString('base64');
+        if (existsSync(tmpFile)) {
+          const buffer = await readFile(tmpFile);
+          const base64 = buffer.toString('base64');
           await ctx.exec(`rm -f "${tmpFile}"`);
           return {
             type: 'image',

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'fs/promises';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { FIBER_ROOT_JS, GET_ROUTE_FUNC_JS, SWIPE_COORDS } from '../utils/fiber.js';
@@ -187,7 +188,7 @@ export const uiInteractPlugin = definePlugin({
             await ctx.exec(
               `adb shell uiautomator dump /sdcard/uidump.xml && adb pull /sdcard/uidump.xml ${tmpFile} 2>/dev/null`
             );
-            content = await Bun.file(tmpFile).text();
+            content = await readFile(tmpFile, 'utf8');
           } finally {
             await ctx.exec(`rm -f ${tmpFile}`).catch(() => {});
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,9 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const execAsync = promisify(exec);
 import { z } from 'zod';
 import type {
   MetroMCPConfig,
@@ -241,16 +245,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
         },
       },
       exec: async (command: string) => {
-        const proc = Bun.spawn(['sh', '-c', command], {
-          stdout: 'pipe',
-          stderr: 'pipe',
-        });
-        const stdout = await new Response(proc.stdout).text();
-        const stderr = await new Response(proc.stderr).text();
-        await proc.exited;
-        if (proc.exitCode !== 0) {
-          throw new Error(stderr || `Command failed with exit code ${proc.exitCode}`);
-        }
+        const { stdout } = await execAsync(command);
         return stdout;
       },
       format: formatUtils,


### PR DESCRIPTION
## Summary
This PR migrates the codebase from Bun-specific APIs to Node.js standard library equivalents, making the project compatible with standard Node.js runtimes while maintaining the same functionality.

## Key Changes
- **Command execution**: Replaced `Bun.spawn()` with Node.js `child_process.exec()` via `promisify()`
- **File operations**: Replaced Bun's `Bun.file()` API with standard Node.js `fs/promises` and `fs` modules
  - `Bun.file().exists()` → `existsSync()`
  - `Bun.file().arrayBuffer()` → `readFile()` with Buffer conversion
  - `Bun.file().text()` → `readFile()` with 'utf8' encoding
- **Runtime target**: Updated shebang from `#!/usr/bin/env bun` to `#!/usr/bin/env node` in entry points
- **Build configuration**: Changed binary build target from `bun` to `node` in package.json build script

## Implementation Details
- The `exec()` handler in server.ts now uses the standard Node.js `child_process` module with promisified interface for cleaner async/await syntax
- File reading operations now use the standard `fs/promises` API which returns Buffers directly, eliminating the need for ArrayBuffer conversion
- All file existence checks now use synchronous `existsSync()` from the standard `fs` module
- The changes maintain backward compatibility with the existing API surface while removing Bun runtime dependencies

https://claude.ai/code/session_01MQh6ZLGPAU8ePjSmecjEfQ