### PR TITLE
Add permissions plugin for iOS Simulator and Android Emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 | **storage** | 3 | AsyncStorage reading |
 | **simulator** | 6 | iOS simulator / Android device control |
 | **deeplink** | 2 | Cross-platform deep link testing |
+| **permissions** | 5 | Inspect and manage app permissions on iOS Simulator and Android Emulator |
 | **ui-interact** | 6 | UI automation (tap, swipe, type) |
 | **navigation** | 4 | React Navigation / Expo Router state |
 | **accessibility** | 3 | Accessibility auditing |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -86,11 +86,11 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 
 Inspect and manage app permissions on iOS Simulator and Android Emulator without leaving your workflow. Uses `xcrun simctl privacy` on iOS and `adb shell pm` on Android. Bundle ID / package name is auto-detected from config or the running app, or can be supplied explicitly.
 
-**iOS services:** `camera`, `microphone`, `photos`, `location`, `contacts`, `calendars`, `reminders`, `motion`, `health`, `homekit`, `medialibrary`, `bluetooth`, `network`, `speech`, `notifications`, `focus`, `tracking`
+**iOS services** (supported by `xcrun simctl privacy`): `calendar`, `contacts`, `contacts-limited`, `location`, `location-always`, `media-library`, `microphone`, `motion`, `photos`, `photos-add`, `reminders`, `siri`
 
-**Android permissions:** Standard `android.permission.*` strings — provide just the suffix (e.g. `CAMERA`) or the full string (e.g. `android.permission.CAMERA`).
+**Android permissions:** Runtime (dangerous) permissions only — the app must have declared the permission in its `AndroidManifest.xml`. Provide just the suffix (e.g. `CAMERA`) or the full string (e.g. `android.permission.CAMERA`). Install-time permissions (e.g. `INTERNET`) cannot be granted this way.
 
-- **`list_permissions`** — List all permission statuses for the app. Returns an object mapping service/permission → status (e.g. `granted`, `denied`, `undetermined`).
+- **`list_permissions`** — List all permission statuses for the app. Returns compact text: one `name=status` line per permission.
 - **`grant_permission`** — Grant a permission to the app.
 - **`revoke_permission`** — Revoke a permission from the app.
 - **`reset_permissions`** — Reset one or all permissions to their default state. On iOS, omit `service` to reset everything. On Android, omit `service` to reset all runtime permissions (falls back to `pm clear` on older devices).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Evaluate](#evaluate) · [Device](#device) · [Redux](#redux) · [Components](#components) · [Storage](#storage) · [Bundle](#bundle) · [Simulator](#simulator) · [Deep Link](#deep-link) · [UI Interact](#ui-interact) · [Navigation](#navigation) · [Accessibility](#accessibility) · [Profiler](#profiler) · [Test Recorder](#test-recorder) · [Commands](#commands) · [Resources](#resources) · [Prompts](#prompts)
+Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Evaluate](#evaluate) · [Device](#device) · [Redux](#redux) · [Components](#components) · [Storage](#storage) · [Bundle](#bundle) · [Simulator](#simulator) · [Deep Link](#deep-link) · [Permissions](#permissions) · [UI Interact](#ui-interact) · [Navigation](#navigation) · [Accessibility](#accessibility) · [Profiler](#profiler) · [Test Recorder](#test-recorder) · [Commands](#commands) · [Resources](#resources) · [Prompts](#prompts)
 
 ## Console
 
@@ -81,6 +81,20 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 
 - **`open_deeplink`** — Open a URL or deep link on the device.
 - **`list_url_schemes`** — List registered URL schemes.
+
+## Permissions
+
+Inspect and manage app permissions on iOS Simulator and Android Emulator without leaving your workflow. Uses `xcrun simctl privacy` on iOS and `adb shell pm` on Android. Bundle ID / package name is auto-detected from config or the running app, or can be supplied explicitly.
+
+**iOS services:** `camera`, `microphone`, `photos`, `location`, `contacts`, `calendars`, `reminders`, `motion`, `health`, `homekit`, `medialibrary`, `bluetooth`, `network`, `speech`, `notifications`, `focus`, `tracking`
+
+**Android permissions:** Standard `android.permission.*` strings — provide just the suffix (e.g. `CAMERA`) or the full string (e.g. `android.permission.CAMERA`).
+
+- **`list_permissions`** — List all permission statuses for the app. Returns an object mapping service/permission → status (e.g. `granted`, `denied`, `undetermined`).
+- **`grant_permission`** — Grant a permission to the app.
+- **`revoke_permission`** — Revoke a permission from the app.
+- **`reset_permissions`** — Reset one or all permissions to their default state. On iOS, omit `service` to reset everything. On Android, omit `service` to reset all runtime permissions (falls back to `pm clear` on older devices).
+- **`open_app_settings`** — Open the app's system settings page. On iOS, opens the Settings panel for the frontmost app. On Android, requires a bundle ID / package name.
 
 ## UI Interact
 

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -1,6 +1,30 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 
+// Module-level caches — persist across tool handler calls for the lifetime of the server.
+let platformCache: { value: 'ios' | 'android' | null; ts: number } | null = null;
+const PLATFORM_TTL_MS = 5000;
+let bundleIdCache: string | null = null;
+
+function normalizeAndroidPermission(service: string): string {
+  return service.startsWith('android.permission.')
+    ? service
+    : `android.permission.${service.toUpperCase()}`;
+}
+
+const permissionServiceParams = z.object({
+  service: z
+    .string()
+    .describe(
+      'iOS: service name (e.g. "camera", "location"). Android: permission name (e.g. "CAMERA" or "android.permission.CAMERA").'
+    ),
+  platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
+  bundleId: z
+    .string()
+    .optional()
+    .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
+});
+
 export const permissionsPlugin = definePlugin({
   name: 'permissions',
 
@@ -8,37 +32,79 @@ export const permissionsPlugin = definePlugin({
 
   async setup(ctx) {
     async function detectPlatform(): Promise<'ios' | 'android' | null> {
-      try {
-        await ctx.exec('xcrun simctl list booted 2>/dev/null | grep -q Booted');
-        return 'ios';
-      } catch {}
-      try {
-        const output = await ctx.exec('adb devices 2>/dev/null');
-        if (output.trim().split('\n').length > 1) return 'android';
-      } catch {}
-      return null;
+      const now = Date.now();
+      if (platformCache && now - platformCache.ts < PLATFORM_TTL_MS) return platformCache.value;
+      const [iosResult, androidResult] = await Promise.allSettled([
+        ctx.exec('xcrun simctl list booted 2>/dev/null | grep -q Booted'),
+        ctx.exec('adb devices 2>/dev/null'),
+      ]);
+      let platform: 'ios' | 'android' | null = null;
+      if (iosResult.status === 'fulfilled') {
+        platform = 'ios';
+      } else if (androidResult.status === 'fulfilled') {
+        const output = (androidResult as PromiseFulfilledResult<string>).value;
+        if (output.trim().split('\n').length > 1) platform = 'android';
+      }
+      platformCache = { value: platform, ts: now };
+      return platform;
     }
 
     async function detectBundleId(platform: 'ios' | 'android'): Promise<string | null> {
+      if (bundleIdCache) return bundleIdCache;
       const config = ctx.config as Record<string, unknown>;
-      if (platform === 'android' && config.packageName) return String(config.packageName);
-      if (config.bundleId) return String(config.bundleId);
-
+      if (platform === 'android' && config.packageName)
+        return (bundleIdCache = String(config.packageName));
+      if (config.bundleId) return (bundleIdCache = String(config.bundleId));
       try {
         if (ctx.cdp.isConnected) {
           const id = await ctx.evalInApp(
             `(function(){ try { return require('react-native-device-info').getBundleId(); } catch(e) { return null; } })()`,
             { awaitPromise: false }
           );
-          if (id) return String(id);
+          if (id) return (bundleIdCache = String(id));
         }
       } catch {}
-
       return null;
     }
 
-    function resolvePlatform(platform: 'ios' | 'android' | 'auto' | undefined) {
-      return platform === 'auto' || !platform ? detectPlatform() : Promise.resolve(platform);
+    async function resolveTarget(
+      platform: 'ios' | 'android' | 'auto' | undefined,
+      bundleId: string | undefined
+    ): Promise<{ p: 'ios' | 'android'; id: string } | string> {
+      const p = platform === 'auto' || !platform ? await detectPlatform() : platform;
+      if (!p) return 'No simulator/emulator detected.';
+      const id = bundleId || (await detectBundleId(p));
+      if (!id)
+        return 'Bundle ID / package name required. Provide bundleId or ensure the app is running.';
+      return { p, id };
+    }
+
+    function permissionMutationHandler(action: 'grant' | 'revoke') {
+      return async ({ service, platform, bundleId }: z.infer<typeof permissionServiceParams>) => {
+        const resolved = await resolveTarget(platform, bundleId);
+        if (typeof resolved === 'string') return resolved;
+        const { p, id } = resolved;
+        if (p === 'ios') {
+          try {
+            await ctx.exec(`xcrun simctl privacy booted ${action} "${service}" "${id}"`);
+            return action === 'grant'
+              ? `Granted "${service}" permission to ${id} on iOS simulator.`
+              : `Revoked "${service}" permission from ${id} on iOS simulator.`;
+          } catch (err) {
+            return `Failed to ${action} permission: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        } else {
+          const perm = normalizeAndroidPermission(service);
+          try {
+            await ctx.exec(`adb shell pm ${action} "${id}" "${perm}"`);
+            return action === 'grant'
+              ? `Granted "${perm}" to ${id} on Android device.`
+              : `Revoked "${perm}" from ${id} on Android device.`;
+          } catch (err) {
+            return `Failed to ${action} permission: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+      };
     }
 
     ctx.registerTool('list_permissions', {
@@ -53,12 +119,9 @@ export const permissionsPlugin = definePlugin({
           .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
       }),
       handler: async ({ platform, bundleId }) => {
-        const p = await resolvePlatform(platform);
-        if (!p) return 'No simulator/emulator detected.';
-
-        const id = bundleId || (await detectBundleId(p));
-        if (!id)
-          return 'Bundle ID / package name required. Provide bundleId or ensure the app is running.';
+        const resolved = await resolveTarget(platform, bundleId);
+        if (typeof resolved === 'string') return resolved;
+        const { p, id } = resolved;
 
         if (p === 'ios') {
           try {
@@ -78,11 +141,8 @@ export const permissionsPlugin = definePlugin({
           }
         } else {
           try {
-            const output = await ctx.exec(
-              `adb shell dumpsys package "${id}" 2>/dev/null`
-            );
+            const output = await ctx.exec(`adb shell dumpsys package "${id}" 2>/dev/null`);
             const permissions: Record<string, string> = {};
-            // Parse all "android.permission.FOO: granted=true/false" entries
             const permRegex = /(android\.permission\.\w+):\s*granted=(\w+)/g;
             let match;
             while ((match = permRegex.exec(output)) !== null) {
@@ -102,88 +162,16 @@ export const permissionsPlugin = definePlugin({
       description:
         'Grant a permission to the app on the connected iOS simulator or Android emulator.',
       annotations: { destructiveHint: true },
-      parameters: z.object({
-        service: z
-          .string()
-          .describe(
-            'iOS: service name (e.g. "camera", "location"). Android: permission name (e.g. "CAMERA" or "android.permission.CAMERA").'
-          ),
-        platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
-        bundleId: z
-          .string()
-          .optional()
-          .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
-      }),
-      handler: async ({ service, platform, bundleId }) => {
-        const p = await resolvePlatform(platform);
-        if (!p) return 'No simulator/emulator detected.';
-
-        const id = bundleId || (await detectBundleId(p));
-        if (!id) return 'Bundle ID / package name required.';
-
-        if (p === 'ios') {
-          try {
-            await ctx.exec(`xcrun simctl privacy booted grant "${service}" "${id}"`);
-            return `Granted "${service}" permission to ${id} on iOS simulator.`;
-          } catch (err) {
-            return `Failed to grant permission: ${err instanceof Error ? err.message : String(err)}`;
-          }
-        } else {
-          const perm = service.startsWith('android.permission.')
-            ? service
-            : `android.permission.${service.toUpperCase()}`;
-          try {
-            await ctx.exec(`adb shell pm grant "${id}" "${perm}"`);
-            return `Granted "${perm}" to ${id} on Android device.`;
-          } catch (err) {
-            return `Failed to grant permission: ${err instanceof Error ? err.message : String(err)}`;
-          }
-        }
-      },
+      parameters: permissionServiceParams,
+      handler: permissionMutationHandler('grant'),
     });
 
     ctx.registerTool('revoke_permission', {
       description:
         'Revoke a permission from the app on the connected iOS simulator or Android emulator.',
       annotations: { destructiveHint: true },
-      parameters: z.object({
-        service: z
-          .string()
-          .describe(
-            'iOS: service name (e.g. "camera", "location"). Android: permission name (e.g. "CAMERA" or "android.permission.CAMERA").'
-          ),
-        platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
-        bundleId: z
-          .string()
-          .optional()
-          .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
-      }),
-      handler: async ({ service, platform, bundleId }) => {
-        const p = await resolvePlatform(platform);
-        if (!p) return 'No simulator/emulator detected.';
-
-        const id = bundleId || (await detectBundleId(p));
-        if (!id) return 'Bundle ID / package name required.';
-
-        if (p === 'ios') {
-          try {
-            await ctx.exec(`xcrun simctl privacy booted revoke "${service}" "${id}"`);
-            return `Revoked "${service}" permission from ${id} on iOS simulator.`;
-          } catch (err) {
-            return `Failed to revoke permission: ${err instanceof Error ? err.message : String(err)}`;
-          }
-        } else {
-          const perm = service.startsWith('android.permission.')
-            ? service
-            : `android.permission.${service.toUpperCase()}`;
-          try {
-            await ctx.exec(`adb shell pm revoke "${id}" "${perm}"`);
-            return `Revoked "${perm}" from ${id} on Android device.`;
-          } catch (err) {
-            return `Failed to revoke permission: ${err instanceof Error ? err.message : String(err)}`;
-          }
-        }
-      },
+      parameters: permissionServiceParams,
+      handler: permissionMutationHandler('revoke'),
     });
 
     ctx.registerTool('reset_permissions', {
@@ -204,16 +192,14 @@ export const permissionsPlugin = definePlugin({
           .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
       }),
       handler: async ({ service, platform, bundleId }) => {
-        const p = await resolvePlatform(platform);
-        if (!p) return 'No simulator/emulator detected.';
-
-        const id = bundleId || (await detectBundleId(p));
-        if (!id) return 'Bundle ID / package name required.';
+        const resolved = await resolveTarget(platform, bundleId);
+        if (typeof resolved === 'string') return resolved;
+        const { p, id } = resolved;
 
         if (p === 'ios') {
-          const target = service ?? 'all';
+          const iosTarget = service ?? 'all';
           try {
-            await ctx.exec(`xcrun simctl privacy booted reset "${target}" "${id}"`);
+            await ctx.exec(`xcrun simctl privacy booted reset "${iosTarget}" "${id}"`);
             return `Reset ${service ? `"${service}"` : 'all'} permissions for ${id} on iOS simulator.`;
           } catch (err) {
             return `Failed to reset permissions: ${err instanceof Error ? err.message : String(err)}`;
@@ -221,13 +207,11 @@ export const permissionsPlugin = definePlugin({
         } else {
           try {
             if (service) {
-              const perm = service.startsWith('android.permission.')
-                ? service
-                : `android.permission.${service.toUpperCase()}`;
+              const perm = normalizeAndroidPermission(service);
               await ctx.exec(`adb shell pm revoke "${id}" "${perm}"`);
               return `Reset "${perm}" for ${id} on Android device.`;
             } else {
-              // pm reset-permissions is available on newer Android; fall back to pm clear
+              // pm reset-permissions not available on older Android; pm clear resets all app state including permissions
               try {
                 await ctx.exec(`adb shell pm reset-permissions -p "${id}" 2>/dev/null`);
               } catch {
@@ -256,7 +240,7 @@ export const permissionsPlugin = definePlugin({
           ),
       }),
       handler: async ({ platform, bundleId }) => {
-        const p = await resolvePlatform(platform);
+        const p = platform === 'auto' ? await detectPlatform() : platform;
         if (!p) return 'No simulator/emulator detected.';
 
         if (p === 'ios') {

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -3,13 +3,61 @@ import { definePlugin } from '../plugin.js';
 
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let platformCache: { value: 'ios' | 'android' | null; ts: number } | null = null;
-const PLATFORM_TTL_MS = 5000;
 let bundleIdCache: string | null = null;
+let iosUdidCache: { value: string | null; ts: number } | null = null;
+const IOS_UDID_TTL_MS = 30_000;
+
+// TCC service name → friendly name
+const TCC_SERVICE_MAP: Record<string, string> = {
+  kTCCServiceCamera: 'camera',
+  kTCCServicePhotos: 'photos',
+  kTCCServiceMicrophone: 'microphone',
+  kTCCServiceLocation: 'location',
+  kTCCServiceLiverpool: 'location-always',
+  kTCCServiceContacts: 'contacts',
+  kTCCServiceContactsFull: 'contacts-full',
+  kTCCServiceCalendar: 'calendar',
+  kTCCServiceReminders: 'reminders',
+  kTCCServiceMotion: 'motion',
+  kTCCServiceMediaLibrary: 'media-library',
+  kTCCServiceSiri: 'siri',
+  kTCCServiceBluetoothAlways: 'bluetooth',
+  kTCCServiceFaceID: 'face-id',
+  kTCCServiceUserTracking: 'tracking',
+};
+
+// TCC auth_value integer (as string) → permission status
+const TCC_AUTH_VALUE_MAP: Record<string, string> = {
+  '0': 'denied',
+  '1': 'not-determined',
+  '2': 'granted',
+  '3': 'limited',
+  '4': 'restricted',
+};
+
+// locationd Authorization: 0=notDetermined, 1=restricted, 2=whenInUse, 3=always, 4=denied
+const LOCATIOND_AUTH_MAP: Record<number, string> = {
+  0: 'not-determined',
+  1: 'restricted',
+  2: 'when-in-use',
+  3: 'always',
+  4: 'denied',
+};
 
 function normalizeAndroidPermission(service: string): string {
   return service.startsWith('android.permission.')
     ? service
     : `android.permission.${service.toUpperCase()}`;
+}
+
+function formatPermissions(
+  platform: 'ios' | 'android',
+  bundleId: string,
+  permissions: Record<string, string>
+): string {
+  const header = `[${platform}] ${bundleId}`;
+  const lines = Object.entries(permissions).map(([k, v]) => `${k}=${v}`);
+  return `${header}\n${lines.join('\n')}`;
 }
 
 const permissionServiceParams = z.object({
@@ -33,13 +81,13 @@ export const permissionsPlugin = definePlugin({
   async setup(ctx) {
     async function detectPlatform(): Promise<'ios' | 'android' | null> {
       const now = Date.now();
-      if (platformCache && now - platformCache.ts < PLATFORM_TTL_MS) return platformCache.value;
-      const [iosResult, androidResult] = await Promise.allSettled([
-        ctx.exec('xcrun simctl list booted 2>/dev/null | grep -q Booted'),
+      if (platformCache && now - platformCache.ts < IOS_UDID_TTL_MS) return platformCache.value;
+      const [iosUdidResult, androidResult] = await Promise.allSettled([
+        getBootedIosUdid(),
         ctx.exec('adb devices 2>/dev/null'),
       ]);
       let platform: 'ios' | 'android' | null = null;
-      if (iosResult.status === 'fulfilled') {
+      if (iosUdidResult.status === 'fulfilled' && iosUdidResult.value !== null) {
         platform = 'ios';
       } else if (androidResult.status === 'fulfilled') {
         const output = (androidResult as PromiseFulfilledResult<string>).value;
@@ -49,21 +97,32 @@ export const permissionsPlugin = definePlugin({
       return platform;
     }
 
+    async function getBootedIosUdid(): Promise<string | null> {
+      const now = Date.now();
+      if (iosUdidCache && now - iosUdidCache.ts < IOS_UDID_TTL_MS) return iosUdidCache.value;
+      const devicesJson = await ctx.exec('xcrun simctl list devices booted --json');
+      const devicesData = JSON.parse(devicesJson) as {
+        devices: Record<string, Array<{ udid: string; state: string }>>;
+      };
+      const udid =
+        Object.values(devicesData.devices)
+          .flat()
+          .find((d) => d.state === 'Booted')?.udid ?? null;
+      iosUdidCache = { value: udid, ts: now };
+      return udid;
+    }
+
     async function detectBundleId(platform: 'ios' | 'android'): Promise<string | null> {
       if (bundleIdCache) return bundleIdCache;
       const config = ctx.config as Record<string, unknown>;
       if (platform === 'android' && config.packageName)
         return (bundleIdCache = String(config.packageName));
       if (config.bundleId) return (bundleIdCache = String(config.bundleId));
-      try {
-        if (ctx.cdp.isConnected) {
-          const id = await ctx.evalInApp(
-            `(function(){ try { return require('react-native-device-info').getBundleId(); } catch(e) { return null; } })()`,
-            { awaitPromise: false }
-          );
-          if (id) return (bundleIdCache = String(id));
-        }
-      } catch {}
+      const title = ctx.cdp.getTarget()?.title;
+      if (title) {
+        const match = title.match(/^(.+?)\s+\(/);
+        if (match?.[1]) return (bundleIdCache = match[1]);
+      }
       return null;
     }
 
@@ -107,9 +166,75 @@ export const permissionsPlugin = definePlugin({
       };
     }
 
+    async function fetchPermissions(
+      p: 'ios' | 'android',
+      id: string
+    ): Promise<Record<string, string> | string> {
+      if (p === 'ios') {
+        try {
+          // simctl privacy has no 'list' action — read the TCC database directly.
+          const udid = await getBootedIosUdid();
+          if (!udid) return 'No booted iOS simulator found.';
+
+          const safeId = id.replace(/'/g, "''");
+          const tccDb = `${process.env.HOME}/Library/Developer/CoreSimulator/Devices/${udid}/data/Library/TCC/TCC.db`;
+          // Location is managed by locationd, not TCC — read clients.plist separately.
+          // Keys are like "i<bundleId>:" (leading i, trailing colon); PlistBuddy escapes the
+          // literal colon in the key name with \:
+          const locationdPlist = `${process.env.HOME}/Library/Developer/CoreSimulator/Devices/${udid}/data/Library/Caches/locationd/clients.plist`;
+
+          const [tccResult, locationResult] = await Promise.allSettled([
+            ctx.exec(
+              `sqlite3 "${tccDb}" "SELECT service, auth_value FROM access WHERE client = '${safeId}'" 2>/dev/null`
+            ),
+            ctx.exec(
+              `/usr/libexec/PlistBuddy -c "Print 'i${id}\\::Authorization'" "${locationdPlist}" 2>/dev/null`
+            ),
+          ]);
+
+          const permissions: Record<string, string> = {};
+
+          if (tccResult.status === 'fulfilled') {
+            for (const line of tccResult.value.trim().split('\n')) {
+              if (!line) continue;
+              const parts = line.split('|');
+              if (parts.length < 2) continue;
+              const [service, authValue] = parts;
+              permissions[TCC_SERVICE_MAP[service] ?? service] =
+                TCC_AUTH_VALUE_MAP[authValue] ?? authValue;
+            }
+          }
+
+          if (locationResult.status === 'fulfilled') {
+            const auth = parseInt(locationResult.value.trim(), 10);
+            if (!isNaN(auth)) {
+              permissions['location'] = LOCATIOND_AUTH_MAP[auth] ?? String(auth);
+            }
+          }
+
+          return permissions;
+        } catch (err) {
+          return `Failed to list permissions: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      } else {
+        try {
+          const output = await ctx.exec(`adb shell dumpsys package "${id}" 2>/dev/null`);
+          const permissions: Record<string, string> = {};
+          const permRegex = /(android\.permission\.\w+):\s*granted=(\w+)/g;
+          let match;
+          while ((match = permRegex.exec(output)) !== null) {
+            permissions[match[1]] = match[2] === 'true' ? 'granted' : 'denied';
+          }
+          return permissions;
+        } catch (err) {
+          return `Failed to list permissions: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      }
+    }
+
     ctx.registerTool('list_permissions', {
       description:
-        'List all app permission statuses on the connected iOS simulator or Android emulator. Returns an object mapping service/permission → status.',
+        'List all app permission statuses on the connected iOS simulator or Android emulator. Returns compact text: one name=status line per permission.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
@@ -122,39 +247,13 @@ export const permissionsPlugin = definePlugin({
         const resolved = await resolveTarget(platform, bundleId);
         if (typeof resolved === 'string') return resolved;
         const { p, id } = resolved;
-
-        if (p === 'ios') {
-          try {
-            const output = await ctx.exec(
-              `xcrun simctl privacy booted list "${id}" 2>/dev/null`
-            );
-            const permissions: Record<string, string> = {};
-            for (const line of output.trim().split('\n')) {
-              const match = line.match(/^\s*(\w+):\s*(\S+)/);
-              if (match) permissions[match[1].toLowerCase()] = match[2].toLowerCase();
-            }
-            if (Object.keys(permissions).length === 0)
-              return `No permissions found for "${id}". Make sure the app is installed on the booted simulator.`;
-            return permissions;
-          } catch (err) {
-            return `Failed to list permissions: ${err instanceof Error ? err.message : String(err)}`;
-          }
-        } else {
-          try {
-            const output = await ctx.exec(`adb shell dumpsys package "${id}" 2>/dev/null`);
-            const permissions: Record<string, string> = {};
-            const permRegex = /(android\.permission\.\w+):\s*granted=(\w+)/g;
-            let match;
-            while ((match = permRegex.exec(output)) !== null) {
-              permissions[match[1]] = match[2] === 'true' ? 'granted' : 'denied';
-            }
-            if (Object.keys(permissions).length === 0)
-              return `No permissions found for "${id}". Make sure the app is installed on the connected device.`;
-            return permissions;
-          } catch (err) {
-            return `Failed to list permissions: ${err instanceof Error ? err.message : String(err)}`;
-          }
-        }
+        const perms = await fetchPermissions(p, id);
+        if (typeof perms === 'string') return perms;
+        if (Object.keys(perms).length === 0)
+          return p === 'ios'
+            ? `No permissions found for "${id}". The app has not requested any permissions yet on this simulator.`
+            : `No permissions found for "${id}". Make sure the app is installed on the connected device.`;
+        return formatPermissions(p, id, perms);
       },
     });
 
@@ -262,6 +361,24 @@ export const permissionsPlugin = definePlugin({
             return `Failed to open app settings: ${err instanceof Error ? err.message : String(err)}`;
           }
         }
+      },
+    });
+
+    ctx.registerResource('metro://permissions', {
+      name: 'App Permissions',
+      description:
+        'Current permission statuses for the connected app (auto-detected platform and bundle ID)',
+      mimeType: 'text/plain',
+      handler: async () => {
+        const p = await detectPlatform();
+        if (!p) return '(no simulator/emulator detected)';
+        const id = await detectBundleId(p);
+        if (!id) return `(${p}) bundle ID not detected — run the app first`;
+        const perms = await fetchPermissions(p, id);
+        if (typeof perms === 'string') return perms;
+        if (Object.keys(perms).length === 0)
+          return `[${p}] ${id}\n(no permissions requested yet)`;
+        return formatPermissions(p, id, perms);
       },
     });
   },

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -44,6 +44,24 @@ const LOCATIOND_AUTH_MAP: Record<number, string> = {
   4: 'denied',
 };
 
+// Services supported by `xcrun simctl privacy booted grant/revoke/reset`
+// Note: camera, bluetooth, face-id, tracking, notifications are NOT supported.
+const IOS_SIMCTL_PRIVACY_SERVICES = new Set([
+  'all',
+  'calendar',
+  'contacts-limited',
+  'contacts',
+  'location',
+  'location-always',
+  'photos-add',
+  'photos',
+  'media-library',
+  'microphone',
+  'motion',
+  'reminders',
+  'siri',
+]);
+
 function normalizeAndroidPermission(service: string): string {
   return service.startsWith('android.permission.')
     ? service
@@ -64,7 +82,7 @@ const permissionServiceParams = z.object({
   service: z
     .string()
     .describe(
-      'iOS: service name (e.g. "camera", "location"). Android: permission name (e.g. "CAMERA" or "android.permission.CAMERA").'
+      'iOS: simctl service (calendar, contacts, contacts-limited, location, location-always, microphone, motion, photos, photos-add, media-library, reminders, siri). Android: runtime permission (e.g. "CAMERA" or "android.permission.CAMERA").'
     ),
   platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
   bundleId: z
@@ -138,12 +156,19 @@ export const permissionsPlugin = definePlugin({
       return { p, id };
     }
 
+    function validateIosService(service: string): string | null {
+      if (IOS_SIMCTL_PRIVACY_SERVICES.has(service)) return null;
+      return `"${service}" not supported. Use: calendar, contacts, contacts-limited, location, location-always, microphone, motion, photos, photos-add, media-library, reminders, siri.`;
+    }
+
     function permissionMutationHandler(action: 'grant' | 'revoke') {
       return async ({ service, platform, bundleId }: z.infer<typeof permissionServiceParams>) => {
         const resolved = await resolveTarget(platform, bundleId);
         if (typeof resolved === 'string') return resolved;
         const { p, id } = resolved;
         if (p === 'ios') {
+          const serviceError = validateIosService(service);
+          if (serviceError) return serviceError;
           try {
             await ctx.exec(`xcrun simctl privacy booted ${action} "${service}" "${id}"`);
             return action === 'grant'
@@ -282,7 +307,7 @@ export const permissionsPlugin = definePlugin({
           .string()
           .optional()
           .describe(
-            'iOS: specific service to reset (e.g. "camera"); omit to reset all. Android: permission name (e.g. "CAMERA"); omit to reset all runtime permissions.'
+            'iOS: specific service to reset (e.g. "location"); omit to reset all. Android: permission name (e.g. "CAMERA"); omit to reset all runtime permissions.'
           ),
         platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
         bundleId: z
@@ -297,6 +322,10 @@ export const permissionsPlugin = definePlugin({
 
         if (p === 'ios') {
           const iosTarget = service ?? 'all';
+          if (service !== undefined) {
+            const serviceError = validateIosService(service);
+            if (serviceError) return serviceError;
+          }
           try {
             await ctx.exec(`xcrun simctl privacy booted reset "${iosTarget}" "${id}"`);
             return `Reset ${service ? `"${service}"` : 'all'} permissions for ${id} on iOS simulator.`;

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -1,0 +1,284 @@
+import { z } from 'zod';
+import { definePlugin } from '../plugin.js';
+
+export const permissionsPlugin = definePlugin({
+  name: 'permissions',
+
+  description: 'Inspect and manage app permissions on iOS Simulator and Android Emulator',
+
+  async setup(ctx) {
+    async function detectPlatform(): Promise<'ios' | 'android' | null> {
+      try {
+        await ctx.exec('xcrun simctl list booted 2>/dev/null | grep -q Booted');
+        return 'ios';
+      } catch {}
+      try {
+        const output = await ctx.exec('adb devices 2>/dev/null');
+        if (output.trim().split('\n').length > 1) return 'android';
+      } catch {}
+      return null;
+    }
+
+    async function detectBundleId(platform: 'ios' | 'android'): Promise<string | null> {
+      const config = ctx.config as Record<string, unknown>;
+      if (platform === 'android' && config.packageName) return String(config.packageName);
+      if (config.bundleId) return String(config.bundleId);
+
+      try {
+        if (ctx.cdp.isConnected) {
+          const id = await ctx.evalInApp(
+            `(function(){ try { return require('react-native-device-info').getBundleId(); } catch(e) { return null; } })()`,
+            { awaitPromise: false }
+          );
+          if (id) return String(id);
+        }
+      } catch {}
+
+      return null;
+    }
+
+    function resolvePlatform(platform: 'ios' | 'android' | 'auto' | undefined) {
+      return platform === 'auto' || !platform ? detectPlatform() : Promise.resolve(platform);
+    }
+
+    ctx.registerTool('list_permissions', {
+      description:
+        'List all app permission statuses on the connected iOS simulator or Android emulator. Returns an object mapping service/permission → status.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({
+        platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
+      }),
+      handler: async ({ platform, bundleId }) => {
+        const p = await resolvePlatform(platform);
+        if (!p) return 'No simulator/emulator detected.';
+
+        const id = bundleId || (await detectBundleId(p));
+        if (!id)
+          return 'Bundle ID / package name required. Provide bundleId or ensure the app is running.';
+
+        if (p === 'ios') {
+          try {
+            const output = await ctx.exec(
+              `xcrun simctl privacy booted list "${id}" 2>/dev/null`
+            );
+            const permissions: Record<string, string> = {};
+            for (const line of output.trim().split('\n')) {
+              const match = line.match(/^\s*(\w+):\s*(\S+)/);
+              if (match) permissions[match[1].toLowerCase()] = match[2].toLowerCase();
+            }
+            if (Object.keys(permissions).length === 0)
+              return `No permissions found for "${id}". Make sure the app is installed on the booted simulator.`;
+            return permissions;
+          } catch (err) {
+            return `Failed to list permissions: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        } else {
+          try {
+            const output = await ctx.exec(
+              `adb shell dumpsys package "${id}" 2>/dev/null`
+            );
+            const permissions: Record<string, string> = {};
+            // Parse all "android.permission.FOO: granted=true/false" entries
+            const permRegex = /(android\.permission\.\w+):\s*granted=(\w+)/g;
+            let match;
+            while ((match = permRegex.exec(output)) !== null) {
+              permissions[match[1]] = match[2] === 'true' ? 'granted' : 'denied';
+            }
+            if (Object.keys(permissions).length === 0)
+              return `No permissions found for "${id}". Make sure the app is installed on the connected device.`;
+            return permissions;
+          } catch (err) {
+            return `Failed to list permissions: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+      },
+    });
+
+    ctx.registerTool('grant_permission', {
+      description:
+        'Grant a permission to the app on the connected iOS simulator or Android emulator.',
+      annotations: { destructiveHint: true },
+      parameters: z.object({
+        service: z
+          .string()
+          .describe(
+            'iOS: service name (e.g. "camera", "location"). Android: permission name (e.g. "CAMERA" or "android.permission.CAMERA").'
+          ),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
+      }),
+      handler: async ({ service, platform, bundleId }) => {
+        const p = await resolvePlatform(platform);
+        if (!p) return 'No simulator/emulator detected.';
+
+        const id = bundleId || (await detectBundleId(p));
+        if (!id) return 'Bundle ID / package name required.';
+
+        if (p === 'ios') {
+          try {
+            await ctx.exec(`xcrun simctl privacy booted grant "${service}" "${id}"`);
+            return `Granted "${service}" permission to ${id} on iOS simulator.`;
+          } catch (err) {
+            return `Failed to grant permission: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        } else {
+          const perm = service.startsWith('android.permission.')
+            ? service
+            : `android.permission.${service.toUpperCase()}`;
+          try {
+            await ctx.exec(`adb shell pm grant "${id}" "${perm}"`);
+            return `Granted "${perm}" to ${id} on Android device.`;
+          } catch (err) {
+            return `Failed to grant permission: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+      },
+    });
+
+    ctx.registerTool('revoke_permission', {
+      description:
+        'Revoke a permission from the app on the connected iOS simulator or Android emulator.',
+      annotations: { destructiveHint: true },
+      parameters: z.object({
+        service: z
+          .string()
+          .describe(
+            'iOS: service name (e.g. "camera", "location"). Android: permission name (e.g. "CAMERA" or "android.permission.CAMERA").'
+          ),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
+      }),
+      handler: async ({ service, platform, bundleId }) => {
+        const p = await resolvePlatform(platform);
+        if (!p) return 'No simulator/emulator detected.';
+
+        const id = bundleId || (await detectBundleId(p));
+        if (!id) return 'Bundle ID / package name required.';
+
+        if (p === 'ios') {
+          try {
+            await ctx.exec(`xcrun simctl privacy booted revoke "${service}" "${id}"`);
+            return `Revoked "${service}" permission from ${id} on iOS simulator.`;
+          } catch (err) {
+            return `Failed to revoke permission: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        } else {
+          const perm = service.startsWith('android.permission.')
+            ? service
+            : `android.permission.${service.toUpperCase()}`;
+          try {
+            await ctx.exec(`adb shell pm revoke "${id}" "${perm}"`);
+            return `Revoked "${perm}" from ${id} on Android device.`;
+          } catch (err) {
+            return `Failed to revoke permission: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+      },
+    });
+
+    ctx.registerTool('reset_permissions', {
+      description:
+        'Reset one or all permissions for the app on the connected iOS simulator or Android emulator. On iOS, omitting service resets all services. On Android, omitting service resets all runtime permissions.',
+      annotations: { destructiveHint: true },
+      parameters: z.object({
+        service: z
+          .string()
+          .optional()
+          .describe(
+            'iOS: specific service to reset (e.g. "camera"); omit to reset all. Android: permission name (e.g. "CAMERA"); omit to reset all runtime permissions.'
+          ),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
+      }),
+      handler: async ({ service, platform, bundleId }) => {
+        const p = await resolvePlatform(platform);
+        if (!p) return 'No simulator/emulator detected.';
+
+        const id = bundleId || (await detectBundleId(p));
+        if (!id) return 'Bundle ID / package name required.';
+
+        if (p === 'ios') {
+          const target = service ?? 'all';
+          try {
+            await ctx.exec(`xcrun simctl privacy booted reset "${target}" "${id}"`);
+            return `Reset ${service ? `"${service}"` : 'all'} permissions for ${id} on iOS simulator.`;
+          } catch (err) {
+            return `Failed to reset permissions: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        } else {
+          try {
+            if (service) {
+              const perm = service.startsWith('android.permission.')
+                ? service
+                : `android.permission.${service.toUpperCase()}`;
+              await ctx.exec(`adb shell pm revoke "${id}" "${perm}"`);
+              return `Reset "${perm}" for ${id} on Android device.`;
+            } else {
+              // pm reset-permissions is available on newer Android; fall back to pm clear
+              try {
+                await ctx.exec(`adb shell pm reset-permissions -p "${id}" 2>/dev/null`);
+              } catch {
+                await ctx.exec(`adb shell pm clear "${id}"`);
+              }
+              return `Reset all permissions for ${id} on Android device.`;
+            }
+          } catch (err) {
+            return `Failed to reset permissions: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+      },
+    });
+
+    ctx.registerTool('open_app_settings', {
+      description:
+        "Open the app's system settings page on the connected iOS simulator or Android emulator.",
+      annotations: { destructiveHint: false },
+      parameters: z.object({
+        platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe(
+            'Bundle ID (iOS) or package name (Android). Auto-detected if omitted. Required for Android.'
+          ),
+      }),
+      handler: async ({ platform, bundleId }) => {
+        const p = await resolvePlatform(platform);
+        if (!p) return 'No simulator/emulator detected.';
+
+        if (p === 'ios') {
+          try {
+            await ctx.exec('xcrun simctl openurl booted app-settings:');
+            return 'Opened app settings on iOS simulator.';
+          } catch (err) {
+            return `Failed to open app settings: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        } else {
+          const id = bundleId || (await detectBundleId(p));
+          if (!id) return 'Package name required for Android. Provide bundleId.';
+          try {
+            await ctx.exec(
+              `adb shell am start -a android.settings.APPLICATION_DETAILS_SETTINGS -d "package:${id}"`
+            );
+            return `Opened app settings for ${id} on Android device.`;
+          } catch (err) {
+            return `Failed to open app settings: ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+      },
+    });
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,7 @@ import { statuslinePlugin } from './plugins/statusline.js';
 import { debugGlobalsPlugin } from './plugins/debug-globals.js';
 import { inspectPointPlugin } from './plugins/inspect-point.js';
 import { devtoolsPlugin } from './plugins/devtools.js';
+import { permissionsPlugin } from './plugins/permissions.js';
 
 const logger = createLogger('server');
 
@@ -63,6 +64,7 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   storagePlugin,
   simulatorPlugin,
   deeplinkPlugin,
+  permissionsPlugin,
   uiInteractPlugin,
   navigationPlugin,
   accessibilityPlugin,


### PR DESCRIPTION
Implements the `permissions` plugin with five tools:
- `list_permissions` — lists all permission statuses for an app
- `grant_permission` — grants a specific permission
- `revoke_permission` — revokes a specific permission
- `reset_permissions` — resets one or all permissions to their defaults
- `open_app_settings` — opens the app's system settings page

iOS uses `xcrun simctl privacy booted <action> <service> <bundleId>`.
Android uses `adb shell pm grant/revoke` and `adb shell dumpsys package`.
Bundle ID / package name is auto-detected from config, CDP (react-native-device-info),
or can be provided explicitly.

https://claude.ai/code/session_011GyWrVvrvo2cpL9Rs2qHWG