### PR TITLE
fix: resolve ReferenceError in get_current_route tool

### DIFF
--- a/src/plugins/navigation.ts
+++ b/src/plugins/navigation.ts
@@ -87,8 +87,8 @@ export const navigationPlugin = definePlugin({
       handler: async () => {
         const expr = `
           (function() {
-            var state = ${GET_NAV_STATE_EXPR.replace('(function()', 'function getState()')
-              .replace(/\n\s*\}\)\(\)/, '\n      }\n      return getState()')};
+            ${GET_NAV_STATE_EXPR.replace('(function()', 'function getState()')
+              .replace(/\n\s*\}\)\(\)/, '\n      }\n      var state = getState()')};
 
             if (!state) return null;
 

--- a/src/plugins/navigation.ts
+++ b/src/plugins/navigation.ts
@@ -85,28 +85,21 @@ export const navigationPlugin = definePlugin({
       description: 'Get the currently focused route name and params.',
       parameters: z.object({}),
       handler: async () => {
-        const expr = `
-          (function() {
-            ${GET_NAV_STATE_EXPR.replace('(function()', 'function getState()')
-              .replace(/\n\s*\}\)\(\)/, '\n      }\n      var state = getState()')};
+        const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
+        if (!state || typeof state !== 'object') return 'No focused route found.';
 
-            if (!state) return null;
+        function getFocusedRoute(s: Record<string, unknown>): Record<string, unknown> | null {
+          const routes = s.routes as Array<Record<string, unknown>>;
+          if (!routes) return null;
+          const idx = s.index !== undefined ? (s.index as number) : routes.length - 1;
+          const route = routes[idx];
+          if (route.state && typeof route.state === 'object') {
+            return getFocusedRoute(route.state as Record<string, unknown>);
+          }
+          return { name: route.name, params: route.params || {}, key: route.key };
+        }
 
-            // Walk to the deepest focused route
-            function getFocusedRoute(s) {
-              if (!s || !s.routes) return null;
-              var idx = s.index !== undefined ? s.index : s.routes.length - 1;
-              var route = s.routes[idx];
-              if (route.state && route.state.routes) {
-                return getFocusedRoute(route.state);
-              }
-              return { name: route.name, params: route.params || {}, key: route.key };
-            }
-
-            return getFocusedRoute(state);
-          })()
-        `;
-        const result = await ctx.evalInApp(expr, { awaitPromise: true });
+        const result = getFocusedRoute(state as Record<string, unknown>);
         if (!result) return 'No focused route found.';
         return result;
       },

--- a/src/plugins/navigation.ts
+++ b/src/plugins/navigation.ts
@@ -81,24 +81,23 @@ export const navigationPlugin = definePlugin({
       },
     });
 
+    function getFocusedRoute(s: Record<string, unknown>): Record<string, unknown> | null {
+      const routes = s.routes as Array<Record<string, unknown>>;
+      if (!routes) return null;
+      const idx = s.index !== undefined ? (s.index as number) : routes.length - 1;
+      const route = routes[idx];
+      if (route.state && typeof route.state === 'object') {
+        return getFocusedRoute(route.state as Record<string, unknown>);
+      }
+      return { name: route.name, params: route.params || {}, key: route.key };
+    }
+
     ctx.registerTool('get_current_route', {
       description: 'Get the currently focused route name and params.',
       parameters: z.object({}),
       handler: async () => {
         const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
         if (!state || typeof state !== 'object') return 'No focused route found.';
-
-        function getFocusedRoute(s: Record<string, unknown>): Record<string, unknown> | null {
-          const routes = s.routes as Array<Record<string, unknown>>;
-          if (!routes) return null;
-          const idx = s.index !== undefined ? (s.index as number) : routes.length - 1;
-          const route = routes[idx];
-          if (route.state && typeof route.state === 'object') {
-            return getFocusedRoute(route.state as Record<string, unknown>);
-          }
-          return { name: route.name, params: route.params || {}, key: route.key };
-        }
-
         const result = getFocusedRoute(state as Record<string, unknown>);
         if (!result) return 'No focused route found.';
         return result;


### PR DESCRIPTION
Fixes #19

## Problem

`get_current_route` threw `ReferenceError: Property 'getState' doesn't exist` because of a broken string-manipulation approach used to build the evaluated JS expression.

The two regex replacements were transforming `GET_NAV_STATE_EXPR` into a **named function expression** assigned to `var state`:

```js
// What was generated (broken):
var state = function getState() { ... }
return getState(); // ❌ ReferenceError — name not accessible outside the function body
```

In JavaScript, a named function expression's name is only in scope inside the function itself, not the surrounding code.

## Fix

Replaced the brittle string-manipulation approach with the same `evalInApp` pattern used by `get_navigation_state`, `get_route_history`, and `list_routes`:

1. Evaluate `GET_NAV_STATE_EXPR` via `evalInApp` to get the nav state
2. Walk to the focused route in TypeScript server-side

This removes the regex transformations entirely and makes `get_current_route` consistent with the rest of the navigation tools.