### PR TITLE
Improve connection health detection with ping-based keepalive

### DIFF
--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -32,7 +32,7 @@ export class CDPClient implements CDPConnection {
   private suppressReconnect = false;
   private _isConnected = false;
   private target: MetroTarget | null = null;
-  private pongReceived = false;
+  private lastPingAt = 0;
 
   private readonly requestTimeout = 10000;
   private readonly keepAliveInterval = 10000;
@@ -71,7 +71,7 @@ export class CDPClient implements CDPConnection {
 
         this.ws.on('open', () => {
           this._isConnected = true;
-          this.pongReceived = true;
+          this.lastPingAt = Date.now();
           this.startKeepAlive();
           logger.info(`Connected to ${this.target?.title || 'unknown'}`);
           resolve();
@@ -103,15 +103,10 @@ export class CDPClient implements CDPConnection {
         });
 
         // Metro's InspectorProxy sends pings every 5s — ws auto-responds with pong.
-        // Log for diagnostics.
+        // Track the last ping time so keepalive can detect a silently dead connection.
         this.ws.on('ping', () => {
+          this.lastPingAt = Date.now();
           logger.debug('Received ping from Metro');
-        });
-
-        // Track pong responses to our own pings (sent by startKeepAlive).
-        this.ws.on('pong', () => {
-          this.pongReceived = true;
-          logger.debug('Received pong from Metro');
         });
       } catch (err) {
         reject(err);
@@ -189,23 +184,15 @@ export class CDPClient implements CDPConnection {
 
   private startKeepAlive(): void {
     this.stopKeepAlive();
-    let missedKeepAlives = 0;
     this.keepAliveTimer = setInterval(() => {
       if (!this._isConnected || !this.ws) return;
 
-      if (!this.pongReceived) {
-        missedKeepAlives++;
-        if (missedKeepAlives >= 3) {
-          logger.warn(`${missedKeepAlives} consecutive pongs missed — closing connection`);
-          try { this.ws.close(); } catch {}
-          return;
-        }
-      } else {
-        missedKeepAlives = 0;
+      // Metro sends pings every 5s. If we haven't received one in 20s the connection is dead.
+      const elapsed = Date.now() - this.lastPingAt;
+      if (elapsed > 20000) {
+        logger.warn(`No ping received from Metro in ${elapsed}ms — closing connection`);
+        try { this.ws.close(); } catch {}
       }
-
-      this.pongReceived = false;
-      this.ws.ping();
     }, this.keepAliveInterval);
   }
 

--- a/src/plugins/statusline.ts
+++ b/src/plugins/statusline.ts
@@ -53,10 +53,15 @@ export const statuslinePlugin = definePlugin({
   description: 'Writes CDP connection state to a file for Claude Code status bar integration',
 
   async setup(ctx) {
+    let lastConnected: boolean | null = null;
+
     function write(): void {
+      const connected = ctx.cdp.isConnected();
+      if (connected === lastConnected) return;
+      lastConnected = connected;
       const target = ctx.cdp.getTarget();
       writeStatus({
-        connected: ctx.cdp.isConnected(),
+        connected,
         host: ctx.metro.host,
         port: ctx.metro.port,
         target: target?.description ?? null,
@@ -67,7 +72,7 @@ export const statuslinePlugin = definePlugin({
     ctx.cdp.on('reconnected', write);
     ctx.cdp.on('disconnected', write);
 
-    // Poll every 5s so the statusline stays accurate even if events are missed
+    // Poll every 5s so the statusline self-corrects if an event is missed
     setInterval(write, 5000);
 
     // Write initial state

--- a/src/plugins/statusline.ts
+++ b/src/plugins/statusline.ts
@@ -53,10 +53,10 @@ export const statuslinePlugin = definePlugin({
   description: 'Writes CDP connection state to a file for Claude Code status bar integration',
 
   async setup(ctx) {
-    function write(connected: boolean): void {
+    function write(): void {
       const target = ctx.cdp.getTarget();
       writeStatus({
-        connected,
+        connected: ctx.cdp.isConnected(),
         host: ctx.metro.host,
         port: ctx.metro.port,
         target: target?.description ?? null,
@@ -64,11 +64,14 @@ export const statuslinePlugin = definePlugin({
       });
     }
 
-    ctx.cdp.on('reconnected', () => write(true));
-    ctx.cdp.on('disconnected', () => write(false));
+    ctx.cdp.on('reconnected', write);
+    ctx.cdp.on('disconnected', write);
+
+    // Poll every 5s so the statusline stays accurate even if events are missed
+    setInterval(write, 5000);
 
     // Write initial state
-    write(ctx.cdp.isConnected());
+    write();
 
     ctx.registerTool('setup_statusline', {
       description:


### PR DESCRIPTION
## Summary
Refactored the connection health monitoring mechanism to use Metro's incoming ping messages as a heartbeat indicator, replacing the previous approach of sending outbound pings and waiting for pongs. This provides more reliable detection of silently dead connections.

## Key Changes

- **Connection health tracking**: Replaced `pongReceived` flag with `lastPingAt` timestamp to track when Metro last sent a ping
- **Simplified keepalive logic**: Removed outbound ping/pong mechanism and instead monitor the time elapsed since the last incoming ping from Metro (which are sent every 5s)
- **Improved dead connection detection**: If no ping is received within 20 seconds, the connection is now closed as it's considered dead
- **Statusline plugin robustness**: Added 5-second polling interval to ensure the status file stays accurate even if connection events are missed, and simplified the write function to always query current state

## Implementation Details

The keepalive mechanism now leverages Metro's built-in ping behavior (sent every 5s) rather than relying on our own ping/pong exchanges. This is more efficient and provides a clearer signal of connection health. The 20-second timeout window (4 missed pings) gives a reasonable grace period while still detecting stale connections promptly.

The statusline plugin now uses polling as a safety net alongside event-based updates, ensuring the status file reflects the true connection state even if events are lost.

https://claude.ai/code/session_017GqG97HdRyecRzuAxx2h6m