### PR TITLE
Add optional Metro middleware for CDP proxy integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.tsbuildinfo
 .env
 .claude
+.metro-mcp-proxy-port

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Works with **Expo**, **bare React Native**, and any project using **Metro + Herm
 - [Requirements](#requirements)
 - [How It Works](#how-it-works)
 - [Features](#features)
+- [Chrome DevTools](#chrome-devtools)
 - [Claude Code Status Bar](#claude-code-status-bar)
 - [Test Recording](#test-recording)
 - [App Integration](#app-integration-optional)
@@ -115,6 +116,33 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 | **statusline** | 1 | Claude Code status bar integration |
 
 → See the [full tools reference](docs/tools.md).
+
+---
+
+## Chrome DevTools
+
+Hermes (the React Native JavaScript engine) only allows a **single CDP debugger connection** at a time. Since metro-mcp uses that connection, pressing **"j" in Metro** or tapping **"Open Debugger"** in the dev menu will steal the connection and disconnect the MCP.
+
+metro-mcp solves this with a built-in **CDP proxy** that multiplexes the single Hermes connection, allowing Chrome DevTools and the MCP to work simultaneously.
+
+### Opening DevTools
+
+Use the `open_devtools` MCP tool instead of the usual methods. It opens the same React Native DevTools frontend (rn_fusebox) that Metro uses, but routes the WebSocket connection through the proxy so both can coexist.
+
+### Making "j" and "Open Debugger" work
+
+Add the optional Metro middleware to make **all** debugger entry points work alongside the MCP:
+
+```js
+// metro.config.js
+const { withMetroMcp } = require('metro-mcp/metro');
+
+module.exports = withMetroMcp(getDefaultConfig(__dirname));
+```
+
+This rewrites CDP target discovery so that pressing "j", tapping "Open Debugger", or any other tool using standard CDP discovery will connect through the proxy. See the [configuration docs](docs/configuration.md#metro-middleware-optional) for details.
+
+Without the middleware, use `open_devtools` from your MCP client instead.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,45 @@ export default defineConfig({
 });
 ```
 
+## Metro Middleware (Optional)
+
+Add the `withMetroMcp` wrapper to your Metro config to make pressing **"j"** and **"Open Debugger"** work alongside the MCP. Without it, those actions steal the CDP connection and disconnect the MCP. With it, they route through the MCP's proxy automatically.
+
+```js
+// metro.config.js
+const { getDefaultConfig } = require('expo/metro-config');
+const { withMetroMcp } = require('metro-mcp/metro');
+
+module.exports = withMetroMcp(getDefaultConfig(__dirname));
+```
+
+Or for bare React Native:
+
+```js
+// metro.config.js
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const { withMetroMcp } = require('metro-mcp/metro');
+
+module.exports = withMetroMcp(mergeConfig(getDefaultConfig(__dirname), {}));
+```
+
+### How it works
+
+The middleware intercepts Metro's `/json` and `/json/list` responses — the standard CDP target discovery endpoints — and rewrites `webSocketDebuggerUrl` to point at the MCP's CDP proxy. Any tool that uses standard CDP discovery (Metro's "j" handler, the dev menu, Flipper, custom scripts) will connect through the proxy instead of directly to Hermes.
+
+The middleware discovers the proxy port via the `METRO_MCP_PROXY_PORT` environment variable or a `.metro-mcp-proxy-port` file that the MCP server writes on startup. If the MCP server isn't running, the middleware is a no-op — all requests pass through unchanged.
+
+### What if I don't add the middleware?
+
+Everything still works. The only difference is:
+
+| Action | Without middleware | With middleware |
+|--------|-------------------|----------------|
+| MCP tools | Work normally | Work normally |
+| `open_devtools` MCP tool | Opens DevTools via proxy | Opens DevTools via proxy |
+| Press "j" in Metro | Disconnects MCP | Works alongside MCP |
+| "Open Debugger" in dev menu | Disconnects MCP | Works alongside MCP |
+
 ## Profiler Options
 
 | Option | Default | Description |

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
       "types": "./dist/plugin.d.ts",
       "require": "./dist/plugin.cjs",
       "import": "./dist/plugin.js"
+    },
+    "./metro": {
+      "types": "./dist/metro-config/index.d.ts",
+      "require": "./dist/metro-config/index.cjs",
+      "import": "./dist/metro-config/index.js"
     }
   },
   "files": [
@@ -40,7 +45,7 @@
     "dev": "bun run --watch src/index.ts",
     "clean": "rm -rf dist",
     "build": "bun run clean && bun run build:js && bun run build:bin && bun run build:types",
-    "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external zod --external ws && bun build src/client/index.ts --outfile dist/client/index.js --target browser --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.cjs --target browser --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod",
+    "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external zod --external ws && bun build src/client/index.ts --outfile dist/client/index.js --target browser --external @modelcontextprotocol/sdk --external zod && bun build src/client/index.ts --outfile dist/client/index.cjs --target browser --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external zod && bun build src/metro-config/index.ts --outfile dist/metro-config/index.js --target node && bun build src/metro-config/index.ts --outfile dist/metro-config/index.cjs --target node --format cjs",
     "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target node --external @modelcontextprotocol/sdk --external zod --external ws && chmod +x dist/bin/metro-mcp.js",
     "build:types": "bunx tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit"

--- a/src/metro-config/index.ts
+++ b/src/metro-config/index.ts
@@ -1,0 +1,185 @@
+/**
+ * Optional Metro middleware for metro-mcp.
+ *
+ * Rewrites CDP target discovery responses (`/json`, `/json/list`) so that
+ * `webSocketDebuggerUrl` and `devtoolsFrontendUrl` point at the MCP's CDP
+ * proxy instead of directly at Hermes. This means pressing "j" in Metro,
+ * tapping "Open Debugger" in the dev menu, or any tool that uses standard
+ * CDP discovery will automatically connect through the proxy — allowing
+ * Chrome DevTools and the MCP to coexist.
+ *
+ * Usage in metro.config.js:
+ *
+ *   const { withMetroMcp } = require('metro-mcp/metro');
+ *   module.exports = withMetroMcp(getDefaultConfig(__dirname));
+ *
+ * This is entirely optional. The MCP works without it — the only difference
+ * is that "j" and "Open Debugger" will steal the CDP connection if the
+ * middleware is not installed.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'http';
+
+/** The file metro-mcp writes its proxy port to so the middleware can discover it. */
+const PROXY_PORT_ENV = 'METRO_MCP_PROXY_PORT';
+const PROXY_PORT_FILE = '.metro-mcp-proxy-port';
+
+interface MetroConfig {
+  server?: {
+    enhanceMiddleware?: (
+      middleware: MiddlewareFn,
+      metroServer?: unknown,
+    ) => MiddlewareFn;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+type MiddlewareFn = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: (err?: unknown) => void,
+) => void;
+
+/**
+ * Discover the proxy port. Checks (in order):
+ * 1. METRO_MCP_PROXY_PORT env var (set by the MCP server on startup)
+ * 2. .metro-mcp-proxy-port file in cwd (written by the MCP server)
+ */
+function discoverProxyPort(): number | null {
+  // Env var — set by the MCP server or the user
+  const envPort = process.env[PROXY_PORT_ENV];
+  if (envPort) {
+    const port = parseInt(envPort, 10);
+    if (!isNaN(port) && port > 0) return port;
+  }
+
+  // Port file — written by the MCP server on startup
+  try {
+    // Use require('fs') to avoid top-level await issues in CJS metro configs
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const content = fs.readFileSync(PROXY_PORT_FILE, 'utf8').trim();
+    const port = parseInt(content, 10);
+    if (!isNaN(port) && port > 0) return port;
+  } catch {
+    // File doesn't exist yet — MCP server may not be running
+  }
+
+  return null;
+}
+
+/**
+ * Rewrite a `/json` or `/json/list` response body to point WebSocket URLs
+ * at the MCP proxy.
+ */
+function rewriteTargetList(body: string, proxyPort: number): string {
+  try {
+    const targets = JSON.parse(body);
+    if (!Array.isArray(targets)) return body;
+
+    for (const target of targets) {
+      if (target.webSocketDebuggerUrl) {
+        // Replace the host:port in the WS URL with the proxy
+        // e.g. ws://localhost:8081/inspector/debug?device=1&page=-1
+        //   -> ws://127.0.0.1:<proxyPort>
+        target.webSocketDebuggerUrl = `ws://127.0.0.1:${proxyPort}`;
+      }
+      if (target.devtoolsFrontendUrl) {
+        // Rewrite the devtools frontend URL's ws= param to point at the proxy.
+        // The frontend URL is like:
+        //   http://localhost:8081/debugger-frontend/rn_fusebox.html?ws=...
+        // We replace the ws= value with our proxy address.
+        target.devtoolsFrontendUrl = target.devtoolsFrontendUrl.replace(
+          /([?&]wss?=)[^&]+/,
+          `$1127.0.0.1:${proxyPort}`,
+        );
+      }
+    }
+
+    return JSON.stringify(targets);
+  } catch {
+    return body;
+  }
+}
+
+/**
+ * Create the middleware that intercepts `/json` responses.
+ */
+function createMcpMiddleware(existingMiddleware: MiddlewareFn): MiddlewareFn {
+  return (req, res, next) => {
+    const url = req.url || '';
+
+    // Only intercept GET /json and /json/list
+    if (req.method === 'GET' && (url === '/json' || url === '/json/list' || url === '/json/')) {
+      const proxyPort = discoverProxyPort();
+
+      if (proxyPort) {
+        // Intercept the response by wrapping write/end
+        const originalWrite = res.write.bind(res);
+        const originalEnd = res.end.bind(res);
+        const chunks: Buffer[] = [];
+
+        res.write = function (chunk: unknown, ...args: unknown[]): boolean {
+          if (chunk) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+          }
+          return true;
+        } as typeof res.write;
+
+        res.end = function (chunk?: unknown, ...args: unknown[]): ServerResponse {
+          if (chunk) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+          }
+
+          const body = Buffer.concat(chunks).toString('utf8');
+          const rewritten = rewriteTargetList(body, proxyPort);
+
+          // Update content-length and write the rewritten response
+          res.setHeader('Content-Length', Buffer.byteLength(rewritten));
+          originalWrite(rewritten);
+          return originalEnd();
+        } as typeof res.end;
+      }
+    }
+
+    // Pass through to Metro's middleware (which handles the actual /json response)
+    return existingMiddleware(req, res, next);
+  };
+}
+
+/**
+ * Wrap a Metro config to install the metro-mcp middleware.
+ *
+ * This rewrites CDP target discovery (`/json/list`) so that external tools
+ * — including pressing "j" in Metro and the "Open Debugger" dev menu item —
+ * connect through the MCP's CDP proxy instead of directly to Hermes.
+ *
+ * @example
+ * ```js
+ * // metro.config.js
+ * const { getDefaultConfig } = require('expo/metro-config');
+ * const { withMetroMcp } = require('metro-mcp/metro');
+ *
+ * module.exports = withMetroMcp(getDefaultConfig(__dirname));
+ * ```
+ */
+export function withMetroMcp(config: MetroConfig): MetroConfig {
+  const existingEnhance = config.server?.enhanceMiddleware;
+
+  return {
+    ...config,
+    server: {
+      ...config.server,
+      enhanceMiddleware: (middleware: MiddlewareFn, metroServer?: unknown) => {
+        // Apply any existing enhanceMiddleware first
+        const enhanced = existingEnhance
+          ? existingEnhance(middleware, metroServer)
+          : middleware;
+
+        // Then wrap with our interceptor
+        return createMcpMiddleware(enhanced);
+      },
+    },
+  };
+}

--- a/src/metro-config/index.ts
+++ b/src/metro-config/index.ts
@@ -19,8 +19,8 @@
  */
 
 import type { IncomingMessage, ServerResponse } from 'http';
+import { readFileSync } from 'fs';
 
-/** The file metro-mcp writes its proxy port to so the middleware can discover it. */
 const PROXY_PORT_ENV = 'METRO_MCP_PROXY_PORT';
 const PROXY_PORT_FILE = '.metro-mcp-proxy-port';
 
@@ -42,30 +42,37 @@ type MiddlewareFn = (
 ) => void;
 
 /**
- * Discover the proxy port. Checks (in order):
- * 1. METRO_MCP_PROXY_PORT env var (set by the MCP server on startup)
- * 2. .metro-mcp-proxy-port file in cwd (written by the MCP server)
+ * Discover and cache the proxy port. The port is invariant for the lifetime
+ * of the Metro process, so we read it once and cache the result.
  */
+let cachedProxyPort: number | null | undefined;
+
 function discoverProxyPort(): number | null {
-  // Env var — set by the MCP server or the user
+  if (cachedProxyPort !== undefined) return cachedProxyPort;
+
   const envPort = process.env[PROXY_PORT_ENV];
   if (envPort) {
     const port = parseInt(envPort, 10);
-    if (!isNaN(port) && port > 0) return port;
+    if (!isNaN(port) && port > 0) {
+      cachedProxyPort = port;
+      return port;
+    }
   }
 
-  // Port file — written by the MCP server on startup
   try {
-    // Use require('fs') to avoid top-level await issues in CJS metro configs
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const fs = require('fs');
-    const content = fs.readFileSync(PROXY_PORT_FILE, 'utf8').trim();
+    const content = readFileSync(PROXY_PORT_FILE, 'utf8').trim();
     const port = parseInt(content, 10);
-    if (!isNaN(port) && port > 0) return port;
+    if (!isNaN(port) && port > 0) {
+      cachedProxyPort = port;
+      return port;
+    }
   } catch {
-    // File doesn't exist yet — MCP server may not be running
+    // File doesn't exist yet — MCP server may not be running.
+    // Return null but don't cache so we retry on next request.
+    return null;
   }
 
+  cachedProxyPort = null;
   return null;
 }
 
@@ -120,14 +127,16 @@ function createMcpMiddleware(existingMiddleware: MiddlewareFn): MiddlewareFn {
         const originalEnd = res.end.bind(res);
         const chunks: Buffer[] = [];
 
-        res.write = function (chunk: unknown, ...args: unknown[]): boolean {
+        // Buffer the response so we can rewrite it before sending.
+        // Safe because /json responses are tiny (<10KB).
+        res.write = function (chunk: unknown): boolean {
           if (chunk) {
             chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
           }
           return true;
         } as typeof res.write;
 
-        res.end = function (chunk?: unknown, ...args: unknown[]): ServerResponse {
+        res.end = function (chunk?: unknown): ServerResponse {
           if (chunk) {
             chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
           }
@@ -135,7 +144,6 @@ function createMcpMiddleware(existingMiddleware: MiddlewareFn): MiddlewareFn {
           const body = Buffer.concat(chunks).toString('utf8');
           const rewritten = rewriteTargetList(body, proxyPort);
 
-          // Update content-length and write the rewritten response
           res.setHeader('Content-Length', Buffer.byteLength(rewritten));
           originalWrite(rewritten);
           return originalEnd();

--- a/src/server.ts
+++ b/src/server.ts
@@ -381,6 +381,16 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
         port: proxyPort,
         url: devtoolsUrl,
       };
+
+      // Write the port file so the optional Metro middleware can discover it.
+      // Also set the env var for child processes.
+      process.env.METRO_MCP_PROXY_PORT = String(proxyPort);
+      try {
+        const fs = await import('fs');
+        fs.writeFileSync('.metro-mcp-proxy-port', String(proxyPort));
+      } catch {
+        // Non-critical — middleware can still use the env var
+      }
     } catch (err) {
       logger.warn('Could not start CDP proxy:', err);
     }
@@ -392,8 +402,13 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   logger.info('MCP server started');
 
   // Clean up on shutdown
-  process.on('SIGINT', () => { cdpProxy?.stop(); process.exit(0); });
-  process.on('SIGTERM', () => { cdpProxy?.stop(); process.exit(0); });
+  function cleanup() {
+    cdpProxy?.stop();
+    try { require('fs').unlinkSync('.metro-mcp-proxy-port'); } catch {}
+    process.exit(0);
+  }
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
 
   // Try connecting to Metro (non-blocking — server works without connection)
   void connectToMetro();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { exec } from 'child_process';
+import { writeFileSync, unlinkSync } from 'fs';
 import { promisify } from 'util';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -385,12 +386,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       // Write the port file so the optional Metro middleware can discover it.
       // Also set the env var for child processes.
       process.env.METRO_MCP_PROXY_PORT = String(proxyPort);
-      try {
-        const fs = await import('fs');
-        fs.writeFileSync('.metro-mcp-proxy-port', String(proxyPort));
-      } catch {
-        // Non-critical — middleware can still use the env var
-      }
+      try { writeFileSync('.metro-mcp-proxy-port', String(proxyPort)); } catch {}
     } catch (err) {
       logger.warn('Could not start CDP proxy:', err);
     }
@@ -404,7 +400,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   // Clean up on shutdown
   function cleanup() {
     cdpProxy?.stop();
-    try { require('fs').unlinkSync('.metro-mcp-proxy-port'); } catch {}
+    try { unlinkSync('.metro-mcp-proxy-port'); } catch {}
     process.exit(0);
   }
   process.on('SIGINT', cleanup);


### PR DESCRIPTION
## Summary

- Add `withMetroMcp()` wrapper for `metro.config.js` that rewrites `/json` target discovery so "j", "Open Debugger", and any CDP discovery tool route through the MCP's proxy automatically
- New `metro-mcp/metro` package export (ESM + CJS) — one-line opt-in:
  ```js
  const { withMetroMcp } = require('metro-mcp/metro');
  module.exports = withMetroMcp(getDefaultConfig(__dirname));
  ```
- MCP server writes proxy port to `.metro-mcp-proxy-port` file + `METRO_MCP_PROXY_PORT` env var for middleware discovery
- Entirely optional — MCP works without it, middleware is a no-op when MCP isn't running
- Updated README with Chrome DevTools section and configuration docs with detailed middleware setup

### How it works

The middleware intercepts `GET /json` and `GET /json/list` responses from Metro and rewrites `webSocketDebuggerUrl` and `devtoolsFrontendUrl` to point at the MCP's CDP proxy port. This means Metro's own debugger launch flow (used by "j" and "Open Debugger") constructs a DevTools URL that connects through the proxy instead of directly to Hermes.

## Test plan

- [ ] Start Metro with `withMetroMcp()` in metro.config.js, verify `/json/list` returns rewritten WebSocket URLs when MCP is running
- [ ] Press "j" in Metro — should open DevTools without disconnecting MCP
- [ ] Tap "Open Debugger" in dev menu — should work alongside MCP
- [ ] Start Metro without `withMetroMcp()` — verify MCP tools still work, `open_devtools` still works
- [ ] Start Metro with `withMetroMcp()` but MCP not running — verify `/json/list` returns unchanged URLs

https://claude.ai/code/session_01WNwPM6jHNocnoEQJRRu3pg