### PR TITLE
Bump version to 0.7.1 and update metro-bridge dependency

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",
   "repository": {
@@ -61,7 +61,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.1.1",
+    "metro-bridge": "^0.1.2",
     "ws": "^8.20.0",
     "zod": "^3.24.4"
   },


### PR DESCRIPTION
## Summary
This release updates the metro-mcp package version to 0.7.1 and bumps the metro-bridge dependency to version 0.1.2 across all configuration files.

## Changes
- Updated package version from 0.7.0 to 0.7.1 in `package.json`
- Updated metro-bridge dependency from ^0.1.1 to ^0.1.2 in `package.json`
- Synchronized version number to 0.7.1 in `.claude-plugin/plugin.json`
- Synchronized version number to 0.7.1 in `.codex-plugin/plugin.json`

## Notes
This is a patch release that updates the metro-bridge dependency to incorporate fixes or improvements from that package's 0.1.2 release.

https://claude.ai/code/session_01X5H1U8AnjZfDY3U2UWvRCF