### PR TITLE
Improve token efficiency of tool responses

### DIFF
--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { DeviceBufferManager } from '../utils/buffer.js';
-import { formatTimestamp } from '../utils/format.js';
+import { formatTime } from '../utils/format.js';
 
 interface LogEntry {
   timestamp: number;
@@ -89,7 +89,7 @@ async function resolveRemoteObject(
     const result = (await cdpSend('Runtime.callFunctionOn', {
       objectId,
       functionDeclaration:
-        'function() { try { return JSON.stringify(this, null, 2); } catch(e) { return "[unserializable]"; } }',
+        'function() { try { return JSON.stringify(this); } catch(e) { return "[unserializable]"; } }',
       returnByValue: true,
     })) as Record<string, unknown>;
     const inner = result.result as Record<string, unknown> | undefined;
@@ -181,20 +181,21 @@ export const consolePlugin = definePlugin({
     });
 
     ctx.registerTool('get_console_logs', {
-      description: 'Get recent console output from the React Native app. Filter by log level and search text.',
+      description: 'Get recent console output. Filter by level or search text.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         level: z.enum(['log', 'warn', 'error', 'info', 'debug']).optional().describe('Filter by log level'),
         search: z.string().optional().describe('Search text to filter logs'),
         limit: z.number().default(50).describe('Maximum number of logs to return'),
-        summary: z.boolean().default(false).describe('Return summary with counts + last few entries'),
-        compact: z.boolean().default(false).describe('Return compact single-line format'),
+        since: z.number().optional().describe('Only return entries after this Unix timestamp (ms). Pass the timestamp of the last seen entry to fetch only new ones.'),
+        summary: z.boolean().default(false).describe('Return a one-line summary with counts'),
         device: z.string().optional().describe('Device key or "all" for aggregated logs. Defaults to current device.'),
       }),
-      handler: async ({ level, search, limit, summary, compact: isCompact, device }) => {
+      handler: async ({ level, search, limit, since, summary, device }) => {
         let logs = buffers.resolve(device, ctx.getActiveDeviceKey());
         if (level) logs = logs.filter((l) => l.level === level);
         if (search) logs = logs.filter((l) => l.message.toLowerCase().includes(search.toLowerCase()));
+        if (since !== undefined) logs = logs.filter((l) => l.timestamp > since);
 
         if (summary) {
           return ctx.format.summarize(
@@ -203,16 +204,7 @@ export const consolePlugin = definePlugin({
           );
         }
 
-        const result = logs.slice(-limit);
-        if (isCompact) {
-          return result.map((l) => `${formatTimestamp(l.timestamp)} [${l.level}] ${l.message}`).join('\n');
-        }
-
-        return result.map((l) => ({
-          time: formatTimestamp(l.timestamp),
-          level: l.level,
-          message: l.message,
-        }));
+        return logs.slice(-limit).map((l) => `${formatTime(l.timestamp)} [${l.level}] ${l.message}`).join('\n');
       },
     });
 
@@ -235,17 +227,10 @@ export const consolePlugin = definePlugin({
     ctx.registerResource('metro://logs', {
       name: 'Console Logs',
       description: 'Recent console output from the React Native app',
+      mimeType: 'text/plain',
       handler: async () => {
         const logs = buffers.resolve(undefined, ctx.getActiveDeviceKey()).slice(-20);
-        return JSON.stringify(
-          logs.map((l) => ({
-            time: formatTimestamp(l.timestamp),
-            level: l.level,
-            message: l.message,
-          })),
-          null,
-          2
-        );
+        return logs.map((l) => `${formatTime(l.timestamp)} [${l.level}] ${l.message}`).join('\n') || '(no logs)';
       },
     });
   },

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { CircularBuffer, DeviceBufferManager } from '../utils/buffer.js';
-import { formatTimestamp } from '../utils/format.js';
+import { formatTime } from '../utils/format.js';
 import { extractCDPExceptionMessage } from '../utils/cdp.js';
 
 interface ErrorEntry {
@@ -134,26 +134,31 @@ export const errorsPlugin = definePlugin({
     }
 
     ctx.registerTool('get_errors', {
-      description: 'Get recent uncaught exceptions and errors from the React Native app.',
+      description: 'Get recent uncaught exceptions from the React Native app.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         limit: z.number().default(20).describe('Maximum number of errors to return'),
-        summary: z.boolean().default(false).describe('Return summary with counts'),
+        since: z.number().optional().describe('Only return entries after this Unix timestamp (ms). Pass the timestamp of the last seen entry to fetch only new ones.'),
+        summary: z.boolean().default(false).describe('Return a one-line summary with counts'),
         device: z.string().optional().describe('Device key or "all" for aggregated errors. Defaults to current device.'),
       }),
-      handler: async ({ limit, summary, device }) => {
-        const errors = getErrors(device);
+      handler: async ({ limit, since, summary, device }) => {
+        let errors = getErrors(device);
+        if (since !== undefined) errors = errors.filter((e) => e.timestamp > since);
         if (summary) {
           return ctx.format.summarize(
             errors.map((e) => e.message),
             5
           );
         }
-        return errors.slice(-limit).map((e) => ({
-          time: formatTimestamp(e.timestamp),
-          message: e.message,
-          stack: e.symbolicatedStack || e.stack,
-        }));
+        const result = errors.slice(-limit);
+        if (result.length === 0) return '(no errors)';
+        return result.map((e) => {
+          const stack = e.symbolicatedStack || e.stack;
+          return stack
+            ? `${formatTime(e.timestamp)} ${e.message}\n${stack}`
+            : `${formatTime(e.timestamp)} ${e.message}`;
+        }).join('\n\n');
       },
     });
 
@@ -182,31 +187,21 @@ export const errorsPlugin = definePlugin({
       handler: async ({ limit }) => {
         const errs = bundleErrors.getAll().slice(-limit);
         if (errs.length === 0) return 'No bundle errors detected.';
-        return errs.map((e) => ({
-          time: formatTimestamp(e.timestamp),
-          type: e.type,
-          message: ctx.format.truncate(e.message, 500),
-          file: e.file,
-          line: e.lineNumber,
-          column: e.column,
-        }));
+        return errs.map((e) => {
+          const location = e.file ? ` ${e.file}${e.lineNumber ? `:${e.lineNumber}` : ''}${e.column ? `:${e.column}` : ''}` : '';
+          return `${formatTime(e.timestamp)} [${e.type}]${location} ${ctx.format.truncate(e.message, 500)}`;
+        }).join('\n\n');
       },
     });
 
     ctx.registerResource('metro://errors', {
       name: 'Errors',
       description: 'Recent uncaught exceptions from the React Native app',
+      mimeType: 'text/plain',
       handler: async () => {
-        const all = getErrors();
-        const errors = all.slice(-10);
-        return JSON.stringify(
-          errors.map((e) => ({
-            time: formatTimestamp(e.timestamp),
-            message: e.message,
-          })),
-          null,
-          2
-        );
+        const errors = getErrors().slice(-10);
+        if (errors.length === 0) return '(no errors)';
+        return errors.map((e) => `${formatTime(e.timestamp)} ${e.message}`).join('\n');
       },
     });
   },

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { DeviceBufferManager } from '../utils/buffer.js';
-import { formatTimestamp, formatBytes } from '../utils/format.js';
+import { formatTime, formatBytes } from '../utils/format.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('network');
@@ -163,12 +163,13 @@ export const networkPlugin = definePlugin({
       annotations: { readOnlyHint: true },
       parameters: z.object({
         limit: z.number().default(50).describe('Maximum number of requests to return'),
-        summary: z.boolean().default(false).describe('Return summary with counts'),
-        compact: z.boolean().default(false).describe('Return compact single-line format'),
+        since: z.number().optional().describe('Only return requests after this Unix timestamp (ms). Pass the timestamp of the last seen entry to fetch only new ones.'),
+        summary: z.boolean().default(false).describe('Return a one-line summary with counts'),
         device: z.string().optional().describe('Device key or "all" for aggregated requests. Defaults to current device.'),
       }),
-      handler: async ({ limit, summary, compact: isCompact, device }) => {
-        const requests = getRequests(device);
+      handler: async ({ limit, since, summary, device }) => {
+        let requests = getRequests(device);
+        if (since !== undefined) requests = requests.filter((r) => r.startTime > since);
 
         if (summary) {
           const total = requests.length;
@@ -179,26 +180,15 @@ export const networkPlugin = definePlugin({
           return `${total} requests, ${errors} errors, avg response time: ${Math.round(avgTime)}ms`;
         }
 
-        const result = requests.slice(-limit);
-        if (isCompact) {
-          return result
-            .map((r) => {
-              const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
-              const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
-              return `${r.method} ${r.url} → ${status} (${duration})`;
-            })
-            .join('\n');
-        }
-
-        return result.map((r) => ({
-          method: r.method,
-          url: r.url,
-          status: r.status,
-          duration: r.endTime ? `${r.endTime - r.startTime}ms` : 'pending',
-          size: r.size ? formatBytes(r.size) : undefined,
-          error: r.error,
-          time: formatTimestamp(r.startTime),
-        }));
+        return requests
+          .slice(-limit)
+          .map((r) => {
+            const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
+            const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
+            const size = r.size ? `, ${formatBytes(r.size)}` : '';
+            return `${formatTime(r.startTime)} ${r.method} ${r.url} → ${status} (${duration}${size})`;
+          })
+          .join('\n');
       },
     });
 
@@ -220,10 +210,7 @@ export const networkPlugin = definePlugin({
     });
 
     ctx.registerTool('get_response_body', {
-      description:
-        'Get the response body for a specific network request. ' +
-        'Bodies are eagerly cached when small enough, so they survive reconnections. ' +
-        'Larger bodies are fetched on demand and only available in the current CDP session.',
+      description: 'Get response body for a network request (cached if small; requires active session if large).',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         url: z.string().describe('URL or partial URL to find the request'),
@@ -274,9 +261,10 @@ export const networkPlugin = definePlugin({
         method: z.string().optional().describe('HTTP method filter'),
         statusCode: z.number().optional().describe('HTTP status code filter'),
         errorsOnly: z.boolean().default(false).describe('Show only failed requests'),
+        limit: z.number().default(20).describe('Maximum number of results to return'),
         device: z.string().optional().describe('Device key or "all". Defaults to current device.'),
       }),
-      handler: async ({ urlPattern, method, statusCode, errorsOnly, device }) => {
+      handler: async ({ urlPattern, method, statusCode, errorsOnly, limit, device }) => {
         let results = getRequests(device);
         if (urlPattern) {
           const regex = new RegExp(urlPattern, 'i');
@@ -285,18 +273,19 @@ export const networkPlugin = definePlugin({
         if (method) results = results.filter((r) => r.method.toUpperCase() === method.toUpperCase());
         if (statusCode) results = results.filter((r) => r.status === statusCode);
         if (errorsOnly) results = results.filter((r) => r.error || (r.status && r.status >= 400));
-        return results.map((r) => ({
-          method: r.method,
-          url: r.url,
-          status: r.status,
-          error: r.error,
-          duration: r.endTime ? `${r.endTime - r.startTime}ms` : 'pending',
-        }));
+        return results
+          .slice(-limit)
+          .map((r) => {
+            const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
+            const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
+            return `${r.method} ${r.url} → ${status} (${duration})`;
+          })
+          .join('\n');
       },
     });
 
     ctx.registerTool('clear_network_requests', {
-      description: 'Clear the network request buffer. Useful after a reload or when old requests are no longer relevant.',
+      description: 'Clear the network request buffer.',
       annotations: { destructiveHint: true, idempotentHint: true },
       parameters: z.object({
         device: z.string().optional().describe('Device key to clear, or omit for current device. Use "all" to clear all.'),
@@ -443,19 +432,17 @@ export const networkPlugin = definePlugin({
     ctx.registerResource('metro://network', {
       name: 'Network Requests',
       description: 'Recent network requests from the React Native app',
+      mimeType: 'text/plain',
       handler: async () => {
-        const all = getRequests();
-        const requests = all.slice(-20);
-        return JSON.stringify(
-          requests.map((r) => ({
-            method: r.method,
-            url: r.url,
-            status: r.status,
-            duration: r.endTime ? `${r.endTime - r.startTime}ms` : 'pending',
-          })),
-          null,
-          2
-        );
+        const requests = getRequests().slice(-20);
+        if (requests.length === 0) return '(no requests)';
+        return requests
+          .map((r) => {
+            const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
+            const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
+            return `${formatTime(r.startTime)} ${r.method} ${r.url} → ${status} (${duration})`;
+          })
+          .join('\n');
       },
     });
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -232,7 +232,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
 
               try {
                 const result = await toolConfig.handler(args as z.infer<T>, { sendProgress });
-                const content = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+                const content = typeof result === 'string' ? result : JSON.stringify(result);
                 return { content: [{ type: 'text' as const, text: content }] };
               } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -54,6 +54,23 @@ export function formatTimestamp(ts: number): string {
 }
 
 /**
+ * Format a timestamp to HH:MM:SS.mmm (time only, no date).
+ * More compact than ISO 8601 for in-session debugging output.
+ */
+export function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return (
+    String(d.getHours()).padStart(2, '0') +
+    ':' +
+    String(d.getMinutes()).padStart(2, '0') +
+    ':' +
+    String(d.getSeconds()).padStart(2, '0') +
+    '.' +
+    String(d.getMilliseconds()).padStart(3, '0')
+  );
+}
+
+/**
  * Escape a string for safe embedding inside a JS single-quoted string literal.
  */
 export function escapeJsString(str: string): string {


### PR DESCRIPTION
- Always return compact text lines for get_console_logs, get_network_requests,
  and get_errors instead of verbose JSON (removes the compact toggle)
- Switch metro://logs, metro://network, metro://errors resources to plain text
- Add `since` parameter to log/network/error tools for incremental queries
  (avoids re-reading already-seen entries across multiple calls)
- Add formatTime() utility: HH:MM:SS.mmm instead of full ISO 8601 timestamps
- Minify all JSON tool responses in server.ts (remove 2-space indentation)
- Add `limit` parameter to search_network (was unbounded)
- Remove pretty-printing from CDP RemoteObject serialization in console logs
- Trim multi-sentence tool descriptions

https://claude.ai/code/session_0119kfokJ2XEFidu8DmBid3Y