### PR TITLE
fix: prevent multiple instances from competing for Metro's CDP connection

### DIFF
--- a/src/metro/proxy.ts
+++ b/src/metro/proxy.ts
@@ -77,22 +77,36 @@ export class CDPProxy {
    * Start the proxy's HTTP + WebSocket server.
    */
   async start(port = 0): Promise<number> {
-    return new Promise((resolve, reject) => {
-      this.httpServer = http.createServer((req, res) => {
-        this.handleHttpRequest(req, res);
+    const tryPort = (p: number): Promise<number> => new Promise((resolve, reject) => {
+      const httpServer = http.createServer((req, res) => this.handleHttpRequest(req, res));
+      httpServer.on('error', (err) => {
+        httpServer.close();
+        reject(err);
       });
-
-      this.wss = new WebSocketServer({ server: this.httpServer });
-      this.wss.on('connection', (ws) => this.handleNewClient(ws));
-
-      this.httpServer.on('error', reject);
-      this.httpServer.listen(port, () => {
-        const addr = this.httpServer!.address();
-        this._port = typeof addr === 'object' && addr ? addr.port : port;
-        logger.info(`CDP proxy listening on port ${this._port}`);
-        resolve(this._port);
+      httpServer.listen(p, () => {
+        const addr = httpServer.address();
+        const actualPort = typeof addr === 'object' && addr ? addr.port : p;
+        // Only attach WSS after successful bind — creating it before listen() would
+        // cause it to emit an unhandled error event if the port is already in use.
+        const wss = new WebSocketServer({ server: httpServer });
+        wss.on('connection', (ws) => this.handleNewClient(ws));
+        this.httpServer = httpServer;
+        this.wss = wss;
+        this._port = actualPort;
+        logger.info(`CDP proxy listening on port ${actualPort}`);
+        resolve(actualPort);
       });
     });
+
+    if (port !== 0) {
+      try {
+        return await tryPort(port);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw err;
+        logger.debug(`Preferred proxy port ${port} in use, falling back to auto-assign`);
+      }
+    }
+    return tryPort(0);
   }
 
   /**

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -1,9 +1,10 @@
-import { spawn } from 'child_process';
+import fs from 'fs';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('devtools');
+const DEVTOOLS_STATE_FILE = '/tmp/metro-mcp-devtools.json';
 
 /**
  * Find a Chrome/Edge binary path using the same strategy as Metro's
@@ -24,6 +25,48 @@ async function findBrowserPath(): Promise<string | null> {
   } catch {}
 
   return null;
+}
+
+async function tryFocusExisting(frontendUrl: string): Promise<boolean> {
+  try {
+    const state = JSON.parse(fs.readFileSync(DEVTOOLS_STATE_FILE, 'utf8'));
+    if (!state.pid || !state.remoteDebuggingPort) return false;
+
+    try { process.kill(state.pid, 0); } catch { return false; }
+
+    const resp = await fetch(`http://localhost:${state.remoteDebuggingPort}/json`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    if (!resp.ok) return false;
+
+    const targets = await resp.json() as Array<{ id: string; url: string }>;
+    const target = targets.find(t => t.url?.includes('rn_fusebox') || t.url === frontendUrl);
+    if (!target?.id) return false;
+
+    const activate = await fetch(
+      `http://localhost:${state.remoteDebuggingPort}/json/activate/${target.id}`,
+      { signal: AbortSignal.timeout(1000) },
+    );
+    return activate.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function launchDevTools(frontendUrl: string): Promise<void> {
+  const { launch } = await import('chrome-launcher');
+  const chrome = await launch({
+    chromeFlags: [`--app=${frontendUrl}`, '--window-size=1200,600'],
+  });
+  chrome.process.unref();
+  try {
+    fs.writeFileSync(
+      DEVTOOLS_STATE_FILE,
+      JSON.stringify({ pid: chrome.pid, remoteDebuggingPort: chrome.port }),
+    );
+  } catch (err) {
+    logger.warn('Failed to write devtools state:', err);
+  }
 }
 
 export const devtoolsPlugin = definePlugin({
@@ -62,16 +105,13 @@ export const devtoolsPlugin = definePlugin({
 
           if (browserPath) {
             try {
-              // Spawn detached in --app mode, exactly like Metro's DefaultToolLauncher.
-              const child = spawn(
-                browserPath,
-                [`--app=${frontendUrl}`, '--window-size=1200,600'],
-                { detached: true, stdio: 'ignore' },
-              );
-              child.unref();
+              const focused = await tryFocusExisting(frontendUrl);
+              if (!focused) {
+                await launchDevTools(frontendUrl);
+              }
               return { opened: true, url: frontendUrl };
             } catch (err) {
-              logger.debug('Failed to launch browser:', err);
+              logger.debug('Failed to open DevTools:', err);
             }
           } else {
             logger.debug('No Chrome/Edge installation found');

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import fs from 'fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
@@ -17,6 +18,7 @@ import type {
 import { CDPClient } from './metro/connection.js';
 import { MetroEventsClient } from './metro/events.js';
 import { scanMetroPorts, selectBestTarget, fetchTargets } from './metro/discovery.js';
+import type { MetroTarget } from './metro/types.js';
 import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
 import { extractCDPExceptionMessage } from './utils/cdp.js';
@@ -293,6 +295,75 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     }
   }
 
+  // Singleton proxy lock — prevents multiple metro-mcp instances from competing
+  // for Metro's single CDP WebSocket, which causes a connect/disconnect spam loop.
+  // The first instance connects directly to Metro and writes its CDP proxy port to
+  // a lock file. Subsequent instances detect the lock and connect through the
+  // existing proxy instead.
+  const PROXY_LOCK_FILE = '/tmp/metro-mcp-proxy.json';
+  let isPrimaryInstance = false;
+
+  async function tryConnectViaProxy(): Promise<boolean> {
+    try {
+      const lockData = JSON.parse(fs.readFileSync(PROXY_LOCK_FILE, 'utf8'));
+      if (lockData.pid && lockData.port) {
+        // Check if the owning process is still alive
+        try { process.kill(lockData.pid, 0); } catch { return false; }
+        const resp = await fetch(`http://127.0.0.1:${lockData.port}/json`, {
+          signal: AbortSignal.timeout(2000),
+        });
+        if (!resp.ok) return false;
+        const targets = await resp.json() as Array<{ id?: string; title?: string; webSocketDebuggerUrl?: string }>;
+        if (targets.length > 0 && targets[0].webSocketDebuggerUrl) {
+          logger.info(
+            `Found existing metro-mcp proxy (PID ${lockData.pid}, port ${lockData.port}) — connecting as secondary`
+          );
+          await cdpClient.connect(targets[0] as unknown as MetroTarget);
+          if (lockData.metroPort) {
+            eventsClient.connect(config.metro.host!, lockData.metroPort);
+            config.metro.port = lockData.metroPort;
+          }
+          // Point devtools plugin at the primary's proxy so open_devtools uses the right port
+          (config as Record<string, unknown>).proxy = {
+            ...config.proxy,
+            port: lockData.port,
+          };
+          activeDeviceKey = targets[0].id ? `${lockData.port}-${targets[0].id}` : null;
+          activeDeviceName = targets[0].title || targets[0].id || 'secondary';
+          return true;
+        }
+      }
+    } catch {
+      // Lock file missing, stale, or unreadable — fall through to direct connect
+    }
+    return false;
+  }
+
+  function writeProxyLock(proxyPort: number, metroPort: number): void {
+    try {
+      fs.writeFileSync(
+        PROXY_LOCK_FILE,
+        JSON.stringify({ pid: process.pid, port: proxyPort, metroPort })
+      );
+      isPrimaryInstance = true;
+      logger.info(`Wrote proxy lock (port ${proxyPort})`);
+    } catch (err) {
+      logger.warn('Failed to write proxy lock:', err);
+    }
+  }
+
+  function cleanProxyLock(): void {
+    if (!isPrimaryInstance) return;
+    try {
+      const lockData = JSON.parse(fs.readFileSync(PROXY_LOCK_FILE, 'utf8'));
+      if (lockData.pid === process.pid) {
+        fs.unlinkSync(PROXY_LOCK_FILE);
+      }
+    } catch {
+      // Already cleaned or another instance took over
+    }
+  }
+
   // Connect to Metro — always re-discovers targets to get a fresh webSocketDebuggerUrl.
   // Idempotent: concurrent callers wait for the in-flight attempt to finish.
   async function connectToMetro(): Promise<boolean> {
@@ -302,6 +373,11 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     }
     isReconnecting = true;
     try {
+      // If another metro-mcp instance is already connected, piggyback on its proxy
+      if (await tryConnectViaProxy()) {
+        return true;
+      }
+
       let servers;
       if (config.metro.autoDiscover) {
         servers = await scanMetroPorts(config.metro.host!);
@@ -330,6 +406,12 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       // Track active device for per-device buffers
       activeDeviceKey = `${server.port}-${target.id}`;
       activeDeviceName = target.title || target.deviceName || target.id;
+
+      // Write lock so other instances connect through our proxy
+      const proxyPort = (config as Record<string, unknown>).proxy as { port?: number } | undefined;
+      if (proxyPort?.port) {
+        writeProxyLock(proxyPort.port, server.port);
+      }
 
       return true;
     } catch (err) {
@@ -392,8 +474,9 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   logger.info('MCP server started');
 
   // Clean up on shutdown
-  process.on('SIGINT', () => { cdpProxy?.stop(); process.exit(0); });
-  process.on('SIGTERM', () => { cdpProxy?.stop(); process.exit(0); });
+  process.on('SIGINT', () => { cleanProxyLock(); cdpProxy?.stop(); process.exit(0); });
+  process.on('SIGTERM', () => { cleanProxyLock(); cdpProxy?.stop(); process.exit(0); });
+  process.on('exit', () => { cleanProxyLock(); });
 
   // Try connecting to Metro (non-blocking — server works without connection)
   void connectToMetro();

--- a/src/server.ts
+++ b/src/server.ts
@@ -451,7 +451,14 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   if (config.proxy?.enabled !== false) {
     cdpProxy = new CDPProxy(cdpClient);
     try {
-      const proxyPort = await cdpProxy.start(config.proxy?.port ?? 0);
+      let preferredProxyPort = config.proxy?.port ?? 0;
+      if (preferredProxyPort === 0) {
+        try {
+          const stale = JSON.parse(fs.readFileSync(PROXY_LOCK_FILE, 'utf8'));
+          if (stale.port) preferredProxyPort = stale.port;
+        } catch { /* no stale lock */ }
+      }
+      const proxyPort = await cdpProxy.start(preferredProxyPort);
       const devtoolsUrl = cdpProxy.getDevToolsUrl();
       logger.info(`CDP proxy started on port ${proxyPort}`);
       if (devtoolsUrl) {


### PR DESCRIPTION
## Problem

When multiple MCP clients (e.g., multiple Claude Code sessions) run in the same project, each spawns its own `metro-mcp` process. Since Metro only allows **one CDP WebSocket client at a time**, these instances fight for the connection, causing a rapid connect/disconnect loop:

```
INFO  Connection established to DevTools for app='com.myapp'...
INFO  Connection closed to DevTools for app='com.myapp'... with code='1005'
INFO  Connection established to DevTools for app='com.myapp'...
INFO  Connection closed to DevTools for app='com.myapp'... with code='1005'
(repeats indefinitely)
```

This spams the Metro console and breaks DevTools for all sessions.

## Solution

Adds a file-lock based singleton mechanism so multiple metro-mcp instances can coexist:

- **First instance** (primary): connects to Metro directly and writes its CDP proxy port to `/tmp/metro-mcp-proxy.json`
- **Subsequent instances** (secondary): detect the lock file, verify the owning process is alive via `kill(pid, 0)`, and connect through the primary's existing CDP proxy instead of directly to Metro
- The lock file is cleaned up on process exit (`SIGINT`, `SIGTERM`, `exit`)
- Stale locks (dead PIDs) are detected and ignored, allowing a new primary to take over

This leverages the existing `CDPProxy` which already multiplexes a single Hermes connection — secondary instances simply become additional proxy clients.

## Test plan

- [ ] Start Metro (`npx react-native start`)
- [ ] Start first metro-mcp instance — verify it connects to Metro and writes `/tmp/metro-mcp-proxy.json`
- [ ] Start second metro-mcp instance — verify it logs "connecting as secondary" and connects via the proxy
- [ ] Verify no connection spam in Metro console
- [ ] Kill the primary instance — verify lock file is cleaned up
- [ ] Verify the secondary can become primary on next `connectToMetro()` call
- [ ] Verify `open_devtools` from both instances opens the correct DevTools URL (pointing to the primary's proxy port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)