### PR TITLE
Use default debugger URL on RN 0.85+

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "^0.1.1",
+        "metro-bridge": "^0.2.0",
         "ws": "^8.20.0",
         "zod": "^3.24.4",
       },
@@ -419,7 +419,7 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
-    "metro-bridge": ["metro-bridge@0.1.1", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-W0dkUDzXZ6R//E4/jXXykV7qEL9kaBkLMM5W/LSC8gA3wrOwkGR/niyDS10zQ4XL7F/c14DFCfjJrQnKOeksfg=="],
+    "metro-bridge": ["metro-bridge@0.2.0", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-KVF/N6DyD5vqD5CMaKLHPjb2Sr8/ecN6IUKPrM4aikoELd53z24Ggib9VQe3ysaOVxCHuVqup9Ihvd3PQJ0pbA=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.1.2",
+    "metro-bridge": "^0.2.0",
     "ws": "^8.20.0",
     "zod": "^3.24.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",
   "repository": {
@@ -61,7 +61,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.2.0",
+    "metro-bridge": "^0.2.2",
     "ws": "^8.20.0",
     "zod": "^3.24.4"
   },

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -7,6 +7,10 @@ import { createLogger } from '../utils/logger.js';
 const logger = createLogger('devtools');
 const DEVTOOLS_STATE_FILE = '/tmp/metro-mcp-devtools.json';
 
+function buildFrontendUrl(metroHost: string, metroPort: number, wsEndpoint: string): string {
+  return `http://${metroHost}:${metroPort}/debugger-frontend/rn_fusebox.html?ws=${wsEndpoint}&sources.hide_add_folder=true`;
+}
+
 /**
  * Find a Chrome/Edge binary path using the same strategy as Metro's
  * DefaultToolLauncher: try chrome-launcher first, fall back to
@@ -92,12 +96,13 @@ export const devtoolsPlugin = definePlugin({
         }
 
         if (supportsMultipleDebuggers(target)) {
-          // RN 0.85+: Metro supports concurrent debugger sessions natively.
-          // Point DevTools directly at Metro's own WebSocket — no proxy needed.
-          const wsHost = new URL(target.webSocketDebuggerUrl).host;
-          const frontendUrl =
-            `http://${ctx.metro.host}:${ctx.metro.port}/debugger-frontend/rn_fusebox.html` +
-            `?ws=${wsHost}&sources.hide_add_folder=true`;
+          let wsHost: string;
+          try {
+            wsHost = new URL(target.webSocketDebuggerUrl).host;
+          } catch {
+            return 'Could not parse Metro WebSocket URL. Try reconnecting.';
+          }
+          const frontendUrl = buildFrontendUrl(ctx.metro.host, ctx.metro.port, wsHost);
 
           if (open) {
             try {
@@ -115,8 +120,8 @@ export const devtoolsPlugin = definePlugin({
           };
         }
 
-        // RN <0.85: proxy-based path — DevTools connects through the CDPMultiplexer
-        // so both it and the MCP can share the single Hermes connection.
+        // RN <0.85: only one debugger can hold the connection at a time, so the
+        // CDPMultiplexer proxy shares it between DevTools and the MCP.
         const config = ctx.config as Record<string, unknown>;
         const proxyConfig = config.proxy as { port?: number } | undefined;
         const proxyPort = proxyConfig?.port;
@@ -125,9 +130,7 @@ export const devtoolsPlugin = definePlugin({
           return 'CDP proxy is not running. Set proxy.enabled to true in your metro-mcp config.';
         }
 
-        const frontendUrl = `http://${ctx.metro.host}:${ctx.metro.port}/debugger-frontend/rn_fusebox.html`
-          + `?ws=127.0.0.1:${proxyPort}`
-          + `&sources.hide_add_folder=true`;
+        const frontendUrl = buildFrontendUrl(ctx.metro.host, ctx.metro.port, `127.0.0.1:${proxyPort}`);
 
         if (open) {
           const browserPath = await findBrowserPath();

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { z } from 'zod';
+import { supportsMultipleDebuggers, openDevTools } from 'metro-bridge';
 import { definePlugin } from '../plugin.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -78,12 +79,44 @@ export const devtoolsPlugin = definePlugin({
     ctx.registerTool('open_devtools', {
       description:
         'Open the React Native DevTools debugger panel in Chrome. ' +
-        'Uses Metro\'s bundled DevTools frontend but connects through our CDP proxy ' +
-        'so both DevTools and the MCP can share the single Hermes connection.',
+        'On RN 0.85+ connects directly to Metro (no proxy needed). ' +
+        'On older RN versions connects through the CDP proxy so both ' +
+        'DevTools and the MCP can share the single Hermes connection.',
       parameters: z.object({
         open: z.boolean().default(true).describe('Attempt to open the browser automatically'),
       }),
       handler: async ({ open }) => {
+        const target = ctx.cdp.getTarget();
+        if (!target) {
+          return 'Not connected to Metro. Start your React Native app and try again.';
+        }
+
+        if (supportsMultipleDebuggers(target)) {
+          // RN 0.85+: Metro supports concurrent debugger sessions natively.
+          // Point DevTools directly at Metro's own WebSocket — no proxy needed.
+          const wsHost = new URL(target.webSocketDebuggerUrl).host;
+          const frontendUrl =
+            `http://${ctx.metro.host}:${ctx.metro.port}/debugger-frontend/rn_fusebox.html` +
+            `?ws=${wsHost}&sources.hide_add_folder=true`;
+
+          if (open) {
+            try {
+              const result = await openDevTools(frontendUrl);
+              return { opened: result.opened, url: frontendUrl };
+            } catch (err) {
+              logger.debug('Failed to open DevTools:', err);
+            }
+          }
+
+          return {
+            opened: false,
+            url: frontendUrl,
+            instructions: 'Open this URL in Chrome or Edge: ' + frontendUrl,
+          };
+        }
+
+        // RN <0.85: proxy-based path — DevTools connects through the CDPMultiplexer
+        // so both it and the MCP can share the single Hermes connection.
         const config = ctx.config as Record<string, unknown>;
         const proxyConfig = config.proxy as { port?: number } | undefined;
         const proxyPort = proxyConfig?.port;
@@ -92,10 +125,6 @@ export const devtoolsPlugin = definePlugin({
           return 'CDP proxy is not running. Set proxy.enabled to true in your metro-mcp config.';
         }
 
-        // Build a URL using Metro's own DevTools frontend, but pointing the
-        // WebSocket connection at our proxy instead of Metro's inspector.
-        // This is the same frontend Metro uses when you press "j", served
-        // from the @react-native/debugger-frontend package.
         const frontendUrl = `http://${ctx.metro.host}:${ctx.metro.port}/debugger-frontend/rn_fusebox.html`
           + `?ws=127.0.0.1:${proxyPort}`
           + `&sources.hide_add_folder=true`;

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -96,13 +96,22 @@ export const devtoolsPlugin = definePlugin({
         }
 
         if (supportsMultipleDebuggers(target)) {
-          let wsHost: string;
-          try {
-            wsHost = new URL(target.webSocketDebuggerUrl).host;
-          } catch {
-            return 'Could not parse Metro WebSocket URL. Try reconnecting.';
+          // Prefer the devtoolsFrontendUrl Metro provides — it encodes the exact
+          // device+page path in the `ws` query param, which is what DevTools needs
+          // to connect to the right session. Falling back to just the host (as we
+          // used to do) opens a generic target-picker that doesn't auto-connect.
+          let frontendUrl: string;
+          if (target.devtoolsFrontendUrl) {
+            frontendUrl = `http://${ctx.metro.host}:${ctx.metro.port}${target.devtoolsFrontendUrl}`;
+          } else {
+            let wsHost: string;
+            try {
+              wsHost = new URL(target.webSocketDebuggerUrl).host;
+            } catch {
+              return 'Could not parse Metro WebSocket URL. Try reconnecting.';
+            }
+            frontendUrl = buildFrontendUrl(ctx.metro.host, ctx.metro.port, wsHost);
           }
-          const frontendUrl = buildFrontendUrl(ctx.metro.host, ctx.metro.port, wsHost);
 
           if (open) {
             try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import type {
   PromptConfig,
   EvalOptions,
 } from './plugin.js';
-import { CDPSession, CDPMultiplexer, scanMetroPorts, selectBestTarget, fetchTargets } from 'metro-bridge';
+import { CDPSession, CDPMultiplexer, scanMetroPorts, selectBestTarget, fetchTargets, supportsMultipleDebuggers } from 'metro-bridge';
 import type { MetroTarget } from 'metro-bridge';
 import { MetroEventsClient } from './metro/events.js';
 import { createLogger } from './utils/logger.js';
@@ -405,10 +405,36 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       activeDeviceKey = `${server.port}-${target.id}`;
       activeDeviceName = target.title || target.deviceName || target.id;
 
-      // Write lock so other instances connect through our proxy
-      const proxyPort = (config as Record<string, unknown>).proxy as { port?: number } | undefined;
-      if (proxyPort?.port) {
-        writeProxyLock(proxyPort.port, server.port);
+      if (supportsMultipleDebuggers(target)) {
+        // RN 0.85+: Metro handles multiple concurrent debugger sessions natively.
+        // No CDPMultiplexer or singleton proxy lock needed — other tools (Chrome
+        // DevTools, other metro-mcp instances) can connect to Metro directly.
+        logger.info('Target supports multiple debuggers (RN 0.85+) — skipping CDP proxy');
+      } else {
+        // RN <0.85: only one debugger at a time. Start the proxy once and write the
+        // singleton lock so other metro-mcp instances piggyback on it.
+        if (!proxyStarted && config.proxy?.enabled !== false) {
+          cdpMultiplexer = new CDPMultiplexer(cdpSession, { protectedDomains: ['Runtime', 'Network'] });
+          try {
+            const startedPort = await cdpMultiplexer.start(preferredProxyPort);
+            const devtoolsUrl = cdpMultiplexer.getDevToolsUrl();
+            logger.info(`CDP proxy started on port ${startedPort}`);
+            if (devtoolsUrl) logger.info(`Chrome DevTools URL: ${devtoolsUrl}`);
+            (config as Record<string, unknown>).proxy = {
+              ...config.proxy,
+              port: startedPort,
+              url: devtoolsUrl,
+            };
+            proxyStarted = true;
+          } catch (err) {
+            logger.warn('Could not start CDP proxy:', err);
+          }
+        }
+
+        const proxyConfig = (config as Record<string, unknown>).proxy as { port?: number } | undefined;
+        if (proxyConfig?.port) {
+          writeProxyLock(proxyConfig.port, server.port);
+        }
       }
 
       return true;
@@ -444,33 +470,18 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     }, delay);
   }
 
-  // Start CDP proxy for Chrome DevTools coexistence
+  // CDP proxy for Chrome DevTools coexistence — started lazily on first connect
+  // only when the target does not support multiple debuggers natively (RN <0.85).
   let cdpMultiplexer: CDPMultiplexer | null = null;
-  if (config.proxy?.enabled !== false) {
-    cdpMultiplexer = new CDPMultiplexer(cdpSession, { protectedDomains: ['Runtime', 'Network'] });
+  let proxyStarted = false;
+
+  // Read preferred proxy port once at startup (stale lock reuse / explicit config).
+  let preferredProxyPort = config.proxy?.port ?? 0;
+  if (preferredProxyPort === 0) {
     try {
-      let preferredProxyPort = config.proxy?.port ?? 0;
-      if (preferredProxyPort === 0) {
-        try {
-          const stale = JSON.parse(fs.readFileSync(PROXY_LOCK_FILE, 'utf8'));
-          if (stale.port) preferredProxyPort = stale.port;
-        } catch { /* no stale lock */ }
-      }
-      const proxyPort = await cdpMultiplexer.start(preferredProxyPort);
-      const devtoolsUrl = cdpMultiplexer.getDevToolsUrl();
-      logger.info(`CDP proxy started on port ${proxyPort}`);
-      if (devtoolsUrl) {
-        logger.info(`Chrome DevTools URL: ${devtoolsUrl}`);
-      }
-      // Make proxy info available to plugins via config
-      (config as Record<string, unknown>).proxy = {
-        ...config.proxy,
-        port: proxyPort,
-        url: devtoolsUrl,
-      };
-    } catch (err) {
-      logger.warn('Could not start CDP proxy:', err);
-    }
+      const stale = JSON.parse(fs.readFileSync(PROXY_LOCK_FILE, 'utf8'));
+      if (stale.port) preferredProxyPort = stale.port;
+    } catch { /* no stale lock */ }
   }
 
   // Start MCP transport

--- a/src/server.ts
+++ b/src/server.ts
@@ -406,18 +406,13 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       activeDeviceName = target.title || target.deviceName || target.id;
 
       if (supportsMultipleDebuggers(target)) {
-        // RN 0.85+: Metro handles multiple concurrent debugger sessions natively.
-        // No CDPMultiplexer or singleton proxy lock needed — other tools (Chrome
-        // DevTools, other metro-mcp instances) can connect to Metro directly.
         logger.info('Target supports multiple debuggers (RN 0.85+) — skipping CDP proxy');
       } else {
-        // RN <0.85: only one debugger at a time. Start the proxy once and write the
-        // singleton lock so other metro-mcp instances piggyback on it.
-        if (!proxyStarted && config.proxy?.enabled !== false) {
-          cdpMultiplexer = new CDPMultiplexer(cdpSession, { protectedDomains: ['Runtime', 'Network'] });
+        if (!cdpMultiplexer && config.proxy?.enabled !== false) {
+          const mux = new CDPMultiplexer(cdpSession, { protectedDomains: ['Runtime', 'Network'] });
           try {
-            const startedPort = await cdpMultiplexer.start(preferredProxyPort);
-            const devtoolsUrl = cdpMultiplexer.getDevToolsUrl();
+            const startedPort = await mux.start(preferredProxyPort);
+            const devtoolsUrl = mux.getDevToolsUrl();
             logger.info(`CDP proxy started on port ${startedPort}`);
             if (devtoolsUrl) logger.info(`Chrome DevTools URL: ${devtoolsUrl}`);
             (config as Record<string, unknown>).proxy = {
@@ -425,7 +420,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
               port: startedPort,
               url: devtoolsUrl,
             };
-            proxyStarted = true;
+            cdpMultiplexer = mux;
           } catch (err) {
             logger.warn('Could not start CDP proxy:', err);
           }
@@ -473,7 +468,6 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   // CDP proxy for Chrome DevTools coexistence — started lazily on first connect
   // only when the target does not support multiple debuggers natively (RN <0.85).
   let cdpMultiplexer: CDPMultiplexer | null = null;
-  let proxyStarted = false;
 
   // Read preferred proxy port once at startup (stale lock reuse / explicit config).
   let preferredProxyPort = config.proxy?.port ?? 0;


### PR DESCRIPTION
RN 0.85+ now supports multiple debuggers connected simultaneously. This is supported upstream in `metro-bridge`.

This PR removes multiplexing when the app supports multiple debuggers.