### PR TITLE
Fix tap_element/long_press not working when testID is on a child element

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",
   "repository": {

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -158,15 +158,16 @@ export const uiInteractPlugin = definePlugin({
           (function() {
             ${FIBER_ROOT_JS}
             var needle = ${jsLabel};
+            // Step 1: find fiber by testID/label (onPress not required here)
             var target = null;
             var stack = [rootFiber];
             while (stack.length && !target) {
               var fiber = stack.pop();
               if (!fiber) continue;
               var props = fiber.memoizedProps || {};
-              if ((props.accessibilityLabel === needle ||
-                   props['aria-label'] === needle ||
-                   props.testID === needle) && props.onPress) {
+              if (props.accessibilityLabel === needle ||
+                  props['aria-label'] === needle ||
+                  props.testID === needle) {
                 target = fiber;
               } else {
                 if (fiber.sibling) stack.push(fiber.sibling);
@@ -174,7 +175,20 @@ export const uiInteractPlugin = definePlugin({
               }
             }
             if (!target) return false;
-            target.memoizedProps.onPress({ nativeEvent: {} });
+            // Step 2: use matched fiber if it has onPress, otherwise walk up to nearest ancestor
+            var pressable = (target.memoizedProps && target.memoizedProps.onPress) ? target : null;
+            if (!pressable) {
+              var ancestor = target.return;
+              while (ancestor) {
+                if (ancestor.memoizedProps && ancestor.memoizedProps.onPress) {
+                  pressable = ancestor;
+                  break;
+                }
+                ancestor = ancestor.return;
+              }
+            }
+            if (!pressable) return false;
+            pressable.memoizedProps.onPress({ nativeEvent: {} });
             return true;
           })()
         `).catch(() => false);
@@ -324,15 +338,16 @@ export const uiInteractPlugin = definePlugin({
             (function() {
               ${FIBER_ROOT_JS}
               var needle = ${jsLabel};
+              // Step 1: find fiber by testID/label (onLongPress not required here)
               var target = null;
               var stack = [rootFiber];
               while (stack.length && !target) {
                 var fiber = stack.pop();
                 if (!fiber) continue;
                 var props = fiber.memoizedProps || {};
-                if ((props.accessibilityLabel === needle ||
-                     props['aria-label'] === needle ||
-                     props.testID === needle) && props.onLongPress) {
+                if (props.accessibilityLabel === needle ||
+                    props['aria-label'] === needle ||
+                    props.testID === needle) {
                   target = fiber;
                 } else {
                   if (fiber.sibling) stack.push(fiber.sibling);
@@ -340,7 +355,20 @@ export const uiInteractPlugin = definePlugin({
                 }
               }
               if (!target) return false;
-              target.memoizedProps.onLongPress({ nativeEvent: {} });
+              // Step 2: use matched fiber if it has onLongPress, otherwise walk up to nearest ancestor
+              var pressable = (target.memoizedProps && target.memoizedProps.onLongPress) ? target : null;
+              if (!pressable) {
+                var ancestor = target.return;
+                while (ancestor) {
+                  if (ancestor.memoizedProps && ancestor.memoizedProps.onLongPress) {
+                    pressable = ancestor;
+                    break;
+                  }
+                  ancestor = ancestor.return;
+                }
+              }
+              if (!pressable) return false;
+              pressable.memoizedProps.onLongPress({ nativeEvent: {} });
               return true;
             })()
           `).catch(() => false);

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { FIBER_ROOT_JS, GET_ROUTE_FUNC_JS, SWIPE_COORDS } from '../utils/fiber.js';
+import { FIBER_ROOT_JS, FIND_AND_INVOKE_JS, GET_ROUTE_FUNC_JS, SWIPE_COORDS } from '../utils/fiber.js';
 
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let idbAvailableCache: boolean | null = null;
@@ -157,39 +157,8 @@ export const uiInteractPlugin = definePlugin({
         const tapped = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
-            var needle = ${jsLabel};
-            // Step 1: find fiber by testID/label (onPress not required here)
-            var target = null;
-            var stack = [rootFiber];
-            while (stack.length && !target) {
-              var fiber = stack.pop();
-              if (!fiber) continue;
-              var props = fiber.memoizedProps || {};
-              if (props.accessibilityLabel === needle ||
-                  props['aria-label'] === needle ||
-                  props.testID === needle) {
-                target = fiber;
-              } else {
-                if (fiber.sibling) stack.push(fiber.sibling);
-                if (fiber.child) stack.push(fiber.child);
-              }
-            }
-            if (!target) return false;
-            // Step 2: use matched fiber if it has onPress, otherwise walk up to nearest ancestor
-            var pressable = (target.memoizedProps && target.memoizedProps.onPress) ? target : null;
-            if (!pressable) {
-              var ancestor = target.return;
-              while (ancestor) {
-                if (ancestor.memoizedProps && ancestor.memoizedProps.onPress) {
-                  pressable = ancestor;
-                  break;
-                }
-                ancestor = ancestor.return;
-              }
-            }
-            if (!pressable) return false;
-            pressable.memoizedProps.onPress({ nativeEvent: {} });
-            return true;
+            ${FIND_AND_INVOKE_JS}
+            return findAndInvoke(${jsLabel}, 'onPress');
           })()
         `).catch(() => false);
         if (tapped) return `Tapped "${label}"`;
@@ -337,39 +306,8 @@ export const uiInteractPlugin = definePlugin({
           const pressed = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
-              var needle = ${jsLabel};
-              // Step 1: find fiber by testID/label (onLongPress not required here)
-              var target = null;
-              var stack = [rootFiber];
-              while (stack.length && !target) {
-                var fiber = stack.pop();
-                if (!fiber) continue;
-                var props = fiber.memoizedProps || {};
-                if (props.accessibilityLabel === needle ||
-                    props['aria-label'] === needle ||
-                    props.testID === needle) {
-                  target = fiber;
-                } else {
-                  if (fiber.sibling) stack.push(fiber.sibling);
-                  if (fiber.child) stack.push(fiber.child);
-                }
-              }
-              if (!target) return false;
-              // Step 2: use matched fiber if it has onLongPress, otherwise walk up to nearest ancestor
-              var pressable = (target.memoizedProps && target.memoizedProps.onLongPress) ? target : null;
-              if (!pressable) {
-                var ancestor = target.return;
-                while (ancestor) {
-                  if (ancestor.memoizedProps && ancestor.memoizedProps.onLongPress) {
-                    pressable = ancestor;
-                    break;
-                  }
-                  ancestor = ancestor.return;
-                }
-              }
-              if (!pressable) return false;
-              pressable.memoizedProps.onLongPress({ nativeEvent: {} });
-              return true;
+              ${FIND_AND_INVOKE_JS}
+              return findAndInvoke(${jsLabel}, 'onLongPress');
             })()
           `).catch(() => false);
           if (pressed) return `Long pressed "${label}"`;

--- a/src/utils/fiber.ts
+++ b/src/utils/fiber.ts
@@ -87,6 +87,44 @@ export const SWIPE_COORDS: Record<string, [number, number, number, number]> = {
 };
 
 /**
+ * JS snippet defining `findAndInvoke(needle, handlerName)`.
+ * Requires `rootFiber` to be set (embed after FIBER_ROOT_JS).
+ * Finds the fiber matching needle by accessibilityLabel, aria-label, or testID,
+ * then walks up to the nearest ancestor that has `handlerName` and calls it.
+ */
+export const FIND_AND_INVOKE_JS = `
+  function findAndInvoke(needle, handlerName) {
+    var target = null;
+    var stack = [rootFiber];
+    while (stack.length && !target) {
+      var fiber = stack.pop();
+      if (!fiber) continue;
+      var props = fiber.memoizedProps || {};
+      if (props.accessibilityLabel === needle ||
+          props['aria-label'] === needle ||
+          props.testID === needle) {
+        target = fiber;
+      } else {
+        if (fiber.sibling) stack.push(fiber.sibling);
+        if (fiber.child) stack.push(fiber.child);
+      }
+    }
+    if (!target) return false;
+    var f = target;
+    var depth = 0;
+    while (f && depth < 50) {
+      if (f.memoizedProps && f.memoizedProps[handlerName]) {
+        f.memoizedProps[handlerName]({ nativeEvent: {} });
+        return true;
+      }
+      f = f.return;
+      depth++;
+    }
+    return false;
+  }
+`;
+
+/**
  * JS snippet that defines a `getRoute()` function reading from the nav ref set by the
  * navigation plugin. Embed inside an IIFE that also calls `getRoute()`.
  */


### PR DESCRIPTION
The fiber-tree walk required onPress/onLongPress to be on the same fiber as the testID/label match. In React Native it's common to place testID on an inner View while onPress lives on a parent Pressable/TouchableOpacity, so the element was never found and tap silently did nothing.

Fix: separate the lookup from the handler requirement. After finding the fiber by testID/label, walk up via fiber.return to find the nearest ancestor with onPress (or onLongPress for long_press). Same fix applied to both tap_element and long_press.

https://claude.ai/code/session_01Gfpd95rYa5pMaBH6D18Z8e