### PR TITLE
Document new tools and Chrome DevTools usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Works with **Expo**, **bare React Native**, and any project using **Metro + Herm
 - [Requirements](#requirements)
 - [How It Works](#how-it-works)
 - [Features](#features)
+- [Chrome DevTools](#chrome-devtools)
 - [Claude Code Status Bar](#claude-code-status-bar)
 - [Test Recording](#test-recording)
 - [App Integration](#app-integration-optional)
@@ -95,10 +96,10 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 | Plugin | Tools | Description |
 |--------|-------|-------------|
 | **console** | 2 | Console log collection with filtering |
-| **network** | 4 | Network request tracking and response body inspection |
+| **network** | 6 | Network request tracking, response body inspection, and stats |
 | **errors** | 3 | Runtime exception collection + Metro bundle error detection |
 | **evaluate** | 1 | Execute JavaScript in the app runtime |
-| **device** | 3 | Device and connection management |
+| **device** | 4 | Device management, connection status, and app reload |
 | **source** | 1 | Stack trace symbolication |
 | **redux** | 3 | Redux state inspection and action dispatch |
 | **components** | 5 | React component tree inspection |
@@ -112,9 +113,46 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 | **automation** | 3 | Wait/polling helpers for async state changes |
 | **profiler** | 9 | CPU profiling (React DevTools hook) + heap sampling + render tracking |
 | **test-recorder** | 7 | Record interactions and generate Appium, Maestro, or Detox tests |
+| **devtools** | 1 | Open Chrome DevTools alongside the MCP via CDP proxy |
+| **debug-globals** | 1 | Auto-discover Redux stores, Apollo Client, and other debug globals |
+| **inspect-point** | 1 | Coordinate-based React component inspection (experimental) |
 | **statusline** | 1 | Claude Code status bar integration |
 
 → See the [full tools reference](docs/tools.md).
+
+---
+
+## Chrome DevTools
+
+Hermes (the React Native JavaScript engine) only allows a **single CDP debugger connection** at a time. Since metro-mcp uses that connection, pressing **"j" in Metro** or tapping **"Open Debugger"** in the dev menu will steal the connection and disconnect the MCP.
+
+metro-mcp solves this with a built-in **CDP proxy** that multiplexes the single Hermes connection, allowing Chrome DevTools and the MCP to work simultaneously.
+
+### Opening DevTools
+
+Use the `open_devtools` MCP tool instead of the usual methods. It opens the same React Native DevTools frontend (rn_fusebox) that Metro uses, but routes the WebSocket connection through the proxy so both can coexist.
+
+The tool automatically finds Chrome or Edge using the same detection as Metro and opens a standalone DevTools window.
+
+### What to avoid
+
+| Method | What happens |
+|--------|-------------|
+| Pressing **"j"** in Metro terminal | Disconnects the MCP |
+| **"Open Debugger"** in the dev menu | Disconnects the MCP |
+| `open_devtools` MCP tool | Works alongside the MCP |
+
+### Configuration
+
+The CDP proxy is enabled by default. To change the port or disable it:
+
+```bash
+# Set a fixed proxy port
+METRO_MCP_PROXY_PORT=9222 npx metro-mcp
+
+# Disable the proxy entirely
+METRO_MCP_PROXY_ENABLED=false npx metro-mcp
+```
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@
 |----------|---------|-------------|
 | `METRO_HOST` | `localhost` | Metro bundler host |
 | `METRO_PORT` | `8081` | Metro bundler port |
+| `METRO_MCP_PROXY_ENABLED` | `true` | Enable the CDP proxy for Chrome DevTools coexistence |
+| `METRO_MCP_PROXY_PORT` | `0` (random) | Fixed port for the CDP proxy. Use `0` for a random available port |
 | `DEBUG` | — | Enable debug logging |
 
 ## CLI Arguments
@@ -43,11 +45,26 @@ export default defineConfig({
   network: {
     interceptFetch: false,  // Opt-in: inject JS to wrap fetch()
   },
+  proxy: {
+    enabled: true,   // CDP proxy for Chrome DevTools coexistence
+    port: 0,         // 0 = random available port
+  },
   profiler: {
     newArchitecture: true,  // Set to false for legacy bridge apps
   },
 });
 ```
+
+## CDP Proxy Options
+
+The CDP proxy allows Chrome DevTools to connect alongside the MCP, working around Hermes's single-connection limitation. See the [Chrome DevTools](../README.md#chrome-devtools) section in the README for details.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `proxy.enabled` | `true` | Enable the CDP proxy server. When enabled, external debuggers (Chrome DevTools, etc.) can connect to the proxy port and share the Hermes connection with the MCP. |
+| `proxy.port` | `0` | Port for the proxy's WebSocket + HTTP server. `0` picks a random available port. Set a fixed port if you need a stable URL. |
+
+The proxy also serves a `/json` endpoint for Chrome's target auto-discovery and a `/json/version` endpoint.
 
 ## Profiler Options
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -9,10 +9,11 @@
 
 ### Request Tracking
 
-- **`get_network_requests`** — Get buffered HTTP requests with method, URL, status, timing.
+- **`get_network_requests`** — Get buffered HTTP requests with method, URL, status, timing. Supports `device` param for per-device filtering.
 - **`get_request_details`** — Get full headers for a specific request by URL.
 - **`get_response_body`** — Get the response body for a specific request. Bodies under 1 MB are eagerly cached and survive reconnections; larger bodies are fetched on demand from the current CDP session.
 - **`search_network`** — Filter by URL pattern, method, status code, or errors only.
+- **`get_network_stats`** — Aggregated network statistics: breakdown by domain, status code distribution, response time percentiles (p50/p95/p99), and slowest endpoints.
 - **`clear_network_requests`** — Clear the network request buffer.
 
 ## Errors
@@ -29,6 +30,7 @@
 - **`list_devices`** — List connected debuggable targets from Metro.
 - **`get_app_info`** — Bundle URL, platform, device name, VM type.
 - **`get_connection_status`** — CDP connection state and Metro status.
+- **`reload_app`** — Reload the app. Tries Metro's HTTP reload endpoint first, then falls back to `DevSettings.reload()` via CDP.
 
 ## Source
 
@@ -136,6 +138,22 @@ Records real user interactions via React fiber patching — no app code changes 
 - **`stop_test_recording`** — Stop recording and retrieve the captured event log. Deduplicates rapid-fire text input events (keeps the final value per field).
 - **`generate_test_from_recording`** — Convert the recording to a test file. Params: `format` (appium/maestro/detox), `testName`, `platform` (ios/android/both), `bundleId`, `includeSetup`.
 - **`generate_wdio_config`** — Generate a minimal `wdio.conf.ts` for Appium + React Native, including the install command for all required packages.
+
+## Chrome DevTools
+
+- **`open_devtools`** — Open the React Native DevTools debugger panel in Chrome (or Edge). Uses Metro's bundled rn_fusebox frontend but routes the WebSocket through the MCP's CDP proxy so both DevTools and the MCP can coexist. Finds Chrome/Edge automatically via `chrome-launcher`. See [Chrome DevTools](#) in the README for why you should use this instead of pressing "j" or tapping "Open Debugger".
+
+## Debug Globals
+
+> No app changes needed.
+
+- **`list_debug_globals`** — Auto-discover well-known global debugging objects in the app runtime: Redux stores, Apollo Client, Expo Router state, React DevTools hook, and more. Use `detailed=true` to include top-level keys for each discovered global.
+
+## Inspect Point (Experimental)
+
+> No app changes needed.
+
+- **`inspect_at_point`** — Inspect the React component rendered at specific screen coordinates. Walks the React fiber tree to find the host component whose layout contains the given (x, y) point, then walks up to find the nearest named React component. Returns component name, host element type, layout bounds, and optionally props. Layout measurement varies between Old and New Architecture.
 
 ## Token-Efficient Output
 


### PR DESCRIPTION
## Summary
- Add Chrome DevTools section explaining the CDP proxy, why pressing "j" or "Open Debugger" disconnects the MCP, and how to use `open_devtools` instead
- Update features table with new plugins: `devtools`, `debug-globals`, `inspect-point`
- Update tool counts for `network` (4 → 6) and `device` (3 → 4)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm feature table tool counts match actual plugin registrations
- [ ] Check all internal links in the table of contents resolve

https://claude.ai/code/session_01WNwPM6jHNocnoEQJRRu3pg