### PR TITLE
feat: add CDP proxy for Chrome DevTools coexistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1357 @@
+{
+  "name": "metro-mcp",
+  "version": "0.5.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "metro-mcp",
+      "version": "0.5.2",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "chrome-launcher": "^1.2.1",
+        "chromium-edge-launcher": "^0.3.0",
+        "ws": "^8.20.0",
+        "zod": "^3.24.4"
+      },
+      "bin": {
+        "metro-mcp": "dist/bin/metro-mcp.js"
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.10",
+        "@types/ws": "^8.18.1",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.11.tgz",
+      "integrity": "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.11"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz",
+      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-edge-launcher": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+      "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/lighthouse-logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.6.9",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "chrome-launcher": "^1.2.1",
+    "chromium-edge-launcher": "^0.3.0",
     "ws": "^8.20.0",
     "zod": "^3.24.4"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,10 @@ const DEFAULT_CONFIG: Required<MetroMCPConfig> = {
   profiler: {
     newArchitecture: true,
   },
+  proxy: {
+    enabled: true,
+    port: 0,
+  },
 };
 
 /**
@@ -36,6 +40,14 @@ export async function loadConfig(args: string[]): Promise<Required<MetroMCPConfi
       config.metro.port = port;
       config.metro.autoDiscover = false;
     }
+  }
+
+  if (process.env.METRO_MCP_PROXY_PORT) {
+    const port = parseInt(process.env.METRO_MCP_PROXY_PORT, 10);
+    if (!isNaN(port)) config.proxy.port = port;
+  }
+  if (process.env.METRO_MCP_PROXY_ENABLED === 'false') {
+    config.proxy.enabled = false;
   }
 
   // CLI args
@@ -87,5 +99,9 @@ function mergeConfig(target: Required<MetroMCPConfig>, source: MetroMCPConfig): 
   }
   if (source.profiler) {
     if (source.profiler.newArchitecture !== undefined) target.profiler.newArchitecture = source.profiler.newArchitecture;
+  }
+  if (source.proxy) {
+    if (source.proxy.enabled !== undefined) target.proxy.enabled = source.proxy.enabled;
+    if (source.proxy.port !== undefined) target.proxy.port = source.proxy.port;
   }
 }

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -35,12 +35,13 @@ export class CDPClient implements CDPConnection {
   private lastPingAt = 0;
 
   /**
-   * Optional interceptor for raw incoming CDP messages.
+   * Optional interceptor for parsed incoming CDP messages.
    * If set and returns true, the message is consumed by the interceptor
    * and won't be processed by CDPClient's own handleMessage logic.
    * Used by CDPProxy to route responses to external clients.
+   * Receives both the parsed message and the raw string to avoid double parsing.
    */
-  messageInterceptor: ((data: string) => boolean) | null = null;
+  messageInterceptor: ((parsed: CDPResponse, raw: string) => boolean) | null = null;
 
   private readonly requestTimeout = 10000;
   private readonly keepAliveInterval = 10000;
@@ -223,9 +224,6 @@ export class CDPClient implements CDPConnection {
   }
 
   private handleMessage(data: string): void {
-    // Let the interceptor handle the message first (used by CDPProxy)
-    if (this.messageInterceptor?.(data)) return;
-
     let message: CDPResponse;
     try {
       message = JSON.parse(data);
@@ -233,6 +231,9 @@ export class CDPClient implements CDPConnection {
       logger.warn('Failed to parse CDP message');
       return;
     }
+
+    // Let the interceptor handle the message first (used by CDPProxy)
+    if (this.messageInterceptor?.(message, data)) return;
 
     // Response to a request
     if (message.id !== undefined) {

--- a/src/metro/connection.ts
+++ b/src/metro/connection.ts
@@ -34,6 +34,14 @@ export class CDPClient implements CDPConnection {
   private target: MetroTarget | null = null;
   private lastPingAt = 0;
 
+  /**
+   * Optional interceptor for raw incoming CDP messages.
+   * If set and returns true, the message is consumed by the interceptor
+   * and won't be processed by CDPClient's own handleMessage logic.
+   * Used by CDPProxy to route responses to external clients.
+   */
+  messageInterceptor: ((data: string) => boolean) | null = null;
+
   private readonly requestTimeout = 10000;
   private readonly keepAliveInterval = 10000;
 
@@ -203,7 +211,21 @@ export class CDPClient implements CDPConnection {
     }
   }
 
+  /**
+   * Send a raw string message to the upstream Hermes WebSocket.
+   * Used by CDPProxy to forward requests from external clients.
+   */
+  sendRaw(data: string): void {
+    if (!this.ws || !this._isConnected) {
+      throw new Error('Not connected to CDP target');
+    }
+    this.ws.send(data);
+  }
+
   private handleMessage(data: string): void {
+    // Let the interceptor handle the message first (used by CDPProxy)
+    if (this.messageInterceptor?.(data)) return;
+
     let message: CDPResponse;
     try {
       message = JSON.parse(data);

--- a/src/metro/proxy.ts
+++ b/src/metro/proxy.ts
@@ -129,11 +129,11 @@ export class CDPProxy {
   }
 
   /**
-   * Get the Chrome DevTools URL for this proxy.
+   * Get the Chrome DevTools frontend URL for this proxy.
    */
   getDevToolsUrl(): string | null {
     if (!this._port) return null;
-    return `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=localhost:${this._port}`;
+    return `chrome-devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=127.0.0.1:${this._port}`;
   }
 
   // ── HTTP handler (serves /json for Chrome auto-discovery) ─────────────────

--- a/src/metro/proxy.ts
+++ b/src/metro/proxy.ts
@@ -1,0 +1,344 @@
+import http from 'http';
+import WebSocket, { WebSocketServer } from 'ws';
+import type { CDPClient } from './connection.js';
+import type { CDPResponse } from './types.js';
+import { createLogger } from '../utils/logger.js';
+import { wsDataToString } from '../utils/ws.js';
+
+const logger = createLogger('cdp-proxy');
+
+interface ExternalClient {
+  id: string;
+  ws: WebSocket;
+  enabledDomains: Set<string>;
+}
+
+interface PendingProxyRequest {
+  clientId: string;
+  originalId: number;
+}
+
+/**
+ * CDP Proxy/Multiplexer.
+ *
+ * Sits between Hermes (single CDP connection via CDPClient) and multiple
+ * downstream consumers: the MCP plugins (internal) and Chrome DevTools
+ * or other external clients (via WebSocket).
+ *
+ * - Requests from external clients get ID-remapped before forwarding upstream.
+ * - Responses are routed back to the originating client only.
+ * - Events are broadcast to ALL connected clients.
+ * - Domain enable/disable is reference-counted so clients don't interfere.
+ */
+export class CDPProxy {
+  private httpServer: http.Server | null = null;
+  private wss: WebSocketServer | null = null;
+  private clients = new Map<string, ExternalClient>();
+  private pendingRequests = new Map<number, PendingProxyRequest>();
+  private domainRefCounts = new Map<string, number>();
+  private nextGlobalId = 1_000_000;
+  private clientCounter = 0;
+  private _port: number | null = null;
+
+  constructor(private readonly cdpClient: CDPClient) {
+    // Install the message interceptor on CDPClient to intercept responses
+    // destined for external clients and broadcast events.
+    cdpClient.messageInterceptor = (data: string) => this.handleUpstreamMessage(data);
+
+    // When the upstream reconnects, re-enable domains for connected external clients.
+    cdpClient.on('reconnected', () => {
+      this.reEnableDomains();
+    });
+
+    // When upstream disconnects, notify external clients.
+    cdpClient.on('disconnected', () => {
+      for (const client of this.clients.values()) {
+        // Send a synthetic event so Chrome DevTools knows the target went away
+        this.sendToClient(client, JSON.stringify({
+          method: 'Inspector.detached',
+          params: { reason: 'target_closed' },
+        }));
+      }
+    });
+  }
+
+  get port(): number | null {
+    return this._port;
+  }
+
+  /**
+   * Start the proxy's HTTP + WebSocket server.
+   */
+  async start(port = 0): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.httpServer = http.createServer((req, res) => {
+        this.handleHttpRequest(req, res);
+      });
+
+      this.wss = new WebSocketServer({ server: this.httpServer });
+      this.wss.on('connection', (ws) => this.handleNewClient(ws));
+
+      this.httpServer.on('error', reject);
+      this.httpServer.listen(port, () => {
+        const addr = this.httpServer!.address();
+        this._port = typeof addr === 'object' && addr ? addr.port : port;
+        logger.info(`CDP proxy listening on port ${this._port}`);
+        resolve(this._port);
+      });
+    });
+  }
+
+  /**
+   * Stop the proxy server.
+   */
+  async stop(): Promise<void> {
+    // Disconnect all external clients
+    for (const client of this.clients.values()) {
+      try { client.ws.close(); } catch {}
+    }
+    this.clients.clear();
+    this.pendingRequests.clear();
+    this.domainRefCounts.clear();
+
+    // Remove the interceptor
+    this.cdpClient.messageInterceptor = null;
+
+    return new Promise((resolve) => {
+      if (this.wss) {
+        this.wss.close(() => {
+          if (this.httpServer) {
+            this.httpServer.close(() => resolve());
+          } else {
+            resolve();
+          }
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  /**
+   * Get the Chrome DevTools URL for this proxy.
+   */
+  getDevToolsUrl(): string | null {
+    if (!this._port) return null;
+    return `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=localhost:${this._port}`;
+  }
+
+  // ── HTTP handler (serves /json for Chrome auto-discovery) ─────────────────
+
+  private handleHttpRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    if (req.url === '/json' || req.url === '/json/list') {
+      const target = this.cdpClient.getTarget();
+      const targetList = target ? [{
+        description: target.description || '',
+        devtoolsFrontendUrl: this.getDevToolsUrl(),
+        id: target.id,
+        title: target.title,
+        type: 'node',
+        webSocketDebuggerUrl: `ws://localhost:${this._port}`,
+        ...(target.vm ? { vm: target.vm } : {}),
+      }] : [];
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(targetList));
+      return;
+    }
+
+    if (req.url === '/json/version') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        Browser: 'metro-mcp/CDP-Proxy',
+        'Protocol-Version': '1.3',
+      }));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not Found');
+  }
+
+  // ── WebSocket client handling ─────────────────────────────────────────────
+
+  private handleNewClient(ws: WebSocket): void {
+    const clientId = `client-${++this.clientCounter}`;
+    const client: ExternalClient = { id: clientId, ws, enabledDomains: new Set() };
+    this.clients.set(clientId, client);
+    logger.info(`External client connected: ${clientId}`);
+
+    ws.on('message', (data) => {
+      this.handleClientMessage(client, wsDataToString(data));
+    });
+
+    ws.on('close', () => {
+      logger.info(`External client disconnected: ${clientId}`);
+      this.cleanupClient(client);
+    });
+
+    ws.on('error', (err) => {
+      logger.error(`Client ${clientId} error: ${err.message}`);
+    });
+  }
+
+  private handleClientMessage(client: ExternalClient, data: string): void {
+    let message: { id?: number; method?: string; params?: Record<string, unknown> };
+    try {
+      message = JSON.parse(data);
+    } catch {
+      logger.warn(`Invalid JSON from client ${client.id}`);
+      return;
+    }
+
+    if (message.id === undefined || !message.method) {
+      // No ID or no method — just forward as-is
+      try { this.cdpClient.sendRaw(data); } catch {}
+      return;
+    }
+
+    const method = message.method;
+
+    // Handle domain enable/disable with reference counting
+    if (method.endsWith('.enable')) {
+      const domain = method.replace('.enable', '');
+      const refCount = this.domainRefCounts.get(domain) || 0;
+      client.enabledDomains.add(domain);
+
+      if (refCount > 0) {
+        // Domain already enabled upstream — return synthetic success
+        this.domainRefCounts.set(domain, refCount + 1);
+        this.sendToClient(client, JSON.stringify({ id: message.id, result: {} }));
+        return;
+      }
+
+      // First enable — forward to Hermes and track the mapping
+      this.domainRefCounts.set(domain, 1);
+    } else if (method.endsWith('.disable')) {
+      const domain = method.replace('.disable', '');
+      const refCount = this.domainRefCounts.get(domain) || 0;
+      client.enabledDomains.delete(domain);
+
+      if (refCount > 1) {
+        // Other clients still need this domain
+        this.domainRefCounts.set(domain, refCount - 1);
+        this.sendToClient(client, JSON.stringify({ id: message.id, result: {} }));
+        return;
+      }
+
+      // Last disable — forward to Hermes
+      if (refCount === 1) this.domainRefCounts.set(domain, 0);
+    }
+
+    // Remap the ID and forward upstream
+    const globalId = this.nextGlobalId++;
+    this.pendingRequests.set(globalId, { clientId: client.id, originalId: message.id });
+
+    const remapped = { ...message, id: globalId };
+    try {
+      this.cdpClient.sendRaw(JSON.stringify(remapped));
+    } catch (err) {
+      // Upstream not connected — send error back
+      this.pendingRequests.delete(globalId);
+      this.sendToClient(client, JSON.stringify({
+        id: message.id,
+        error: { code: -32000, message: 'Upstream CDP connection not available' },
+      }));
+    }
+  }
+
+  // ── Upstream message handling ──────────────────────────────────────────────
+
+  /**
+   * Intercept messages from Hermes before CDPClient processes them.
+   * Returns true if the message was consumed (should not be processed by CDPClient).
+   */
+  private handleUpstreamMessage(data: string): boolean {
+    let message: CDPResponse;
+    try {
+      message = JSON.parse(data);
+    } catch {
+      return false;
+    }
+
+    // Response to a request
+    if (message.id !== undefined) {
+      const pending = this.pendingRequests.get(message.id);
+      if (pending) {
+        // This response belongs to an external client — route it back
+        this.pendingRequests.delete(message.id);
+        const client = this.clients.get(pending.clientId);
+        if (client) {
+          const remapped = { ...message, id: pending.originalId };
+          this.sendToClient(client, JSON.stringify(remapped));
+        }
+        return true; // consumed — don't let CDPClient handle it
+      }
+      // Not for an external client — let CDPClient handle it normally
+      return false;
+    }
+
+    // Event — broadcast to ALL external clients (CDPClient also handles it via its own handlers)
+    if (message.method) {
+      for (const client of this.clients.values()) {
+        this.sendToClient(client, data);
+      }
+    }
+
+    return false; // let CDPClient also process the event
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private sendToClient(client: ExternalClient, data: string): void {
+    if (client.ws.readyState === WebSocket.OPEN) {
+      client.ws.send(data);
+    }
+  }
+
+  private cleanupClient(client: ExternalClient): void {
+    // Decrement domain ref counts for domains this client had enabled
+    for (const domain of client.enabledDomains) {
+      const refCount = this.domainRefCounts.get(domain) || 0;
+      if (refCount > 0) {
+        this.domainRefCounts.set(domain, refCount - 1);
+        // If this was the last client using this domain, disable it upstream
+        if (refCount === 1) {
+          try {
+            this.cdpClient.sendRaw(JSON.stringify({
+              id: this.nextGlobalId++,
+              method: `${domain}.disable`,
+            }));
+          } catch {}
+        }
+      }
+    }
+    this.clients.delete(client.id);
+
+    // Clean up any pending requests for this client
+    for (const [globalId, pending] of this.pendingRequests) {
+      if (pending.clientId === client.id) {
+        this.pendingRequests.delete(globalId);
+      }
+    }
+  }
+
+  /**
+   * Re-enable all domains that external clients need after a reconnection.
+   */
+  private reEnableDomains(): void {
+    const domainsToEnable = new Set<string>();
+    for (const client of this.clients.values()) {
+      for (const domain of client.enabledDomains) {
+        domainsToEnable.add(domain);
+      }
+    }
+    for (const domain of domainsToEnable) {
+      try {
+        this.cdpClient.sendRaw(JSON.stringify({
+          id: this.nextGlobalId++,
+          method: `${domain}.enable`,
+        }));
+      } catch {}
+    }
+  }
+}

--- a/src/metro/proxy.ts
+++ b/src/metro/proxy.ts
@@ -7,6 +7,12 @@ import { wsDataToString } from '../utils/ws.js';
 
 const logger = createLogger('cdp-proxy');
 
+/** Timeout for pending proxy requests (ms). */
+const PENDING_REQUEST_TIMEOUT = 30_000;
+
+/** Domains that MCP itself needs — never disabled even if all external clients disconnect. */
+const PROTECTED_DOMAINS = new Set(['Runtime', 'Network']);
+
 interface ExternalClient {
   id: string;
   ws: WebSocket;
@@ -16,6 +22,7 @@ interface ExternalClient {
 interface PendingProxyRequest {
   clientId: string;
   originalId: number;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -43,7 +50,7 @@ export class CDPProxy {
   constructor(private readonly cdpClient: CDPClient) {
     // Install the message interceptor on CDPClient to intercept responses
     // destined for external clients and broadcast events.
-    cdpClient.messageInterceptor = (data: string) => this.handleUpstreamMessage(data);
+    cdpClient.messageInterceptor = (parsed: CDPResponse, raw: string) => this.handleUpstreamMessage(parsed, raw);
 
     // When the upstream reconnects, re-enable domains for connected external clients.
     cdpClient.on('reconnected', () => {
@@ -97,6 +104,9 @@ export class CDPProxy {
       try { client.ws.close(); } catch {}
     }
     this.clients.clear();
+    for (const pending of this.pendingRequests.values()) {
+      clearTimeout(pending.timer);
+    }
     this.pendingRequests.clear();
     this.domainRefCounts.clear();
 
@@ -231,13 +241,21 @@ export class CDPProxy {
 
     // Remap the ID and forward upstream
     const globalId = this.nextGlobalId++;
-    this.pendingRequests.set(globalId, { clientId: client.id, originalId: message.id });
+    const timer = setTimeout(() => {
+      this.pendingRequests.delete(globalId);
+      this.sendToClient(client, JSON.stringify({
+        id: message.id,
+        error: { code: -32000, message: 'CDP request timed out' },
+      }));
+    }, PENDING_REQUEST_TIMEOUT);
+    this.pendingRequests.set(globalId, { clientId: client.id, originalId: message.id, timer });
 
     const remapped = { ...message, id: globalId };
     try {
       this.cdpClient.sendRaw(JSON.stringify(remapped));
     } catch (err) {
       // Upstream not connected — send error back
+      clearTimeout(timer);
       this.pendingRequests.delete(globalId);
       this.sendToClient(client, JSON.stringify({
         id: message.id,
@@ -252,19 +270,13 @@ export class CDPProxy {
    * Intercept messages from Hermes before CDPClient processes them.
    * Returns true if the message was consumed (should not be processed by CDPClient).
    */
-  private handleUpstreamMessage(data: string): boolean {
-    let message: CDPResponse;
-    try {
-      message = JSON.parse(data);
-    } catch {
-      return false;
-    }
-
+  private handleUpstreamMessage(message: CDPResponse, raw: string): boolean {
     // Response to a request
     if (message.id !== undefined) {
       const pending = this.pendingRequests.get(message.id);
       if (pending) {
         // This response belongs to an external client — route it back
+        clearTimeout(pending.timer);
         this.pendingRequests.delete(message.id);
         const client = this.clients.get(pending.clientId);
         if (client) {
@@ -280,7 +292,7 @@ export class CDPProxy {
     // Event — broadcast to ALL external clients (CDPClient also handles it via its own handlers)
     if (message.method) {
       for (const client of this.clients.values()) {
-        this.sendToClient(client, data);
+        this.sendToClient(client, raw);
       }
     }
 
@@ -301,8 +313,9 @@ export class CDPProxy {
       const refCount = this.domainRefCounts.get(domain) || 0;
       if (refCount > 0) {
         this.domainRefCounts.set(domain, refCount - 1);
-        // If this was the last client using this domain, disable it upstream
-        if (refCount === 1) {
+        // If this was the last external client using this domain, disable it upstream
+        // — but never disable protected domains that MCP itself needs
+        if (refCount === 1 && !PROTECTED_DOMAINS.has(domain)) {
           try {
             this.cdpClient.sendRaw(JSON.stringify({
               id: this.nextGlobalId++,
@@ -317,6 +330,7 @@ export class CDPProxy {
     // Clean up any pending requests for this client
     for (const [globalId, pending] of this.pendingRequests) {
       if (pending.clientId === client.id) {
+        clearTimeout(pending.timer);
         this.pendingRequests.delete(globalId);
       }
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -147,6 +147,12 @@ export interface MetroMCPConfig {
      */
     newArchitecture?: boolean;
   };
+  proxy?: {
+    /** Enable the CDP proxy so Chrome DevTools can connect alongside the MCP. Defaults to true. */
+    enabled?: boolean;
+    /** Port for the proxy server. Use 0 for OS-assigned. Defaults to 0. */
+    port?: number;
+  };
 }
 
 export function defineConfig(config: MetroMCPConfig): MetroMCPConfig {

--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -87,9 +87,7 @@ export const consolePlugin = definePlugin({
         device: z.string().optional().describe('Device key or "all" for aggregated logs. Defaults to current device.'),
       }),
       handler: async ({ level, search, limit, summary, compact: isCompact, device }) => {
-        let logs = device === 'all'
-          ? buffers.getAll()
-          : buffers.getAllForDevice(device || ctx.getActiveDeviceKey() || '');
+        let logs = buffers.resolve(device, ctx.getActiveDeviceKey());
         if (level) logs = logs.filter((l) => l.level === level);
         if (search) logs = logs.filter((l) => l.message.toLowerCase().includes(search.toLowerCase()));
 
@@ -132,9 +130,7 @@ export const consolePlugin = definePlugin({
       name: 'Console Logs',
       description: 'Recent console output from the React Native app',
       handler: async () => {
-        const key = ctx.getActiveDeviceKey();
-        const all = key ? buffers.getAllForDevice(key) : buffers.getAll();
-        const logs = all.slice(-20);
+        const logs = buffers.resolve(undefined, ctx.getActiveDeviceKey()).slice(-20);
         return JSON.stringify(
           logs.map((l) => ({
             time: formatTimestamp(l.timestamp),

--- a/src/plugins/debug-globals.ts
+++ b/src/plugins/debug-globals.ts
@@ -37,7 +37,7 @@ export const debugGlobalsPlugin = definePlugin({
           }
 
           // Also look for common Redux store patterns
-          var storeLocations = ['store', '__REDUX_STORE__', '__STORE__'];
+          var storeLocations = ['store', '__REDUX_STORE__', '__store__'];
           for (var j = 0; j < storeLocations.length; j++) {
             var loc = storeLocations[j];
             var s = globalThis[loc];

--- a/src/plugins/device.ts
+++ b/src/plugins/device.ts
@@ -100,7 +100,7 @@ export const devicePlugin = definePlugin({
 
         // Fallback: evaluate DevSettings.reload() in the app
         try {
-          await ctx.evalInApp(
+          const result = await ctx.evalInApp(
             `(function() {
               try {
                 var DevSettings = require('react-native/Libraries/Utilities/DevSettings');
@@ -113,6 +113,9 @@ export const devicePlugin = definePlugin({
               return 'no reload method found';
             })()`
           );
+          if (result === 'no reload method found') {
+            return 'Could not find a reload method. The app may not support programmatic reload.';
+          }
           return 'App reload triggered.';
         } catch (err) {
           return `Could not reload app: ${err instanceof Error ? err.message : String(err)}`;

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -28,11 +28,14 @@ export const devtoolsPlugin = definePlugin({
 
         if (open) {
           try {
-            // Try macOS first
-            await ctx.exec(`open "${proxyUrl}"`);
+            // Launch Chrome with the DevTools URL using open -a on macOS.
+            // The chrome-devtools:// scheme requires Chrome to handle it directly.
+            await ctx.exec(
+              `/usr/bin/open -a "Google Chrome" "${proxyUrl}"`
+            );
             return { opened: true, url: proxyUrl, port: proxyPort };
           } catch {
-            // Not macOS or Chrome not available — just return the URL
+            // Not macOS or Chrome not installed — fall through to manual instructions
           }
         }
 

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -1,49 +1,56 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('devtools');
 
 export const devtoolsPlugin = definePlugin({
   name: 'devtools',
 
-  description: 'Open Chrome DevTools alongside the MCP connection',
+  description: 'Open React Native DevTools via the CDP proxy',
 
   async setup(ctx) {
     ctx.registerTool('open_devtools', {
       description:
-        'Get the Chrome DevTools URL for the CDP proxy. ' +
-        'Since Hermes only allows a single debugger connection, the MCP acts as a proxy ' +
-        'so Chrome DevTools can connect alongside the MCP. ' +
-        'On macOS, this will also attempt to open Chrome automatically.',
+        'Open the React Native DevTools debugger panel in Chrome. ' +
+        'Uses Metro\'s bundled DevTools frontend but connects through our CDP proxy ' +
+        'so both DevTools and the MCP can share the single Hermes connection.',
       parameters: z.object({
         open: z.boolean().default(true).describe('Attempt to open Chrome automatically (macOS only)'),
       }),
       handler: async ({ open }) => {
         const config = ctx.config as Record<string, unknown>;
-        const proxyConfig = config.proxy as { url?: string; port?: number } | undefined;
-        const proxyUrl = proxyConfig?.url;
+        const proxyConfig = config.proxy as { port?: number } | undefined;
         const proxyPort = proxyConfig?.port;
 
-        if (!proxyUrl || !proxyPort) {
+        if (!proxyPort) {
           return 'CDP proxy is not running. Set proxy.enabled to true in your metro-mcp config.';
         }
 
+        // Build a URL using Metro's own DevTools frontend, but pointing the
+        // WebSocket connection at our proxy instead of Metro's inspector.
+        // This is the same frontend Metro uses when you press "j", served
+        // from the @react-native/debugger-frontend package.
+        const frontendUrl = `http://${ctx.metro.host}:${ctx.metro.port}/debugger-frontend/rn_fusebox.html`
+          + `?ws=127.0.0.1:${proxyPort}`
+          + `&sources.hide_add_folder=true`;
+
         if (open) {
           try {
-            // Launch Chrome with the DevTools URL using open -a on macOS.
-            // The chrome-devtools:// scheme requires Chrome to handle it directly.
+            // Launch Chrome in app mode like Metro does (via DefaultToolLauncher)
             await ctx.exec(
-              `/usr/bin/open -a "Google Chrome" "${proxyUrl}"`
+              `/usr/bin/open -a "Google Chrome" --args --app="${frontendUrl}" --window-size=1200,600`
             );
-            return { opened: true, url: proxyUrl, port: proxyPort };
+            return { opened: true, url: frontendUrl };
           } catch {
-            // Not macOS or Chrome not installed — fall through to manual instructions
+            // Not macOS or Chrome not installed
           }
         }
 
         return {
           opened: false,
-          url: proxyUrl,
-          port: proxyPort,
-          instructions: `Open this URL in Chrome: ${proxyUrl}`,
+          url: frontendUrl,
+          instructions: 'Open this URL in Chrome: ' + frontendUrl,
         };
       },
     });

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'child_process';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { createLogger } from '../utils/logger.js';
@@ -5,24 +6,25 @@ import { createLogger } from '../utils/logger.js';
 const logger = createLogger('devtools');
 
 /**
- * Well-known Chrome/Chromium binary paths by platform.
- * Same locations that chrome-launcher and Metro's DefaultToolLauncher check.
+ * Find a Chrome/Edge binary path using the same strategy as Metro's
+ * DefaultToolLauncher: try chrome-launcher first, fall back to
+ * chromium-edge-launcher.
  */
-const CHROME_PATHS: Record<string, string[]> = {
-  darwin: [
-    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
-    '/Applications/Chromium.app/Contents/MacOS/Chromium',
-    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-  ],
-  linux: [
-    'google-chrome',
-    'google-chrome-stable',
-    'chromium-browser',
-    'chromium',
-    'microsoft-edge',
-  ],
-};
+async function findBrowserPath(): Promise<string | null> {
+  try {
+    const { Launcher } = await import('chrome-launcher');
+    const path = Launcher.getFirstInstallation();
+    if (path) return path;
+  } catch {}
+
+  try {
+    const { Launcher: EdgeLauncher } = await import('chromium-edge-launcher');
+    const path = EdgeLauncher.getFirstInstallation();
+    if (path) return path;
+  } catch {}
+
+  return null;
+}
 
 export const devtoolsPlugin = definePlugin({
   name: 'devtools',
@@ -36,7 +38,7 @@ export const devtoolsPlugin = definePlugin({
         'Uses Metro\'s bundled DevTools frontend but connects through our CDP proxy ' +
         'so both DevTools and the MCP can share the single Hermes connection.',
       parameters: z.object({
-        open: z.boolean().default(true).describe('Attempt to open Chrome automatically'),
+        open: z.boolean().default(true).describe('Attempt to open the browser automatically'),
       }),
       handler: async ({ open }) => {
         const config = ctx.config as Record<string, unknown>;
@@ -56,37 +58,30 @@ export const devtoolsPlugin = definePlugin({
           + `&sources.hide_add_folder=true`;
 
         if (open) {
-          try {
-            // Spawn Chrome directly with --app flag, like Metro's DefaultToolLauncher.
-            // Using `open -a` doesn't work because it ignores --args when Chrome
-            // is already running. We need to spawn the binary directly.
-            const platform = await ctx.exec('uname -s').then(s => s.trim().toLowerCase());
-            const candidates = platform === 'darwin' ? CHROME_PATHS.darwin : CHROME_PATHS.linux;
+          const browserPath = await findBrowserPath();
 
-            if (candidates) {
-              for (const chromePath of candidates!) {
-                try {
-                  // Spawn detached so it doesn't block or die with the MCP process.
-                  // On macOS we need the full path; on Linux, commands in PATH work.
-                  await ctx.exec(
-                    `"${chromePath}" --app="${frontendUrl}" --window-size=1200,600 &`
-                  );
-                  return { opened: true, url: frontendUrl };
-                } catch {
-                  // This candidate not found, try next
-                  continue;
-                }
-              }
+          if (browserPath) {
+            try {
+              // Spawn detached in --app mode, exactly like Metro's DefaultToolLauncher.
+              const child = spawn(
+                browserPath,
+                [`--app=${frontendUrl}`, '--window-size=1200,600'],
+                { detached: true, stdio: 'ignore' },
+              );
+              child.unref();
+              return { opened: true, url: frontendUrl };
+            } catch (err) {
+              logger.debug('Failed to launch browser:', err);
             }
-          } catch (err) {
-            logger.debug('Failed to launch Chrome:', err);
+          } else {
+            logger.debug('No Chrome/Edge installation found');
           }
         }
 
         return {
           opened: false,
           url: frontendUrl,
-          instructions: 'Open this URL in Chrome: ' + frontendUrl,
+          instructions: 'Open this URL in Chrome or Edge: ' + frontendUrl,
         };
       },
     });

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { definePlugin } from '../plugin.js';
+
+export const devtoolsPlugin = definePlugin({
+  name: 'devtools',
+
+  description: 'Open Chrome DevTools alongside the MCP connection',
+
+  async setup(ctx) {
+    ctx.registerTool('open_devtools', {
+      description:
+        'Get the Chrome DevTools URL for the CDP proxy. ' +
+        'Since Hermes only allows a single debugger connection, the MCP acts as a proxy ' +
+        'so Chrome DevTools can connect alongside the MCP. ' +
+        'On macOS, this will also attempt to open Chrome automatically.',
+      parameters: z.object({
+        open: z.boolean().default(true).describe('Attempt to open Chrome automatically (macOS only)'),
+      }),
+      handler: async ({ open }) => {
+        const config = ctx.config as Record<string, unknown>;
+        const proxyConfig = config.proxy as { url?: string; port?: number } | undefined;
+        const proxyUrl = proxyConfig?.url;
+        const proxyPort = proxyConfig?.port;
+
+        if (!proxyUrl || !proxyPort) {
+          return 'CDP proxy is not running. Set proxy.enabled to true in your metro-mcp config.';
+        }
+
+        if (open) {
+          try {
+            // Try macOS first
+            await ctx.exec(`open "${proxyUrl}"`);
+            return { opened: true, url: proxyUrl, port: proxyPort };
+          } catch {
+            // Not macOS or Chrome not available — just return the URL
+          }
+        }
+
+        return {
+          opened: false,
+          url: proxyUrl,
+          port: proxyPort,
+          instructions: `Open this URL in Chrome: ${proxyUrl}`,
+        };
+      },
+    });
+  },
+});

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -4,6 +4,26 @@ import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('devtools');
 
+/**
+ * Well-known Chrome/Chromium binary paths by platform.
+ * Same locations that chrome-launcher and Metro's DefaultToolLauncher check.
+ */
+const CHROME_PATHS: Record<string, string[]> = {
+  darwin: [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+  ],
+  linux: [
+    'google-chrome',
+    'google-chrome-stable',
+    'chromium-browser',
+    'chromium',
+    'microsoft-edge',
+  ],
+};
+
 export const devtoolsPlugin = definePlugin({
   name: 'devtools',
 
@@ -16,7 +36,7 @@ export const devtoolsPlugin = definePlugin({
         'Uses Metro\'s bundled DevTools frontend but connects through our CDP proxy ' +
         'so both DevTools and the MCP can share the single Hermes connection.',
       parameters: z.object({
-        open: z.boolean().default(true).describe('Attempt to open Chrome automatically (macOS only)'),
+        open: z.boolean().default(true).describe('Attempt to open Chrome automatically'),
       }),
       handler: async ({ open }) => {
         const config = ctx.config as Record<string, unknown>;
@@ -37,13 +57,29 @@ export const devtoolsPlugin = definePlugin({
 
         if (open) {
           try {
-            // Launch Chrome in app mode like Metro does (via DefaultToolLauncher)
-            await ctx.exec(
-              `/usr/bin/open -a "Google Chrome" --args --app="${frontendUrl}" --window-size=1200,600`
-            );
-            return { opened: true, url: frontendUrl };
-          } catch {
-            // Not macOS or Chrome not installed
+            // Spawn Chrome directly with --app flag, like Metro's DefaultToolLauncher.
+            // Using `open -a` doesn't work because it ignores --args when Chrome
+            // is already running. We need to spawn the binary directly.
+            const platform = await ctx.exec('uname -s').then(s => s.trim().toLowerCase());
+            const candidates = platform === 'darwin' ? CHROME_PATHS.darwin : CHROME_PATHS.linux;
+
+            if (candidates) {
+              for (const chromePath of candidates!) {
+                try {
+                  // Spawn detached so it doesn't block or die with the MCP process.
+                  // On macOS we need the full path; on Linux, commands in PATH work.
+                  await ctx.exec(
+                    `"${chromePath}" --app="${frontendUrl}" --window-size=1200,600 &`
+                  );
+                  return { opened: true, url: frontendUrl };
+                } catch {
+                  // This candidate not found, try next
+                  continue;
+                }
+              }
+            }
+          } catch (err) {
+            logger.debug('Failed to launch Chrome:', err);
           }
         }
 

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -127,9 +127,7 @@ export const errorsPlugin = definePlugin({
     });
 
     function getErrors(device?: string): ErrorEntry[] {
-      if (device === 'all') return buffers.getAll();
-      const key = device || ctx.getActiveDeviceKey() || '';
-      return buffers.getAllForDevice(key);
+      return buffers.resolve(device, ctx.getActiveDeviceKey());
     }
 
     ctx.registerTool('get_errors', {

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -84,7 +84,7 @@ export const inspectPointPlugin = definePlugin({
 
             // Recurse into children
             if (fiber.child) walkFiber(fiber.child, depth + 1);
-            if (fiber.sibling) walkFiber(fiber.sibling, depth + 1);
+            if (fiber.sibling) walkFiber(fiber.sibling, depth);
           }
 
           walkFiber(root.current, 0);

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
+import { FIBER_ROOT_JS } from '../utils/fiber.js';
 
 export const inspectPointPlugin = definePlugin({
   name: 'inspect-point',
@@ -19,21 +20,8 @@ export const inspectPointPlugin = definePlugin({
       }),
       handler: async ({ x, y, includeProps }) => {
         const expression = `(function() {
-          var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-          if (!hook || !hook.renderers || hook.renderers.size === 0) {
-            return { error: 'React DevTools hook not available. Is the app running in __DEV__ mode?' };
-          }
-
-          // Get the first renderer
-          var renderer = hook.renderers.values().next().value;
-          if (!renderer) return { error: 'No React renderer found.' };
-
-          var fiberRoots = hook.getFiberRoots ? hook.getFiberRoots(1) : null;
-          if (!fiberRoots || fiberRoots.size === 0) {
-            return { error: 'No fiber roots found.' };
-          }
-          var root = fiberRoots.values().next().value;
-          if (!root || !root.current) return { error: 'No root fiber found.' };
+          ${FIBER_ROOT_JS}
+          if (!rootFiber) return { error: 'React fiber tree not available. Is the app running in __DEV__ mode?' };
 
           var targetX = ${x};
           var targetY = ${y};
@@ -87,7 +75,7 @@ export const inspectPointPlugin = definePlugin({
             if (fiber.sibling) walkFiber(fiber.sibling, depth);
           }
 
-          walkFiber(root.current, 0);
+          walkFiber(rootFiber, 0);
 
           if (!bestMatch) {
             return {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -135,9 +135,7 @@ export const networkPlugin = definePlugin({
     // ── Request tracking tools ─────────────────────────────────────────────────
 
     function getRequests(device?: string): NetworkRequest[] {
-      if (device === 'all') return buffers.getAll();
-      const key = device || ctx.getActiveDeviceKey() || '';
-      return buffers.getAllForDevice(key);
+      return buffers.resolve(device, ctx.getActiveDeviceKey());
     }
 
     ctx.registerTool('get_network_requests', {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -19,6 +19,7 @@ interface NetworkRequest {
   id: string;
   url: string;
   method: string;
+  type?: string;
   status?: number;
   statusText?: string;
   requestHeaders?: Record<string, string>;
@@ -76,13 +77,40 @@ export const networkPlugin = definePlugin({
 
     // ── CDP Network domain ─────────────────────────────────────────────────────
 
+    // Track recent requests by URL+method to deduplicate Hermes's paired
+    // CDP events (e.g. type "xhr" + type "json" for the same fetch).
+    const recentRequestKeys = new Map<string, number>();
+
     ctx.cdp.on('Network.requestWillBeSent', (params) => {
+      const url = (params.request as Record<string, unknown>)?.url as string;
+      const method = (params.request as Record<string, unknown>)?.method as string || 'GET';
+      const type = params.type as string | undefined;
+
+      // Hermes fires two requestWillBeSent for each fetch: one typed "XHR"
+      // and another typed "json"/"text"/etc. Keep only the first one.
+      const dedupeKey = `${method} ${url}`;
+      const now = Date.now();
+      const lastSeen = recentRequestKeys.get(dedupeKey);
+      if (lastSeen !== undefined && now - lastSeen < 2000) {
+        // Duplicate within 2s window — skip this one
+        return;
+      }
+      recentRequestKeys.set(dedupeKey, now);
+
+      // Prune old dedup keys periodically
+      if (recentRequestKeys.size > 500) {
+        for (const [key, ts] of recentRequestKeys) {
+          if (now - ts > 5000) recentRequestKeys.delete(key);
+        }
+      }
+
       const request: NetworkRequest = {
         id: params.requestId as string,
-        url: (params.request as Record<string, unknown>)?.url as string,
-        method: (params.request as Record<string, unknown>)?.method as string || 'GET',
+        url,
+        method,
+        type,
         requestHeaders: (params.request as Record<string, unknown>)?.headers as Record<string, string>,
-        startTime: Date.now(),
+        startTime: now,
         get timestamp() { return this.startTime; },
         session: currentSession,
       };

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -25,6 +25,8 @@ interface NetworkRequest {
   responseHeaders?: Record<string, string>;
   requestBody?: string;
   responseBody?: string;
+  /** Alias for startTime — required by DeviceBufferManager constraint. */
+  timestamp: number;
   startTime: number;
   endTime?: number;
   error?: string;
@@ -81,6 +83,7 @@ export const networkPlugin = definePlugin({
         method: (params.request as Record<string, unknown>)?.method as string || 'GET',
         requestHeaders: (params.request as Record<string, unknown>)?.headers as Record<string, string>,
         startTime: Date.now(),
+        get timestamp() { return this.startTime; },
         session: currentSession,
       };
       pendingRequests.set(request.id, request);

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -356,17 +356,24 @@ export const networkPlugin = definePlugin({
 
     let fetchWrapperInjected = false;
     let cdpNetworkActive = false;
+    let fetchWrapperTimer: ReturnType<typeof setTimeout> | null = null;
 
     ctx.cdp.on('Network.requestWillBeSent', () => {
       cdpNetworkActive = true;
     });
 
+    ctx.cdp.on('disconnected', () => {
+      if (fetchWrapperTimer) { clearTimeout(fetchWrapperTimer); fetchWrapperTimer = null; }
+    });
+
     ctx.cdp.on('reconnected', () => {
+      if (fetchWrapperTimer) { clearTimeout(fetchWrapperTimer); fetchWrapperTimer = null; }
       fetchWrapperInjected = false;
       cdpNetworkActive = false;
       // After a short delay, check if CDP Network is producing events.
       // If not, inject the fetch wrapper.
-      setTimeout(async () => {
+      fetchWrapperTimer = setTimeout(async () => {
+        fetchWrapperTimer = null;
         if (fetchWrapperInjected || cdpNetworkActive) return;
         try {
           await ctx.evalInApp(`(function() {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -355,13 +355,19 @@ export const networkPlugin = definePlugin({
     // inject a fetch wrapper into the app to capture requests as a fallback.
 
     let fetchWrapperInjected = false;
+    let cdpNetworkActive = false;
+
+    ctx.cdp.on('Network.requestWillBeSent', () => {
+      cdpNetworkActive = true;
+    });
 
     ctx.cdp.on('reconnected', () => {
       fetchWrapperInjected = false;
+      cdpNetworkActive = false;
       // After a short delay, check if CDP Network is producing events.
       // If not, inject the fetch wrapper.
       setTimeout(async () => {
-        if (fetchWrapperInjected) return;
+        if (fetchWrapperInjected || cdpNetworkActive) return;
         try {
           await ctx.evalInApp(`(function() {
             if (globalThis.__METRO_MCP_FETCH_WRAPPED__) return 'already';

--- a/src/server.ts
+++ b/src/server.ts
@@ -94,7 +94,6 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   // Active device tracking — used by plugins to key per-device buffers.
   let activeDeviceKey: string | null = null;
   let activeDeviceName: string | null = null;
-  const deviceNameMap = new Map<string, string>();
 
   // Server-side reconnect state — single source of truth for all reconnect logic.
   // Start with a very short delay (500ms) to recover quickly from brief disconnects
@@ -331,7 +330,6 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       // Track active device for per-device buffers
       activeDeviceKey = `${server.port}-${target.id}`;
       activeDeviceName = target.title || target.deviceName || target.id;
-      deviceNameMap.set(activeDeviceKey, activeDeviceName);
 
       return true;
     } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -391,6 +391,10 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   await mcpServer.connect(transport);
   logger.info('MCP server started');
 
+  // Clean up on shutdown
+  process.on('SIGINT', () => { cdpProxy?.stop(); process.exit(0); });
+  process.on('SIGTERM', () => { cdpProxy?.stop(); process.exit(0); });
+
   // Try connecting to Metro (non-blocking — server works without connection)
   void connectToMetro();
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,8 @@ import { automationPlugin } from './plugins/automation.js';
 import { statuslinePlugin } from './plugins/statusline.js';
 import { debugGlobalsPlugin } from './plugins/debug-globals.js';
 import { inspectPointPlugin } from './plugins/inspect-point.js';
+import { devtoolsPlugin } from './plugins/devtools.js';
+import { CDPProxy } from './metro/proxy.js';
 
 const logger = createLogger('server');
 
@@ -71,6 +73,7 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   statuslinePlugin,
   debugGlobalsPlugin,
   inspectPointPlugin,
+  devtoolsPlugin,
 ];
 
 export async function startServer(config: Required<MetroMCPConfig>): Promise<void> {
@@ -361,6 +364,28 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
         scheduleReconnect();
       }
     }, delay);
+  }
+
+  // Start CDP proxy for Chrome DevTools coexistence
+  let cdpProxy: CDPProxy | null = null;
+  if (config.proxy?.enabled !== false) {
+    cdpProxy = new CDPProxy(cdpClient);
+    try {
+      const proxyPort = await cdpProxy.start(config.proxy?.port ?? 0);
+      const devtoolsUrl = cdpProxy.getDevToolsUrl();
+      logger.info(`CDP proxy started on port ${proxyPort}`);
+      if (devtoolsUrl) {
+        logger.info(`Chrome DevTools URL: ${devtoolsUrl}`);
+      }
+      // Make proxy info available to plugins via config
+      (config as Record<string, unknown>).proxy = {
+        ...config.proxy,
+        port: proxyPort,
+        url: devtoolsUrl,
+      };
+    } catch (err) {
+      logger.warn('Could not start CDP proxy:', err);
+    }
   }
 
   // Start MCP transport

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -70,9 +70,12 @@ export class DeviceBufferManager<T extends { timestamp: number }> {
     let buffer = this.buffers.get(deviceKey);
     if (!buffer) {
       // Evict oldest device if at capacity
-      if (this.buffers.size >= this.maxDevices) {
-        const oldest = this.insertionOrder.shift();
-        if (oldest) this.buffers.delete(oldest);
+      while (this.buffers.size >= this.maxDevices && this.insertionOrder.length > 0) {
+        const oldest = this.insertionOrder.shift()!;
+        if (this.buffers.has(oldest)) {
+          this.buffers.delete(oldest);
+          break;
+        }
       }
       buffer = new CircularBuffer<T>(this.capacityPerDevice);
       this.buffers.set(deviceKey, buffer);
@@ -89,6 +92,15 @@ export class DeviceBufferManager<T extends { timestamp: number }> {
   /** Get all entries from a specific device. */
   getAllForDevice(deviceKey: string): T[] {
     return this.buffers.get(deviceKey)?.getAll() ?? [];
+  }
+
+  /**
+   * Resolve a device query: "all" aggregates, a specific key queries that device,
+   * or falls back to the active key. Returns entries from the resolved device.
+   */
+  resolve(device: string | undefined, activeKey: string | null): T[] {
+    if (device === 'all') return this.getAll();
+    return this.getAllForDevice(device || activeKey || '');
   }
 
   /** Aggregate entries across all devices, sorted by timestamp. */


### PR DESCRIPTION
## Summary

Hermes only allows a single CDP debugger connection. Once metro-mcp connects, Chrome DevTools cannot. This PR adds a CDP proxy/multiplexer so both can work simultaneously:

- **`CDPProxy` class** (`src/metro/proxy.ts`) — acts as a message bus between the single Hermes connection and multiple downstream consumers. Handles request ID remapping, event broadcasting, and domain enable/disable reference counting so clients don't interfere with each other
- **`/json` + `/json/version` HTTP endpoints** — Chrome auto-discovers the proxy target, so you can just point Chrome at `localhost:<proxy-port>` and it connects automatically
- **`messageInterceptor` hook + `sendRaw()`** on `CDPClient` — allows the proxy to intercept upstream responses destined for external clients and forward raw messages
- **`open_devtools` tool** — returns the `devtools://` URL for the proxy and optionally opens Chrome on macOS
- **Enabled by default** (port 0 = OS-assigned), configurable via `proxy.enabled`/`proxy.port` in config or `METRO_MCP_PROXY_PORT` / `METRO_MCP_PROXY_ENABLED` env vars

Depends on #12 (feature gap tools).

## Test plan

- [ ] Start MCP, verify CDP proxy starts and logs the port + DevTools URL
- [ ] Open the DevTools URL in Chrome — verify it connects and shows console/network/sources
- [ ] Generate console logs in the app — verify both MCP tools and Chrome DevTools receive them
- [ ] Set a breakpoint in Chrome DevTools — verify it pauses execution
- [ ] Disconnect Chrome DevTools — verify MCP continues working normally
- [ ] Set `proxy.enabled: false` in config — verify proxy does not start
- [ ] Set `METRO_MCP_PROXY_PORT=9223` — verify proxy binds to that port

https://claude.ai/code/session_01WNwPM6jHNocnoEQJRRu3pg