### PR TITLE
fix: resolve console.log objects fully via CDP

### DIFF
--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -10,23 +10,123 @@ interface LogEntry {
   stackTrace?: string;
 }
 
+interface CDPRemoteObject {
+  type?: string;
+  subtype?: string;
+  className?: string;
+  description?: string;
+  objectId?: string;
+  value?: unknown;
+  preview?: CDPObjectPreview;
+}
+
+interface CDPObjectPreview {
+  type?: string;
+  subtype?: string;
+  description?: string;
+  overflow?: boolean;
+  properties?: CDPPropertyPreview[];
+}
+
+interface CDPPropertyPreview {
+  name: string;
+  type: string;
+  value?: string;
+  valuePreview?: CDPObjectPreview;
+}
+
+/**
+ * Format a CDP ObjectPreview into a readable string.
+ * Handles nested objects/arrays via recursive valuePreview traversal.
+ */
+function formatPreview(preview: CDPObjectPreview): string | null {
+  if (!preview.properties) return null;
+
+  const props = preview.properties.map((p) => {
+    if (p.type === 'object' && p.valuePreview) {
+      const nested = formatPreview(p.valuePreview);
+      return `${p.name}: ${nested || p.value || '[object]'}`;
+    }
+    return `${p.name}: ${p.value}`;
+  });
+
+  const overflow = preview.overflow ? ', ...' : '';
+  if (preview.subtype === 'array') return `[${props.join(', ')}${overflow}]`;
+  return `{${props.join(', ')}${overflow}}`;
+}
+
+/**
+ * Synchronously format a CDP RemoteObject using its value, preview, or description.
+ * Used as the immediate fallback before async deep resolution completes.
+ */
+function formatRemoteObject(obj: CDPRemoteObject): string {
+  if (obj.type === 'string') return obj.value as string;
+  if (obj.type === 'number') return String(obj.value);
+  if (obj.type === 'boolean') return String(obj.value);
+  if (obj.type === 'undefined') return 'undefined';
+  if (obj.subtype === 'null') return 'null';
+  if (obj.preview) {
+    const formatted = formatPreview(obj.preview);
+    if (formatted) return formatted;
+  }
+  if (obj.description) return obj.description;
+  if (obj.value !== undefined) return JSON.stringify(obj.value);
+  return (obj.className as string) || (obj.type as string) || '[object]';
+}
+
 function formatCDPArgs(args: unknown[]): string {
   return args
     .map((arg) => {
       if (typeof arg === 'object' && arg !== null) {
-        const remoteObj = arg as Record<string, unknown>;
-        if (remoteObj.type === 'string') return remoteObj.value as string;
-        if (remoteObj.type === 'number') return String(remoteObj.value);
-        if (remoteObj.type === 'boolean') return String(remoteObj.value);
-        if (remoteObj.type === 'undefined') return 'undefined';
-        if (remoteObj.subtype === 'null') return 'null';
-        if (remoteObj.description) return remoteObj.description as string;
-        if (remoteObj.value !== undefined) return JSON.stringify(remoteObj.value);
-        return remoteObj.className || remoteObj.type || '[object]';
+        return formatRemoteObject(arg as CDPRemoteObject);
       }
       return String(arg);
     })
     .join(' ');
+}
+
+/**
+ * Resolve a RemoteObject deeply by calling JSON.stringify on it in the app runtime.
+ * Uses CDP Runtime.callFunctionOn with the object's objectId.
+ */
+async function resolveRemoteObject(
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
+  objectId: string,
+): Promise<string | null> {
+  try {
+    const result = (await cdpSend('Runtime.callFunctionOn', {
+      objectId,
+      functionDeclaration:
+        'function() { try { return JSON.stringify(this, null, 2); } catch(e) { return "[unserializable]"; } }',
+      returnByValue: true,
+    })) as Record<string, unknown>;
+    const inner = result.result as Record<string, unknown> | undefined;
+    return inner?.value ? (inner.value as string) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Asynchronously resolve all object args in a console log via CDP.
+ * Falls back to formatRemoteObject for non-object args or if resolution fails.
+ */
+async function formatCDPArgsDeep(
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
+  args: unknown[],
+): Promise<string> {
+  const parts = await Promise.all(
+    args.map(async (arg) => {
+      if (typeof arg !== 'object' || arg === null) return String(arg);
+      const remoteObj = arg as CDPRemoteObject;
+      if (remoteObj.objectId && remoteObj.type === 'object') {
+        const deep = await resolveRemoteObject(cdpSend, remoteObj.objectId);
+        if (deep) return deep;
+      }
+      return formatRemoteObject(remoteObj);
+    }),
+  );
+  return parts.join(' ');
 }
 
 export const consolePlugin = definePlugin({
@@ -41,14 +141,29 @@ export const consolePlugin = definePlugin({
       const key = ctx.getActiveDeviceKey();
       if (!key) return;
       const args = (params.args as unknown[]) || [];
-      buffers.getOrCreate(key).push({
+
+      const entry: LogEntry = {
         timestamp: Date.now(),
         level: params.type as string,
         message: formatCDPArgs(args),
         stackTrace: params.stackTrace
           ? JSON.stringify((params.stackTrace as Record<string, unknown>).callFrames)
           : undefined,
-      });
+      };
+      buffers.getOrCreate(key).push(entry);
+
+      // Asynchronously resolve objects deeply via CDP and update the entry in-place.
+      // ObjectIds are short-lived, so this must happen promptly after the log event.
+      const cdpSend = ctx.cdp.send.bind(ctx.cdp);
+      formatCDPArgsDeep(cdpSend, args)
+        .then((deep) => {
+          if (deep !== entry.message) {
+            entry.message = deep;
+          }
+        })
+        .catch(() => {
+          // Keep the shallow fallback on failure
+        });
     });
 
     // Mark when Metro starts rebuilding — a reload is imminent.

--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -35,10 +35,6 @@ interface CDPPropertyPreview {
   valuePreview?: CDPObjectPreview;
 }
 
-/**
- * Format a CDP ObjectPreview into a readable string.
- * Handles nested objects/arrays via recursive valuePreview traversal.
- */
 function formatPreview(preview: CDPObjectPreview): string | null {
   if (!preview.properties) return null;
 
@@ -85,10 +81,6 @@ function formatCDPArgs(args: unknown[]): string {
     .join(' ');
 }
 
-/**
- * Resolve a RemoteObject deeply by calling JSON.stringify on it in the app runtime.
- * Uses CDP Runtime.callFunctionOn with the object's objectId.
- */
 async function resolveRemoteObject(
   cdpSend: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
   objectId: string,
@@ -107,10 +99,6 @@ async function resolveRemoteObject(
   }
 }
 
-/**
- * Asynchronously resolve all object args in a console log via CDP.
- * Falls back to formatRemoteObject for non-object args or if resolution fails.
- */
 async function formatCDPArgsDeep(
   cdpSend: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
   args: unknown[],
@@ -136,6 +124,7 @@ export const consolePlugin = definePlugin({
 
   async setup(ctx) {
     const buffers = new DeviceBufferManager<LogEntry>(500);
+    const cdpSend = ctx.cdp.send.bind(ctx.cdp);
 
     ctx.cdp.on('Runtime.consoleAPICalled', (params) => {
       const key = ctx.getActiveDeviceKey();
@@ -152,18 +141,17 @@ export const consolePlugin = definePlugin({
       };
       buffers.getOrCreate(key).push(entry);
 
-      // Asynchronously resolve objects deeply via CDP and update the entry in-place.
-      // ObjectIds are short-lived, so this must happen promptly after the log event.
-      const cdpSend = ctx.cdp.send.bind(ctx.cdp);
-      formatCDPArgsDeep(cdpSend, args)
-        .then((deep) => {
-          if (deep !== entry.message) {
-            entry.message = deep;
-          }
-        })
-        .catch(() => {
-          // Keep the shallow fallback on failure
-        });
+      // ObjectIds are short-lived, so resolve promptly after the log event.
+      const hasResolvable = args.some(
+        (arg) => typeof arg === 'object' && arg !== null && (arg as CDPRemoteObject).objectId,
+      );
+      if (hasResolvable) {
+        formatCDPArgsDeep(cdpSend, args)
+          .then((deep) => {
+            if (deep !== entry.message) entry.message = deep;
+          })
+          .catch(() => {});
+      }
     });
 
     // Mark when Metro starts rebuilding — a reload is imminent.


### PR DESCRIPTION
## Summary

- `get_console_logs` previously showed `"Object"` for any non-primitive `console.log` argument because `formatCDPArgs` only read the CDP `RemoteObject.description` field
- This adds deep object resolution using two strategies:
  1. **Sync preview formatting** — reads `RemoteObject.preview.properties` for an immediate readable representation (e.g. `{name: "foo", count: 42}`)
  2. **Async deep resolution** — calls `Runtime.callFunctionOn` with the object's `objectId` to run `JSON.stringify` in the app runtime, updating the log entry in-place with the complete serialized result

## Motivation

This is especially valuable for debugging GraphQL responses. Libraries like `apollo-link-logger` log full result objects via `console.log('RESULT', result)` — without this fix those appear as `"RESULT Object"`. With this fix, the entire response payload is readable through `get_console_logs`.

**Before:**
```
test Object
```

**After (sync preview):**
```
test {randomNumber: 0.753, array: Array(2)}
```

**After (async deep resolution):**
```
test {
  "randomNumber": 0.753,
  "array": [
    {"num": 0.673},
    {"num": 0.005}
  ]
}
```

## Implementation details

- `formatPreview()` — recursively formats CDP `ObjectPreview` including nested `valuePreview` for objects and arrays
- `resolveRemoteObject()` — uses `Runtime.callFunctionOn` to call `JSON.stringify(this, null, 2)` on the remote object
- `formatCDPArgsDeep()` — async resolver that processes all args in parallel via `Promise.all`
- The log entry is stored immediately with the sync preview, then updated in-place when async resolution completes
- Falls back gracefully: if the `objectId` has been GC'd or `JSON.stringify` fails, the sync preview or `description` is kept
- Hermes (React Native) does include `objectId` and `preview` on `Runtime.consoleAPICalled` args — verified on Hermes + Android emulator (API 35)

## Test plan

- [x] Verified with simple objects: `console.log('test', {randomNumber: Math.random()})`
- [x] Verified with deeply nested objects (3+ levels, mixed types, arrays of objects)
- [x] Verified with Apollo GraphQL logger output (158KB+ response fully resolved)
- [x] Verified edge cases: null, undefined, boolean, empty objects/arrays, regex, large numbers, -Infinity (serializes as null per JSON spec)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Idempotent: reading logs before async resolution completes returns the sync preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)