### PR TITLE
Add MCP spec features: tool annotations, progress notifications, resource subscriptions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "^0.2.0",
+        "metro-bridge": "^0.2.3",
         "ws": "^8.20.0",
         "zod": "^3.24.4",
       },
@@ -419,7 +419,7 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
-    "metro-bridge": ["metro-bridge@0.2.0", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-KVF/N6DyD5vqD5CMaKLHPjb2Sr8/ecN6IUKPrM4aikoELd53z24Ggib9VQe3ysaOVxCHuVqup9Ihvd3PQJ0pbA=="],
+    "metro-bridge": ["metro-bridge@0.2.3", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-OFXQ98UFROQ+7JfDyu3fb6MkBWIQ5z44Gd4eRZiKDttrdZXm/oQxIFvrrdu/1qmiULFmbMdjl5XWC9gnN+USZA=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",
@@ -62,7 +62,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.2.2",
+    "metro-bridge": "^0.2.3",
     "ws": "^8.20.0",
     "zod": "^3.24.4"
   },

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -32,10 +32,29 @@ export interface ComponentNode {
 
 // ── Tool / Resource / Prompt Registration ──
 
+export interface ToolAnnotations {
+  /** Human-readable name for display in client UIs */
+  title?: string;
+  /** If true, the tool does not modify any state (safe to auto-approve) */
+  readOnlyHint?: boolean;
+  /** If true, the tool may perform irreversible or destructive actions */
+  destructiveHint?: boolean;
+  /** If true, calling with identical arguments multiple times has no additional effect */
+  idempotentHint?: boolean;
+  /** If true, the tool may interact with external systems beyond the local environment */
+  openWorldHint?: boolean;
+}
+
+export interface ToolHandlerContext {
+  /** Send a progress notification to the client (only if client provided a progressToken) */
+  sendProgress?: (progress: number, total: number, message?: string) => Promise<void>;
+}
+
 export interface ToolConfig<T extends z.ZodType = z.ZodType> {
   description: string;
   parameters: T;
-  handler: (args: z.infer<T>) => Promise<unknown>;
+  annotations?: ToolAnnotations;
+  handler: (args: z.infer<T>, ctx: ToolHandlerContext) => Promise<unknown>;
 }
 
 export interface ResourceConfig {
@@ -43,6 +62,10 @@ export interface ResourceConfig {
   description: string;
   mimeType?: string;
   handler: () => Promise<string>;
+  /** Called when a client subscribes to this resource URI */
+  onSubscribe?: (uri: string) => void;
+  /** Called when a client unsubscribes from this resource URI */
+  onUnsubscribe?: (uri: string) => void;
 }
 
 export interface PromptConfig {
@@ -101,6 +124,8 @@ export interface PluginContext {
   getActiveDeviceKey(): string | null;
   /** Returns a human-readable name for the active device, or null if not connected. */
   getActiveDeviceName(): string | null;
+  /** Notify subscribed clients that a resource's content has changed */
+  notifyResourceUpdated(uri: string): void;
 }
 
 // ── Logger ──

--- a/src/plugins/accessibility.ts
+++ b/src/plugins/accessibility.ts
@@ -141,6 +141,7 @@ export const accessibilityPlugin = definePlugin({
     ctx.registerTool('audit_accessibility', {
       description:
         'Run a full accessibility audit on the current screen. Checks for missing labels, roles, testIDs, alt text, and more.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         severity: z.enum(['all', 'error', 'warning', 'info']).default('all').describe('Filter by severity level'),
       }),
@@ -164,6 +165,7 @@ export const accessibilityPlugin = definePlugin({
 
     ctx.registerTool('check_element_accessibility', {
       description: 'Check accessibility properties of a specific component by name or testID.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         name: z.string().optional().describe('Component name to check'),
         testID: z.string().optional().describe('testID to find'),
@@ -217,6 +219,7 @@ export const accessibilityPlugin = definePlugin({
 
     ctx.registerTool('get_accessibility_summary', {
       description: 'Quick overview: counts of elements with and without proper accessibility props.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const expr = `

--- a/src/plugins/automation.ts
+++ b/src/plugins/automation.ts
@@ -21,6 +21,7 @@ export const automationPlugin = definePlugin({
         'Poll the component tree until an element matching the given testID or accessibilityLabel appears. ' +
         'Returns element info on success. Use after tap_element, navigate(), or any action that triggers ' +
         'async screen transitions or data loading — instead of immediately calling the next tool.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         selector: z.string().describe('testID or accessibilityLabel to wait for'),
         timeout: z.number().int().min(100).max(60000).default(10000)
@@ -28,7 +29,7 @@ export const automationPlugin = definePlugin({
         pollInterval: z.number().int().min(100).max(5000).default(500)
           .describe('How often to check in milliseconds (default 500)'),
       }),
-      handler: async ({ selector, timeout, pollInterval }) => {
+      handler: async ({ selector, timeout, pollInterval }, { sendProgress }) => {
         const start = Date.now();
         while (Date.now() - start < timeout) {
           try {
@@ -42,6 +43,7 @@ export const automationPlugin = definePlugin({
           } catch {
             // CDP may not be ready yet — keep polling
           }
+          await sendProgress?.(Date.now() - start, timeout, `Waiting for "${selector}"…`);
           await new Promise<void>((r) => setTimeout(r, pollInterval));
         }
         throw new Error(
@@ -56,6 +58,7 @@ export const automationPlugin = definePlugin({
         'Poll a JavaScript expression in the app until it returns a truthy value, then return that value. ' +
         'Useful for waiting on state changes, loading flags, API responses, or any async condition. ' +
         'Example: wait for globalThis.myStore?.isLoaded === true.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         expression: z.string()
           .describe('JS expression to evaluate; polling stops when it returns truthy'),
@@ -64,7 +67,7 @@ export const automationPlugin = definePlugin({
         pollInterval: z.number().int().min(100).max(5000).default(500)
           .describe('How often to check in milliseconds (default 500)'),
       }),
-      handler: async ({ expression, timeout, pollInterval }) => {
+      handler: async ({ expression, timeout, pollInterval }, { sendProgress }) => {
         const start = Date.now();
         while (Date.now() - start < timeout) {
           try {
@@ -75,6 +78,7 @@ export const automationPlugin = definePlugin({
           } catch {
             // keep polling
           }
+          await sendProgress?.(Date.now() - start, timeout, 'Waiting for condition…');
           await new Promise<void>((r) => setTimeout(r, pollInterval));
         }
         throw new Error(
@@ -88,13 +92,14 @@ export const automationPlugin = definePlugin({
         'Poll the active navigation route until it matches the expected route name, then return. ' +
         'Requires the navigation plugin to be set up (get_current_route must work). ' +
         'Use after tap_element on a link or after dispatching a navigate() action.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         routeName: z.string()
           .describe('Expected route name to wait for (e.g. "HomeScreen", "ProfileTab")'),
         timeout: z.number().int().min(100).max(60000).default(10000)
           .describe('Maximum wait time in milliseconds (default 10000)'),
       }),
-      handler: async ({ routeName, timeout }) => {
+      handler: async ({ routeName, timeout }, { sendProgress }) => {
         const start = Date.now();
         const pollInterval = 300;
         while (Date.now() - start < timeout) {
@@ -106,6 +111,7 @@ export const automationPlugin = definePlugin({
           } catch {
             // keep polling
           }
+          await sendProgress?.(Date.now() - start, timeout, `Waiting for route "${routeName}"…`);
           await new Promise<void>((r) => setTimeout(r, pollInterval));
         }
         throw new Error(

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -22,6 +22,7 @@ export const commandsPlugin = definePlugin({
     ctx.registerTool('list_commands', {
       description:
         'List all custom commands registered by the app. Commands are registered on global.__METRO_BRIDGE__.commands or global.__METRO_BRIDGE_COMMANDS__.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const result = await ctx.evalInApp(`
@@ -43,6 +44,7 @@ export const commandsPlugin = definePlugin({
     ctx.registerTool('run_command', {
       description:
         'Execute a custom command registered by the app. Pass parameters as a JSON object.',
+      annotations: { destructiveHint: true, openWorldHint: true },
       parameters: z.object({
         name: z.string().describe('Command name to execute'),
         params: z.record(z.unknown()).optional().describe('Parameters to pass to the command'),

--- a/src/plugins/components.ts
+++ b/src/plugins/components.ts
@@ -99,6 +99,7 @@ export const componentsPlugin = definePlugin({
     ctx.registerTool('get_component_tree', {
       description:
         'Get the React component tree of the running app. Use structureOnly=true for a compact view (~1-3KB).',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         structureOnly: z.boolean().default(false).describe('Return only component names without props/state'),
         maxDepth: z.number().default(30).describe('Maximum depth to traverse'),
@@ -116,6 +117,7 @@ export const componentsPlugin = definePlugin({
 
     ctx.registerTool('find_components', {
       description: 'Search for components by name pattern in the React tree.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         pattern: z.string().describe('Component name or pattern to search for'),
         includeProps: z.boolean().default(true).describe('Include component props in results'),
@@ -153,6 +155,7 @@ export const componentsPlugin = definePlugin({
 
     ctx.registerTool('inspect_component', {
       description: 'Get detailed props, state, and hooks info for a specific component.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         name: z.string().describe('Exact component name to inspect'),
       }),
@@ -236,6 +239,7 @@ export const componentsPlugin = definePlugin({
     ctx.registerTool('get_testable_elements', {
       description:
         'Get all elements with testID or accessibilityLabel — useful for test generation.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const options = JSON.stringify({

--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -140,6 +140,7 @@ export const consolePlugin = definePlugin({
           : undefined,
       };
       buffers.getOrCreate(key).push(entry);
+      ctx.notifyResourceUpdated('metro://logs');
 
       // ObjectIds are short-lived, so resolve promptly after the log event.
       const hasResolvable = args.some(
@@ -181,6 +182,7 @@ export const consolePlugin = definePlugin({
 
     ctx.registerTool('get_console_logs', {
       description: 'Get recent console output from the React Native app. Filter by log level and search text.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         level: z.enum(['log', 'warn', 'error', 'info', 'debug']).optional().describe('Filter by log level'),
         search: z.string().optional().describe('Search text to filter logs'),
@@ -216,6 +218,7 @@ export const consolePlugin = definePlugin({
 
     ctx.registerTool('clear_console_logs', {
       description: 'Clear the console log buffer.',
+      annotations: { destructiveHint: true, idempotentHint: true },
       parameters: z.object({
         device: z.string().optional().describe('Device key to clear, or omit for current device. Use "all" to clear all.'),
       }),

--- a/src/plugins/debug-globals.ts
+++ b/src/plugins/debug-globals.ts
@@ -19,6 +19,7 @@ export const debugGlobalsPlugin = definePlugin({
     ctx.registerTool('list_debug_globals', {
       description:
         'Auto-discover well-known global debugging objects (Redux stores, Apollo Client, Expo Router, React DevTools hook, etc.) available in the app runtime.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         detailed: z.boolean().default(false).describe('Include top-level keys for each discovered global'),
       }),

--- a/src/plugins/deeplink.ts
+++ b/src/plugins/deeplink.ts
@@ -21,6 +21,7 @@ export const deeplinkPlugin = definePlugin({
 
     ctx.registerTool('open_deeplink', {
       description: 'Open a URL or deep link on the connected iOS simulator or Android device.',
+      annotations: { openWorldHint: true },
       parameters: z.object({
         url: z.string().describe('URL or deep link to open (e.g., "myapp://screen/details" or "https://example.com/path")'),
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
@@ -42,6 +43,7 @@ export const deeplinkPlugin = definePlugin({
 
     ctx.registerTool('list_url_schemes', {
       description: 'List URL schemes registered by the app (attempts to detect from the running app).',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         bundleId: z.string().optional().describe('Bundle ID to check (auto-detected if not provided)'),
       }),

--- a/src/plugins/device.ts
+++ b/src/plugins/device.ts
@@ -10,6 +10,7 @@ export const devicePlugin = definePlugin({
   async setup(ctx) {
     ctx.registerTool('list_devices', {
       description: 'List connected devices and debuggable targets from Metro bundler.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         rescan: z.boolean().default(false).describe('Rescan all Metro ports'),
       }),
@@ -46,6 +47,7 @@ export const devicePlugin = definePlugin({
 
     ctx.registerTool('get_app_info', {
       description: 'Get information about the connected React Native app (bundle URL, platform, device name).',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         if (!ctx.cdp.isConnected) {
@@ -68,6 +70,7 @@ export const devicePlugin = definePlugin({
 
     ctx.registerTool('get_connection_status', {
       description: 'Check the connection status to Metro bundler.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const config = ctx.config as Record<string, Record<string, unknown>>;
@@ -86,6 +89,7 @@ export const devicePlugin = definePlugin({
 
     ctx.registerTool('reload_app', {
       description: 'Reload the React Native app. Tries the Metro HTTP endpoint first, falls back to CDP evaluation.',
+      annotations: { idempotentHint: true },
       parameters: z.object({}),
       handler: async () => {
         // Try Metro HTTP reload endpoint first (most reliable)

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -86,6 +86,7 @@ export const devtoolsPlugin = definePlugin({
         'On RN 0.85+ connects directly to Metro (no proxy needed). ' +
         'On older RN versions connects through the CDP proxy so both ' +
         'DevTools and the MCP can share the single Hermes connection.',
+      annotations: { openWorldHint: true },
       parameters: z.object({
         open: z.boolean().default(true).describe('Attempt to open the browser automatically'),
       }),

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -123,7 +123,10 @@ export const errorsPlugin = definePlugin({
       }
 
       const key = ctx.getActiveDeviceKey();
-      if (key) buffers.getOrCreate(key).push(entry);
+      if (key) {
+        buffers.getOrCreate(key).push(entry);
+        ctx.notifyResourceUpdated('metro://errors');
+      }
     });
 
     function getErrors(device?: string): ErrorEntry[] {
@@ -132,6 +135,7 @@ export const errorsPlugin = definePlugin({
 
     ctx.registerTool('get_errors', {
       description: 'Get recent uncaught exceptions and errors from the React Native app.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         limit: z.number().default(20).describe('Maximum number of errors to return'),
         summary: z.boolean().default(false).describe('Return summary with counts'),
@@ -155,6 +159,7 @@ export const errorsPlugin = definePlugin({
 
     ctx.registerTool('clear_errors', {
       description: 'Clear the error buffer.',
+      annotations: { destructiveHint: true, idempotentHint: true },
       parameters: z.object({
         device: z.string().optional().describe('Device key to clear, or omit for current device. Use "all" to clear all.'),
       }),
@@ -170,6 +175,7 @@ export const errorsPlugin = definePlugin({
 
     ctx.registerTool('get_bundle_errors', {
       description: 'Get recent Metro compilation/transform errors.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         limit: z.number().default(20).describe('Maximum errors to return'),
       }),

--- a/src/plugins/evaluate.ts
+++ b/src/plugins/evaluate.ts
@@ -10,6 +10,7 @@ export const evaluatePlugin = definePlugin({
     ctx.registerTool('evaluate_js', {
       description:
         'Execute a JavaScript expression in the running React Native app and return the result. Use this for inspecting variables, calling functions, or querying app state.',
+      annotations: { destructiveHint: true },
       parameters: z.object({
         expression: z.string().describe('JavaScript expression to evaluate'),
         awaitPromise: z.boolean().default(true).describe('Wait for promise to resolve if expression returns a promise'),

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -13,6 +13,7 @@ export const inspectPointPlugin = definePlugin({
         'Inspect the React component rendered at specific screen coordinates. ' +
         'Walks the React fiber tree to find the component whose layout contains the given point. ' +
         'Experimental: layout measurement varies between Old and New Architecture.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         x: z.number().describe('X coordinate (points/dp)'),
         y: z.number().describe('Y coordinate (points/dp)'),

--- a/src/plugins/navigation.ts
+++ b/src/plugins/navigation.ts
@@ -69,6 +69,7 @@ export const navigationPlugin = definePlugin({
     ctx.registerTool('get_navigation_state', {
       description:
         'Get the full React Navigation / Expo Router state tree including current route, params, and stack history.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         compact: z.boolean().default(false).describe('Return compact format'),
       }),
@@ -95,6 +96,7 @@ export const navigationPlugin = definePlugin({
 
     ctx.registerTool('get_current_route', {
       description: 'Get the currently focused route name and params.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
@@ -107,6 +109,7 @@ export const navigationPlugin = definePlugin({
 
     ctx.registerTool('get_route_history', {
       description: 'Get the navigation back stack / history.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
@@ -127,6 +130,7 @@ export const navigationPlugin = definePlugin({
 
     ctx.registerTool('list_routes', {
       description: 'List all registered route names in the app.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -121,6 +121,7 @@ export const networkPlugin = definePlugin({
         req.size = params.encodedDataLength as number;
         pendingRequests.delete(req.id);
         getDeviceBuffer()?.push(req);
+        ctx.notifyResourceUpdated('metro://network');
         fetchAndCacheBody(req);
       }
     });
@@ -132,6 +133,7 @@ export const networkPlugin = definePlugin({
         req.error = params.errorText as string;
         pendingRequests.delete(req.id);
         getDeviceBuffer()?.push(req);
+        ctx.notifyResourceUpdated('metro://network');
       }
     });
 
@@ -158,6 +160,7 @@ export const networkPlugin = definePlugin({
 
     ctx.registerTool('get_network_requests', {
       description: 'Get recent network requests from the React Native app.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         limit: z.number().default(50).describe('Maximum number of requests to return'),
         summary: z.boolean().default(false).describe('Return summary with counts'),
@@ -201,6 +204,7 @@ export const networkPlugin = definePlugin({
 
     ctx.registerTool('get_request_details', {
       description: 'Get full details of a specific network request including headers and body.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         url: z.string().describe('URL or partial URL to find the request'),
         index: z.number().default(-1).describe('Index of the request if multiple match (-1 for last)'),
@@ -220,6 +224,7 @@ export const networkPlugin = definePlugin({
         'Get the response body for a specific network request. ' +
         'Bodies are eagerly cached when small enough, so they survive reconnections. ' +
         'Larger bodies are fetched on demand and only available in the current CDP session.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         url: z.string().describe('URL or partial URL to find the request'),
         index: z.number().default(-1).describe('Index of the request if multiple match (-1 for last)'),
@@ -263,6 +268,7 @@ export const networkPlugin = definePlugin({
 
     ctx.registerTool('search_network', {
       description: 'Search network requests by URL pattern, method, or status code.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         urlPattern: z.string().optional().describe('URL substring or regex pattern'),
         method: z.string().optional().describe('HTTP method filter'),
@@ -291,6 +297,7 @@ export const networkPlugin = definePlugin({
 
     ctx.registerTool('clear_network_requests', {
       description: 'Clear the network request buffer. Useful after a reload or when old requests are no longer relevant.',
+      annotations: { destructiveHint: true, idempotentHint: true },
       parameters: z.object({
         device: z.string().optional().describe('Device key to clear, or omit for current device. Use "all" to clear all.'),
       }),
@@ -308,6 +315,7 @@ export const networkPlugin = definePlugin({
 
     ctx.registerTool('get_network_stats', {
       description: 'Get aggregated network statistics: breakdown by domain, status code, and response times.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         device: z.string().optional().describe('Device key or "all". Defaults to current device.'),
       }),

--- a/src/plugins/profiler.ts
+++ b/src/plugins/profiler.ts
@@ -453,6 +453,7 @@ export const profilerPlugin = definePlugin({
         'captures all component render durations without requiring <Profiler> wrappers, works on all architectures. ' +
         'Fallback (legacy arch only): CDP Profiler domain for JS CPU call-graph sampling. ' +
         'Perform the interaction you want to measure, then call stop_profiling.',
+      annotations: { destructiveHint: false, idempotentHint: false },
       parameters: z.object({
         samplingInterval: z
           .number().int().min(100).max(100_000).default(1_000)
@@ -514,6 +515,7 @@ export const profilerPlugin = definePlugin({
         'DevTools hook mode: returns top components by total render duration across all commits. ' +
         'CDP mode: returns top JS functions by self time and total time. ' +
         'Must call start_profiling first.',
+      annotations: { readOnlyHint: false, idempotentHint: false },
       parameters: z.object({
         topN: z.number().int().min(1).max(100).default(20)
           .describe('Number of top entries to return.'),
@@ -600,6 +602,7 @@ export const profilerPlugin = definePlugin({
 
     ctx.registerTool('get_profile_status', {
       description: 'Check whether profiling is active, which mode is in use, and whether a previous profile is available.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => ({
         isProfiling: profilingMode !== null,
@@ -618,6 +621,7 @@ export const profilerPlugin = definePlugin({
         'Shows React DevTools component profile (if captured), CPU flamegraph (if CDP profile captured), ' +
         'and React render data from <Profiler> components (if set up). ' +
         'Call stop_profiling first to populate the profile data.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: buildFlamegraphText,
     });
@@ -627,6 +631,7 @@ export const profilerPlugin = definePlugin({
         'Read React render timing data collected via <Profiler onRender={trackRender}>. ' +
         'Returns all recorded renders sorted by actualDuration descending, with memoization savings from baseDuration. ' +
         'Requires importing trackRender from metro-mcp/client. Use clear=true to reset the buffer.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         clear: z.boolean().default(false).describe('Clear the render buffer after reading.'),
       }),
@@ -653,6 +658,7 @@ export const profilerPlugin = definePlugin({
         'Get current JavaScript heap memory usage from the running app. ' +
         'Returns used heap, total heap, and heap size limit (when available). ' +
         'Call repeatedly to track memory growth over time or to detect leaks.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const result = (await ctx.evalInApp(`(function() {
@@ -695,6 +701,7 @@ export const profilerPlugin = definePlugin({
         'Starts profiling, evaluates the expression, waits for it to complete (plus optional extra duration), ' +
         'then stops and returns the top functions by self time. ' +
         'Use instead of calling start_profiling / stop_profiling manually for focused measurements.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         expression: z.string()
           .describe('JavaScript expression to profile (can be an async IIFE)'),
@@ -703,12 +710,13 @@ export const profilerPlugin = definePlugin({
         topN: z.number().int().min(1).max(50).default(15)
           .describe('Number of top functions to return'),
       }),
-      handler: async ({ expression, extraMs, topN }) => {
+      handler: async ({ expression, extraMs, topN }, { sendProgress }) => {
         if (profilingMode !== null) {
           return 'A profiling session is already active. Call stop_profiling first.';
         }
 
         // Start
+        await sendProgress?.(0, 3, 'Starting profiler…');
         let startedMode: ProfilingMode = null;
         try {
           const r = (await ctx.evalInApp(DEVTOOLS_START_EXPR)) as { ok?: boolean; method?: string } | null;
@@ -731,6 +739,7 @@ export const profilerPlugin = definePlugin({
         profilingMode = startedMode;
 
         // Evaluate expression
+        await sendProgress?.(1, 3, 'Evaluating expression…');
         try {
           await ctx.evalInApp(expression, { awaitPromise: true, timeout: 30000 });
         } catch (err) {
@@ -742,6 +751,7 @@ export const profilerPlugin = definePlugin({
         if (extraMs > 0) {
           await new Promise<void>((r) => setTimeout(r, extraMs));
         }
+        await sendProgress?.(2, 3, 'Analysing profile…');
 
         // Stop — reuse stop_profiling logic inline
         try {
@@ -796,6 +806,7 @@ export const profilerPlugin = definePlugin({
         'Start Hermes heap allocation sampling via CDP HeapProfiler. ' +
         'Records memory allocation call stacks to identify where objects are being allocated. ' +
         'Call stop_heap_sampling to retrieve the top allocation sites.',
+      annotations: { destructiveHint: false, idempotentHint: false },
       parameters: z.object({
         samplingInterval: z.number().int().min(128).max(1048576).default(32768)
           .describe('Average bytes between samples (default 32768). Lower = more detail, higher overhead.'),
@@ -816,6 +827,7 @@ export const profilerPlugin = definePlugin({
         'Stop heap allocation sampling and return the top allocation sites. ' +
         'Shows which functions are allocating the most memory, useful for diagnosing memory leaks. ' +
         'Must call start_heap_sampling first.',
+      annotations: { readOnlyHint: false, idempotentHint: false },
       parameters: z.object({
         topN: z.number().int().min(1).max(100).default(20)
           .describe('Number of top allocation sites to return'),

--- a/src/plugins/redux.ts
+++ b/src/plugins/redux.ts
@@ -10,6 +10,7 @@ export const reduxPlugin = definePlugin({
     ctx.registerTool('get_redux_state', {
       description:
         'Get the current Redux state tree or a specific slice. Works without client SDK if Redux DevTools extension is present or store is exposed globally.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         path: z.string().optional().describe('Dot-separated path to a state slice (e.g., "user.profile")'),
         compact: z.boolean().default(false).describe('Return compact format'),
@@ -62,6 +63,7 @@ export const reduxPlugin = definePlugin({
 
     ctx.registerTool('dispatch_redux_action', {
       description: 'Dispatch a Redux action to the store.',
+      annotations: { openWorldHint: false },
       parameters: z.object({
         type: z.string().describe('Action type'),
         payload: z.unknown().optional().describe('Action payload'),
@@ -86,6 +88,7 @@ export const reduxPlugin = definePlugin({
 
     ctx.registerTool('get_redux_actions', {
       description: 'Get recent Redux actions (requires metro-mcp client SDK for real-time tracking).',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         limit: z.number().default(20).describe('Maximum actions to return'),
       }),

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -23,6 +23,7 @@ export const simulatorPlugin = definePlugin({
 
     ctx.registerTool('take_screenshot', {
       description: 'Capture a screenshot from the connected iOS simulator or Android device.',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
       }),
@@ -56,6 +57,7 @@ export const simulatorPlugin = definePlugin({
 
     ctx.registerTool('list_simulators', {
       description: 'List available iOS simulators or Android emulators.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'both']).default('both'),
         bootedOnly: z.boolean().default(false).describe('Show only booted/running devices'),
@@ -111,6 +113,7 @@ export const simulatorPlugin = definePlugin({
 
     ctx.registerTool('install_certificate', {
       description: 'Install a root certificate on the iOS simulator or Android device.',
+      annotations: { destructiveHint: true, openWorldHint: true },
       parameters: z.object({
         certPath: z.string().describe('Path to the certificate file'),
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
@@ -131,6 +134,7 @@ export const simulatorPlugin = definePlugin({
 
     ctx.registerTool('get_native_logs', {
       description: 'Get native platform logs from iOS simulator (syslog) or Android device (logcat).',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
         filter: z.string().optional().describe('Filter string (process name for iOS, tag for Android)'),
@@ -164,6 +168,7 @@ export const simulatorPlugin = definePlugin({
 
     ctx.registerTool('app_lifecycle', {
       description: 'Launch, terminate, install, or uninstall an app on the simulator/emulator.',
+      annotations: { destructiveHint: true },
       parameters: z.object({
         action: z.enum(['launch', 'terminate', 'install', 'uninstall']).describe('Action to perform'),
         bundleId: z.string().describe('App bundle identifier (e.g., com.example.app)'),
@@ -199,6 +204,7 @@ export const simulatorPlugin = definePlugin({
 
     ctx.registerTool('get_screen_orientation', {
       description: 'Get the current screen orientation of the device.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),

--- a/src/plugins/source.ts
+++ b/src/plugins/source.ts
@@ -10,6 +10,7 @@ export const sourcePlugin = definePlugin({
     ctx.registerTool('symbolicate', {
       description:
         'Symbolicate a stack trace using Metro bundler source maps. Converts minified/bundled locations back to original source files.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         stack: z
           .array(

--- a/src/plugins/statusline.ts
+++ b/src/plugins/statusline.ts
@@ -84,6 +84,7 @@ export const statuslinePlugin = definePlugin({
         'Does not modify settings.json — tell the user to add it to their status line themselves ' +
         '(e.g. ask Claude: "/statusline add the script at ~/.claude/metro-mcp-statusline.sh"). ' +
         'Only works with Claude Code.',
+      annotations: { idempotentHint: true },
       parameters: z.object({}),
       handler: async () => {
         mkdirSync(CLAUDE_DIR, { recursive: true });

--- a/src/plugins/storage.ts
+++ b/src/plugins/storage.ts
@@ -10,6 +10,7 @@ export const storagePlugin = definePlugin({
   async setup(ctx) {
     ctx.registerTool('get_storage_keys', {
       description: 'List all AsyncStorage keys in the React Native app.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         const result = await ctx.evalInApp(`
@@ -31,6 +32,7 @@ export const storagePlugin = definePlugin({
 
     ctx.registerTool('get_storage_item', {
       description: 'Read a specific AsyncStorage key value.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         key: z.string().describe('AsyncStorage key to read'),
       }),
@@ -56,6 +58,7 @@ export const storagePlugin = definePlugin({
 
     ctx.registerTool('get_all_storage', {
       description: 'Dump all AsyncStorage key-value pairs.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         maxLength: z.number().default(500).describe('Max length for each value'),
       }),

--- a/src/plugins/test-recorder.ts
+++ b/src/plugins/test-recorder.ts
@@ -307,6 +307,7 @@ export const testRecorderPlugin = definePlugin({
         'with no changes to your app code. Works with ScrollView, FlatList, SectionList, ' +
         'FlashList, and other scroll containers. ' +
         'Call stop_test_recording when done, then generate_test_from_recording to get the test.',
+      annotations: { destructiveHint: false, idempotentHint: false },
       parameters: z.object({}),
       handler: async () => {
         storedEvents = null;
@@ -341,6 +342,7 @@ export const testRecorderPlugin = definePlugin({
         'Stop the active recording, retrieve all captured events, and store them for test generation. ' +
         'Returns a summary of what was recorded. ' +
         'Call generate_test_from_recording next to produce Appium, Maestro, or Detox test code.',
+      annotations: { readOnlyHint: false, idempotentHint: false },
       parameters: z.object({}),
       handler: async () => {
         // Cleanup injection
@@ -381,6 +383,7 @@ export const testRecorderPlugin = definePlugin({
         'Convert the most recent recording into a test file. ' +
         'Supports three formats: appium (WebdriverIO + Jest), maestro (YAML), and detox (Jest). ' +
         'Call stop_test_recording first.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         format: z.enum(['appium', 'maestro', 'detox']).describe('Output format'),
         testName: z.string().optional().describe('Name for the test / describe block'),
@@ -418,6 +421,7 @@ export const testRecorderPlugin = definePlugin({
     ctx.registerTool('generate_wdio_config', {
       description:
         'Generate a minimal but runnable wdio.conf.ts for Appium + React Native testing, along with the npm install command.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'both']).default('ios'),
         bundleId: z.string().optional().describe('iOS bundle ID or Android app package'),
@@ -510,6 +514,7 @@ export const testRecorderPlugin = definePlugin({
         'Add a human-readable annotation (comment marker) to the current recording. ' +
         'Useful for labelling major flow checkpoints like "reached checkout", "error appeared here", ' +
         '"navigated to payment". Annotations appear as code comments in generated tests.',
+      annotations: { destructiveHint: false },
       parameters: z.object({
         note: z.string().describe('Annotation text to embed in the recording'),
       }),
@@ -536,6 +541,7 @@ export const testRecorderPlugin = definePlugin({
         'Save the current recording events to disk as JSON so they can be reloaded later. ' +
         'Useful for regenerating the same flow in a different test format without re-recording. ' +
         'Files are saved to ~/.metro-mcp/recordings/<filename>.json.',
+      annotations: { destructiveHint: false, idempotentHint: true },
       parameters: z.object({
         filename: z.string().describe('Name for the saved recording (without .json extension)'),
       }),
@@ -560,6 +566,7 @@ export const testRecorderPlugin = definePlugin({
         'Load a previously saved recording from disk and make it available for test generation. ' +
         'After loading, call generate_test_from_recording with any format to regenerate the test. ' +
         'Use list_test_recordings to see available files.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         filename: z.string().describe('Name of the saved recording (without .json extension)'),
       }),
@@ -593,6 +600,7 @@ export const testRecorderPlugin = definePlugin({
       description:
         'List all previously saved test recordings in ~/.metro-mcp/recordings/. ' +
         'Returns filenames and sizes. Use load_test_recording to load one for test generation.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         let entries: { name: string }[];

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -48,6 +48,7 @@ export const uiInteractPlugin = definePlugin({
     ctx.registerTool('list_elements', {
       description:
         'Get interactive elements from the current screen via the React component tree. Returns labels, testIDs, and roles — use label or testID with tap_element.',
+      annotations: { readOnlyHint: true },
       parameters: z.object({
         interactiveOnly: z.boolean().default(false).describe('Return only elements with onPress handlers'),
       }),
@@ -122,6 +123,7 @@ export const uiInteractPlugin = definePlugin({
     ctx.registerTool('tap_element', {
       description:
         'Tap an element by label, testID, or coordinates. Uses CDP fiber tree, then simctl/adb, then IDB.',
+      annotations: { destructiveHint: false },
       parameters: z.object({
         label: z.string().optional().describe('Accessibility label, aria-label, or testID to tap'),
         x: z.number().optional().describe('X coordinate'),
@@ -211,6 +213,7 @@ export const uiInteractPlugin = definePlugin({
     ctx.registerTool('type_text', {
       description:
         'Type text into an input field. Targets a specific input by testID/label, or the first visible TextInput. Uses CDP fiber tree, then adb/IDB.',
+      annotations: { destructiveHint: false },
       parameters: z.object({
         text: z.string().describe('Text to type'),
         testID: z
@@ -289,6 +292,7 @@ export const uiInteractPlugin = definePlugin({
     ctx.registerTool('long_press', {
       description:
         'Long press an element by label/testID, or at coordinates. Uses CDP fiber tree, then adb/IDB.',
+      annotations: { destructiveHint: false },
       parameters: z.object({
         label: z.string().optional().describe('Accessibility label or testID of the element to long press'),
         x: z.number().optional().describe('X coordinate'),
@@ -335,6 +339,7 @@ export const uiInteractPlugin = definePlugin({
     ctx.registerTool('swipe', {
       description:
         'Swipe or scroll in a direction. Tries CDP ScrollView scrollTo, then adb/IDB.',
+      annotations: { destructiveHint: false },
       parameters: z.object({
         direction: z.enum(['up', 'down', 'left', 'right']).describe('Swipe direction'),
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
@@ -425,6 +430,7 @@ export const uiInteractPlugin = definePlugin({
 
     ctx.registerTool('press_button', {
       description: 'Press a device button (HOME, BACK, VOLUME_UP, etc.).',
+      annotations: { destructiveHint: false },
       parameters: z.object({
         button: z
           .enum(['HOME', 'BACK', 'VOLUME_UP', 'VOLUME_DOWN', 'POWER', 'ENTER', 'DELETE'])

--- a/src/server.ts
+++ b/src/server.ts
@@ -250,6 +250,9 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
               // A reconnect is already in flight — wait for it rather than starting another
               await waitForReconnect();
             } else {
+              // Reset the attempt counter so the background scheduler can resume
+              // after this tool-triggered reconnect, rather than staying capped out.
+              reconnectAttempts = 0;
               const connected = await cdpSession.waitForConnection();
               if (!connected) await connectToMetro();
             }
@@ -279,6 +282,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
             if (isReconnecting) {
               await waitForReconnect();
             } else {
+              reconnectAttempts = 0;
               await connectToMetro();
             }
             return await tryEval();

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import fs from 'fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SubscribeRequestSchema, UnsubscribeRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 const execAsync = promisify(exec);
 import { z } from 'zod';
@@ -91,6 +92,29 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   const eventsClient = new MetroEventsClient();
   const formatUtils = createFormatUtils();
 
+  // Track URIs that clients have subscribed to for live update notifications
+  const subscribedResources = new Set<string>();
+
+  // Wire up resource subscription handlers so clients can receive push notifications
+  // when resource content changes (e.g. new logs, errors, network requests).
+  mcpServer.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
+    subscribedResources.add(req.params.uri);
+    logger.debug(`Client subscribed to resource: ${req.params.uri}`);
+    return {};
+  });
+
+  mcpServer.server.setRequestHandler(UnsubscribeRequestSchema, async (req) => {
+    subscribedResources.delete(req.params.uri);
+    logger.debug(`Client unsubscribed from resource: ${req.params.uri}`);
+    return {};
+  });
+
+  function notifyResourceUpdated(uri: string): void {
+    if (subscribedResources.has(uri)) {
+      mcpServer.server.sendResourceUpdated({ uri }).catch(() => {});
+    }
+  }
+
   // Active device tracking — used by plugins to key per-device buffers.
   let activeDeviceKey: string | null = null;
   let activeDeviceName: string | null = null;
@@ -137,15 +161,31 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       events: eventsClient,
       registerTool: <T extends z.ZodType>(name: string, toolConfig: ToolConfig<T>) => {
         try {
-          mcpServer.tool(
+          const inputSchema = toolConfig.parameters instanceof z.ZodObject
+            ? (toolConfig.parameters as z.ZodObject<z.ZodRawShape>).shape
+            : { input: toolConfig.parameters };
+
+          mcpServer.registerTool(
             name,
-            toolConfig.description,
-            toolConfig.parameters instanceof z.ZodObject
-              ? (toolConfig.parameters as z.ZodObject<z.ZodRawShape>).shape
-              : { input: toolConfig.parameters },
-            async (args) => {
+            {
+              description: toolConfig.description,
+              inputSchema,
+              annotations: toolConfig.annotations,
+            },
+            async (args, extra) => {
+              // Build a sendProgress helper if the client sent a progressToken
+              const progressToken = extra._meta?.progressToken;
+              const sendProgress = progressToken !== undefined
+                ? async (progress: number, total: number, message?: string) => {
+                    await extra.sendNotification({
+                      method: 'notifications/progress',
+                      params: { progressToken, progress, total, ...(message ? { message } : {}) },
+                    } as Parameters<typeof extra.sendNotification>[0]);
+                  }
+                : undefined;
+
               try {
-                const result = await toolConfig.handler(args as z.infer<T>);
+                const result = await toolConfig.handler(args as z.infer<T>, { sendProgress });
                 const content = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
                 return { content: [{ type: 'text' as const, text: content }] };
               } catch (err) {
@@ -262,6 +302,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       format: formatUtils,
       getActiveDeviceKey: () => activeDeviceKey,
       getActiveDeviceName: () => activeDeviceName,
+      notifyResourceUpdated,
     };
   }
 


### PR DESCRIPTION
Three improvements based on the current MCP spec (2025-11-25):

**Tool Annotations** — All 73 tools now carry readOnlyHint, destructiveHint,
idempotentHint, and/or openWorldHint annotations. AI clients can use these to
auto-approve read-only tools, show confirmation dialogs for destructive ones,
and avoid retrying non-idempotent calls on failure.

**Progress Notifications** — Long-running tools now send notifications/progress
when the client provides a progressToken: profile_action reports start/evaluate/
analyse phases; wait_for_element, wait_for_condition, and wait_for_navigation
report elapsed/timeout on each poll cycle.

**Resource Subscriptions** — Clients can now send resources/subscribe to receive
notifications/resources/updated push events. console, errors, and network
resources emit updates in real time as CDP events arrive (Runtime.consoleAPICalled,
Runtime.exceptionThrown, Network.loadingFinished/Failed), enabling reactive
debugging without polling.

Also migrates tool registration from the deprecated tool() to registerTool() API
and wires ToolHandlerContext (sendProgress) + notifyResourceUpdated through the
plugin context interface.

https://claude.ai/code/session_01PTiYPmbUnydps3Z9UkqZ7K