### PR TITLE
Add filesystem plugin for browsing app sandbox directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 | **automation** | 3 | Wait/polling helpers for async state changes |
 | **profiler** | 9 | CPU profiling (React DevTools hook) + heap sampling + render tracking |
 | **test-recorder** | 7 | Record interactions and generate Appium, Maestro, or Detox tests |
+| **filesystem** | 5 | Browse and read files in app sandbox directories (Documents, caches, SQLite DBs) |
 | **devtools** | 1 | Open Chrome DevTools alongside the MCP via CDP proxy |
 | **debug-globals** | 1 | Auto-discover Redux stores, Apollo Client, and other debug globals |
 | **inspect-point** | 1 | Coordinate-based React component inspection (experimental) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -82,9 +82,9 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 Browse and read files inside the app's private sandbox. Useful for inspecting SQLite databases, MMKV stores, exported files, and cached data — without needing a rooted device or custom app code.
 
 - **`get_app_directories`** — Return absolute paths for the app's known directories: `root`, `documents`, `library`, `cache`, `temp`. iOS requires `bundleId`; Android falls back to `evalInApp` via expo-file-system / react-native-fs if `bundleId` is omitted.
-- **`list_directory`** — List files and subdirectories at a path. Returns structured entries (`name`, `path`, `isDirectory`, `size`, `modified`). Pass `recursive: true` for a full tree (returned as raw text). Call `get_app_directories` first to get the root path.
-- **`read_file`** — Read file contents with a configurable byte cap (default 50 KB, hard cap 1 MB). Use `encoding: 'base64'` for binary files (SQLite, images, MMKV). Params: `path`, `bundleId` (Android), `encoding`, `maxBytes`.
-- **`get_file_info`** — Get metadata for a single file or directory: `size`, `modified`, `isDirectory`.
+- **`list_directory`** — List files and subdirectories at a path. Returns compact text — one entry per line with type (`d`/`f`), size, modified date, and name; directories have a trailing `/`. Pass `recursive: true` for a full tree (raw text). Call `get_app_directories` first to get the root path.
+- **`read_file`** — Read file contents with a configurable byte cap (default 50 KB, hard cap 1 MB). Returns the file content as a plain string, or `{ content, truncated: true }` when the cap was reached. Use `encoding: 'base64'` for binary files (SQLite, images, MMKV). Params: `path`, `bundleId` (Android), `encoding`, `maxBytes`.
+- **`get_file_info`** — Get metadata for a single file or directory. Returns a compact single-line string: type (`d`/`f`), size, modified date, and name.
 - **`delete_file`** *(destructive)* — Delete a file. Requires `confirm: true` to prevent accidental deletion.
 
 > **Platform notes**

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Evaluate](#evaluate) · [Device](#device) · [Redux](#redux) · [Components](#components) · [Storage](#storage) · [Bundle](#bundle) · [Simulator](#simulator) · [Deep Link](#deep-link) · [Permissions](#permissions) · [UI Interact](#ui-interact) · [Navigation](#navigation) · [Accessibility](#accessibility) · [Profiler](#profiler) · [Test Recorder](#test-recorder) · [Commands](#commands) · [Resources](#resources) · [Prompts](#prompts)
+Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Evaluate](#evaluate) · [Device](#device) · [Redux](#redux) · [Components](#components) · [Storage](#storage) · [Bundle](#bundle) · [Simulator](#simulator) · [Filesystem](#filesystem) · [Deep Link](#deep-link) · [Permissions](#permissions) · [UI Interact](#ui-interact) · [Navigation](#navigation) · [Accessibility](#accessibility) · [Profiler](#profiler) · [Test Recorder](#test-recorder) · [Commands](#commands) · [Resources](#resources) · [Prompts](#prompts)
 
 ## Console
 
@@ -76,6 +76,20 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 - **`get_native_logs`** — Native logs (iOS syslog / Android logcat).
 - **`app_lifecycle`** — Launch, terminate, install, uninstall apps.
 - **`get_screen_orientation`** — Get current orientation.
+
+## Filesystem
+
+Browse and read files inside the app's private sandbox. Useful for inspecting SQLite databases, MMKV stores, exported files, and cached data — without needing a rooted device or custom app code.
+
+- **`get_app_directories`** — Return absolute paths for the app's known directories: `root`, `documents`, `library`, `cache`, `temp`. iOS requires `bundleId`; Android falls back to `evalInApp` via expo-file-system / react-native-fs if `bundleId` is omitted.
+- **`list_directory`** — List files and subdirectories at a path. Returns structured entries (`name`, `path`, `isDirectory`, `size`, `modified`). Pass `recursive: true` for a full tree (returned as raw text). Call `get_app_directories` first to get the root path.
+- **`read_file`** — Read file contents with a configurable byte cap (default 50 KB, hard cap 1 MB). Use `encoding: 'base64'` for binary files (SQLite, images, MMKV). Params: `path`, `bundleId` (Android), `encoding`, `maxBytes`.
+- **`get_file_info`** — Get metadata for a single file or directory: `size`, `modified`, `isDirectory`.
+- **`delete_file`** *(destructive)* — Delete a file. Requires `confirm: true` to prevent accidental deletion.
+
+> **Platform notes**
+> - **iOS Simulator**: uses `xcrun simctl get_app_container` to resolve the sandbox root, then `ls`/`head` on the host.
+> - **Android**: uses `adb shell run-as <packageName>` for app-private directories; public storage paths can be read without `bundleId`.
 
 ## Deep Link
 

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -52,18 +52,11 @@ export const filesystemPlugin = definePlugin({
       return out.trim();
     }
 
-    interface FileEntry {
-      name: string;
-      path: string;
-      isDirectory: boolean;
-      size: number;
-      modified: string;
-    }
-
-    // Parse `ls -la` output (macOS or Android busybox) into structured entries.
-    function parseLsOutput(output: string, parentPath: string): FileEntry[] {
-      const base = parentPath.replace(/\/$/, '');
-      const entries: FileEntry[] = [];
+    // Parse `ls -la` output (macOS or Android busybox) into a compact text listing.
+    // Format: `d`/`f` + padded size + modified + name (dirs get trailing `/`).
+    // First line is `# parentPath` so the AI can reconstruct full paths.
+    function parseLsOutput(output: string, parentPath: string): string {
+      const lines: string[] = [`# ${parentPath}`];
       for (const line of output.trim().split('\n')) {
         if (!line.trim() || line.startsWith('total ')) continue;
         const match = line.match(
@@ -72,33 +65,22 @@ export const filesystemPlugin = definePlugin({
         if (!match) continue;
         const [, perms, sizeStr, modified, name] = match;
         if (name === '.' || name === '..') continue;
-        entries.push({
-          name,
-          path: `${base}/${name}`,
-          isDirectory: perms.startsWith('d'),
-          size: parseInt(sizeStr, 10),
-          modified,
-        });
+        const type = perms.startsWith('d') ? 'd' : 'f';
+        lines.push(`${type}  ${sizeStr.padStart(7)}  ${modified}  ${name}${type === 'd' ? '/' : ''}`);
       }
-      return entries;
+      return lines.join('\n');
     }
 
-    // Parse a single `ls -lad` line; uses itemPath for name/path since lad
-    // shows the full path in the name column rather than just the basename.
-    function parseFileInfoLine(output: string, itemPath: string): FileEntry | null {
+    // Parse a single `ls -lad` line into a compact text entry.
+    function parseFileInfoLine(output: string, itemPath: string): string | null {
       for (const line of output.trim().split('\n')) {
         if (!line.trim() || line.startsWith('total ')) continue;
         const match = line.match(LS_LINE_RE);
         if (!match) continue;
         const [, perms, sizeStr, modified] = match;
         const name = itemPath.split('/').filter(Boolean).pop() ?? itemPath;
-        return {
-          name,
-          path: itemPath,
-          isDirectory: perms.startsWith('d'),
-          size: parseInt(sizeStr, 10),
-          modified,
-        };
+        const type = perms.startsWith('d') ? 'd' : 'f';
+        return `${type}  ${parseInt(sizeStr, 10).toString().padStart(7)}  ${modified}  ${name}${type === 'd' ? '/' : ''}`;
       }
       return null;
     }
@@ -237,7 +219,7 @@ export const filesystemPlugin = definePlugin({
               ? await ctx.exec(`ls ${flags} "${targetPath}" 2>&1`)
               : await ctx.exec(`adb shell ${runAs(bundleId)}ls ${flags} "${targetPath}" 2>&1`);
 
-          if (recursive) return { path: targetPath, raw: output };
+          if (recursive) return output;
           return parseLsOutput(output, targetPath);
         } catch (err) {
           return {
@@ -292,7 +274,10 @@ export const filesystemPlugin = definePlugin({
                 : await ctx.exec(`adb shell ${ra}dd if="${path}" bs=${limit} count=1 2>/dev/null`);
           }
 
-          return { path, content, encoding, bytesLimitApplied: limit };
+          const truncated = encoding === 'base64'
+            ? content.length >= Math.ceil(limit / 3) * 4
+            : content.length >= limit;
+          return truncated ? { content, truncated: true } : content;
         } catch (err) {
           return {
             error: `Failed to read file: ${err instanceof Error ? err.message : String(err)}`,
@@ -325,7 +310,7 @@ export const filesystemPlugin = definePlugin({
               : await ctx.exec(`adb shell ${runAs(bundleId)}ls -lad "${path}" 2>&1`);
 
           const info = parseFileInfoLine(output, path);
-          return info ?? { path, raw: output.trim() };
+          return info ?? output.trim();
         } catch (err) {
           return {
             error: `Failed to get file info: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -4,6 +4,10 @@ import { definePlugin } from '../plugin.js';
 const MAX_BYTES_DEFAULT = 50 * 1024;  // 50 KB
 const MAX_BYTES_CAP     = 1024 * 1024; // 1 MB
 
+// Matches one ls -la entry line on both macOS and Android busybox.
+const LS_LINE_RE =
+  /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)/;
+
 export const filesystemPlugin = definePlugin({
   name: 'filesystem',
 
@@ -12,12 +16,15 @@ export const filesystemPlugin = definePlugin({
     '(Documents, Library/Caches, temp). Supports iOS Simulator and Android.',
 
   async setup(ctx) {
-    // ── Helpers ──────────────────────────────────────────────────────────────
+    // Cache the detected platform for the lifetime of this plugin session so
+    // tools with platform:'auto' don't re-run xcrun/adb on every call.
+    let detectedPlatform: 'ios' | 'android' | null | undefined;
 
     async function detectPlatform(): Promise<'ios' | 'android' | null> {
+      if (detectedPlatform !== undefined) return detectedPlatform;
       try {
         const out = await ctx.exec('xcrun simctl list booted 2>/dev/null');
-        if (out.includes('Booted')) return 'ios';
+        if (out.includes('Booted')) return (detectedPlatform = 'ios');
       } catch {}
       try {
         const out = await ctx.exec('adb devices 2>/dev/null');
@@ -26,19 +33,17 @@ export const filesystemPlugin = definePlugin({
           .split('\n')
           .slice(1)
           .filter((l) => l.trim() && !l.startsWith('*'));
-        if (connected.length > 0) return 'android';
+        if (connected.length > 0) return (detectedPlatform = 'android');
       } catch {}
-      return null;
+      return (detectedPlatform = null);
     }
 
-    /** Throw if the path contains ".." segments to prevent directory traversal. */
     function assertSafePath(p: string): void {
       if (p.split('/').includes('..')) {
         throw new Error('Directory traversal not allowed: ".." segments are forbidden');
       }
     }
 
-    /** Return the iOS Simulator data-container root for the given bundle ID. */
     async function getIosContainer(bundleId: string): Promise<string> {
       const out = await ctx.exec(
         `xcrun simctl get_app_container booted "${bundleId}" data`
@@ -54,16 +59,12 @@ export const filesystemPlugin = definePlugin({
       modified: string;
     }
 
-    /**
-     * Parse `ls -la` output (macOS or Android busybox) into structured entries.
-     * parentPath is the directory that was listed.
-     */
+    // Parse `ls -la` output (macOS or Android busybox) into structured entries.
     function parseLsOutput(output: string, parentPath: string): FileEntry[] {
       const base = parentPath.replace(/\/$/, '');
       const entries: FileEntry[] = [];
       for (const line of output.trim().split('\n')) {
         if (!line.trim() || line.startsWith('total ')) continue;
-        // permissions  links  owner  group  size  date(3 tokens)  name
         const match = line.match(
           /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)\s+(.+)$/
         );
@@ -81,19 +82,12 @@ export const filesystemPlugin = definePlugin({
       return entries;
     }
 
-    /**
-     * Parse a single `ls -lad` line for get_file_info.
-     * Returns structured metadata for the item at `itemPath`.
-     */
-    function parseFileInfoLine(
-      output: string,
-      itemPath: string
-    ): FileEntry | null {
+    // Parse a single `ls -lad` line; uses itemPath for name/path since lad
+    // shows the full path in the name column rather than just the basename.
+    function parseFileInfoLine(output: string, itemPath: string): FileEntry | null {
       for (const line of output.trim().split('\n')) {
         if (!line.trim() || line.startsWith('total ')) continue;
-        const match = line.match(
-          /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)/
-        );
+        const match = line.match(LS_LINE_RE);
         if (!match) continue;
         const [, perms, sizeStr, modified] = match;
         const name = itemPath.split('/').filter(Boolean).pop() ?? itemPath;
@@ -108,7 +102,11 @@ export const filesystemPlugin = definePlugin({
       return null;
     }
 
-    // ── get_app_directories ───────────────────────────────────────────────────
+    // Prefix for Android `adb shell` commands that need app-private access.
+    // Package names are alphanumeric+dots, so no quoting is required.
+    function runAs(bundleId?: string): string {
+      return bundleId ? `run-as ${bundleId} ` : '';
+    }
 
     ctx.registerTool('get_app_directories', {
       description:
@@ -151,7 +149,7 @@ export const filesystemPlugin = definePlugin({
         if (bundleId) {
           try {
             const homeOut = await ctx.exec(
-              `adb shell run-as "${bundleId}" sh -c 'echo $HOME' 2>/dev/null`
+              `adb shell ${runAs(bundleId)}sh -c 'echo $HOME' 2>/dev/null`
             );
             const home = homeOut.trim() || `/data/data/${bundleId}`;
             return {
@@ -161,9 +159,7 @@ export const filesystemPlugin = definePlugin({
               cache:     `${home}/cache`,
               temp:      `${home}/cache`,
             };
-          } catch {
-            // fall through to evalInApp
-          }
+          } catch {}
         }
 
         try {
@@ -191,8 +187,6 @@ export const filesystemPlugin = definePlugin({
         }
       },
     });
-
-    // ── list_directory ────────────────────────────────────────────────────────
 
     ctx.registerTool('list_directory', {
       description:
@@ -237,16 +231,10 @@ export const filesystemPlugin = definePlugin({
 
         try {
           const flags = recursive ? '-laR' : '-la';
-          let output: string;
-
-          if (p === 'ios') {
-            output = await ctx.exec(`ls ${flags} "${targetPath}" 2>&1`);
-          } else {
-            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
-            output = await ctx.exec(
-              `adb shell ${runAs}ls ${flags} "${targetPath}" 2>&1`
-            );
-          }
+          const output =
+            p === 'ios'
+              ? await ctx.exec(`ls ${flags} "${targetPath}" 2>&1`)
+              : await ctx.exec(`adb shell ${runAs(bundleId)}ls ${flags} "${targetPath}" 2>&1`);
 
           if (recursive) return { path: targetPath, raw: output };
           return parseLsOutput(output, targetPath);
@@ -257,8 +245,6 @@ export const filesystemPlugin = definePlugin({
         }
       },
     });
-
-    // ── read_file ─────────────────────────────────────────────────────────────
 
     ctx.registerTool('read_file', {
       description:
@@ -291,22 +277,18 @@ export const filesystemPlugin = definePlugin({
           let content: string;
 
           if (p === 'ios') {
-            if (encoding === 'base64') {
-              content = await ctx.exec(`head -c ${limit} "${path}" | base64`);
-            } else {
-              content = await ctx.exec(`head -c ${limit} "${path}"`);
-            }
+            content =
+              encoding === 'base64'
+                ? await ctx.exec(`head -c ${limit} "${path}" | base64`)
+                : await ctx.exec(`head -c ${limit} "${path}"`);
           } else {
-            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
-            if (encoding === 'base64') {
-              content = await ctx.exec(
-                `adb shell "${runAs}sh -c 'dd if=${path} bs=1 count=${limit} 2>/dev/null | base64'"`
-              );
-            } else {
-              content = await ctx.exec(
-                `adb shell ${runAs}dd if="${path}" bs=1 count=${limit} 2>/dev/null`
-              );
-            }
+            // bs=${limit} count=1 reads up to `limit` bytes in a single I/O op,
+            // equivalent to bs=1 count=${limit} but without the per-byte syscall overhead.
+            const ra = runAs(bundleId);
+            content =
+              encoding === 'base64'
+                ? await ctx.exec(`adb shell ${ra}sh -c 'dd if="${path}" bs=${limit} count=1 2>/dev/null | base64'`)
+                : await ctx.exec(`adb shell ${ra}dd if="${path}" bs=${limit} count=1 2>/dev/null`);
           }
 
           return { path, content, encoding, bytesLimitApplied: limit };
@@ -317,8 +299,6 @@ export const filesystemPlugin = definePlugin({
         }
       },
     });
-
-    // ── get_file_info ─────────────────────────────────────────────────────────
 
     ctx.registerTool('get_file_info', {
       description:
@@ -338,20 +318,13 @@ export const filesystemPlugin = definePlugin({
         if (!p) return { error: 'No simulator/emulator detected' };
 
         try {
-          let output: string;
-          if (p === 'ios') {
-            output = await ctx.exec(`ls -lad "${path}" 2>&1`);
-          } else {
-            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
-            output = await ctx.exec(
-              `adb shell ${runAs}ls -lad "${path}" 2>&1`
-            );
-          }
+          const output =
+            p === 'ios'
+              ? await ctx.exec(`ls -lad "${path}" 2>&1`)
+              : await ctx.exec(`adb shell ${runAs(bundleId)}ls -lad "${path}" 2>&1`);
 
           const info = parseFileInfoLine(output, path);
-          if (info) return info;
-          // Fallback: return raw output if parsing failed
-          return { path, raw: output.trim() };
+          return info ?? { path, raw: output.trim() };
         } catch (err) {
           return {
             error: `Failed to get file info: ${err instanceof Error ? err.message : String(err)}`,
@@ -359,8 +332,6 @@ export const filesystemPlugin = definePlugin({
         }
       },
     });
-
-    // ── delete_file ───────────────────────────────────────────────────────────
 
     ctx.registerTool('delete_file', {
       description:
@@ -380,9 +351,7 @@ export const filesystemPlugin = definePlugin({
       }),
       handler: async ({ path, bundleId, platform, confirm }) => {
         if (!confirm) {
-          return {
-            error: 'Deletion not confirmed. Pass confirm: true to proceed.',
-          };
+          return { error: 'Deletion not confirmed. Pass confirm: true to proceed.' };
         }
         assertSafePath(path);
         const p = platform === 'auto' ? await detectPlatform() : platform;
@@ -392,8 +361,7 @@ export const filesystemPlugin = definePlugin({
           if (p === 'ios') {
             await ctx.exec(`rm -f "${path}"`);
           } else {
-            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
-            await ctx.exec(`adb shell ${runAs}rm "${path}"`);
+            await ctx.exec(`adb shell ${runAs(bundleId)}rm "${path}"`);
           }
           return { success: true, deleted: path };
         } catch (err) {

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -5,8 +5,9 @@ const MAX_BYTES_DEFAULT = 50 * 1024;  // 50 KB
 const MAX_BYTES_CAP     = 1024 * 1024; // 1 MB
 
 // Matches one ls -la entry line on both macOS and Android busybox.
+// Handles both month-first (Apr 11 10:19) and day-first (11 Apr 10:19) date formats.
 const LS_LINE_RE =
-  /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)/;
+  /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+((?:\w{3}\s+\d+|\d+\s+\w{3})\s+[\d:]+)/;
 
 export const filesystemPlugin = definePlugin({
   name: 'filesystem',
@@ -66,7 +67,7 @@ export const filesystemPlugin = definePlugin({
       for (const line of output.trim().split('\n')) {
         if (!line.trim() || line.startsWith('total ')) continue;
         const match = line.match(
-          /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)\s+(.+)$/
+          /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+((?:\w{3}\s+\d+|\d+\s+\w{3})\s+[\d:]+)\s+(.+)$/
         );
         if (!match) continue;
         const [, perms, sizeStr, modified, name] = match;

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -1,0 +1,407 @@
+import { z } from 'zod';
+import { definePlugin } from '../plugin.js';
+
+const MAX_BYTES_DEFAULT = 50 * 1024;  // 50 KB
+const MAX_BYTES_CAP     = 1024 * 1024; // 1 MB
+
+export const filesystemPlugin = definePlugin({
+  name: 'filesystem',
+
+  description:
+    'Browse and read files in the app sandboxed directories ' +
+    '(Documents, Library/Caches, temp). Supports iOS Simulator and Android.',
+
+  async setup(ctx) {
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    async function detectPlatform(): Promise<'ios' | 'android' | null> {
+      try {
+        const out = await ctx.exec('xcrun simctl list booted 2>/dev/null');
+        if (out.includes('Booted')) return 'ios';
+      } catch {}
+      try {
+        const out = await ctx.exec('adb devices 2>/dev/null');
+        const connected = out
+          .trim()
+          .split('\n')
+          .slice(1)
+          .filter((l) => l.trim() && !l.startsWith('*'));
+        if (connected.length > 0) return 'android';
+      } catch {}
+      return null;
+    }
+
+    /** Throw if the path contains ".." segments to prevent directory traversal. */
+    function assertSafePath(p: string): void {
+      if (p.split('/').includes('..')) {
+        throw new Error('Directory traversal not allowed: ".." segments are forbidden');
+      }
+    }
+
+    /** Return the iOS Simulator data-container root for the given bundle ID. */
+    async function getIosContainer(bundleId: string): Promise<string> {
+      const out = await ctx.exec(
+        `xcrun simctl get_app_container booted "${bundleId}" data`
+      );
+      return out.trim();
+    }
+
+    interface FileEntry {
+      name: string;
+      path: string;
+      isDirectory: boolean;
+      size: number;
+      modified: string;
+    }
+
+    /**
+     * Parse `ls -la` output (macOS or Android busybox) into structured entries.
+     * parentPath is the directory that was listed.
+     */
+    function parseLsOutput(output: string, parentPath: string): FileEntry[] {
+      const base = parentPath.replace(/\/$/, '');
+      const entries: FileEntry[] = [];
+      for (const line of output.trim().split('\n')) {
+        if (!line.trim() || line.startsWith('total ')) continue;
+        // permissions  links  owner  group  size  date(3 tokens)  name
+        const match = line.match(
+          /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)\s+(.+)$/
+        );
+        if (!match) continue;
+        const [, perms, sizeStr, modified, name] = match;
+        if (name === '.' || name === '..') continue;
+        entries.push({
+          name,
+          path: `${base}/${name}`,
+          isDirectory: perms.startsWith('d'),
+          size: parseInt(sizeStr, 10),
+          modified,
+        });
+      }
+      return entries;
+    }
+
+    /**
+     * Parse a single `ls -lad` line for get_file_info.
+     * Returns structured metadata for the item at `itemPath`.
+     */
+    function parseFileInfoLine(
+      output: string,
+      itemPath: string
+    ): FileEntry | null {
+      for (const line of output.trim().split('\n')) {
+        if (!line.trim() || line.startsWith('total ')) continue;
+        const match = line.match(
+          /^([dlrwxbcpst\-]{10}[+@.]?)\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)/
+        );
+        if (!match) continue;
+        const [, perms, sizeStr, modified] = match;
+        const name = itemPath.split('/').filter(Boolean).pop() ?? itemPath;
+        return {
+          name,
+          path: itemPath,
+          isDirectory: perms.startsWith('d'),
+          size: parseInt(sizeStr, 10),
+          modified,
+        };
+      }
+      return null;
+    }
+
+    // ── get_app_directories ───────────────────────────────────────────────────
+
+    ctx.registerTool('get_app_directories', {
+      description:
+        'Get known app sandbox directory paths (documents, cache, temp, library). ' +
+        'Returns absolute paths usable with list_directory and read_file.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({
+        bundleId: z
+          .string()
+          .optional()
+          .describe(
+            'App bundle ID (iOS, e.g. com.example.app) or package name (Android). ' +
+            'Required for iOS; used for Android private-directory resolution.'
+          ),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto'),
+      }),
+      handler: async ({ bundleId, platform }) => {
+        const p = platform === 'auto' ? await detectPlatform() : platform;
+        if (!p) return { error: 'No simulator/emulator detected' };
+
+        if (p === 'ios') {
+          if (!bundleId) return { error: 'bundleId is required for iOS' };
+          try {
+            const root = await getIosContainer(bundleId);
+            return {
+              root,
+              documents: `${root}/Documents`,
+              library:   `${root}/Library`,
+              cache:     `${root}/Library/Caches`,
+              temp:      `${root}/tmp`,
+            };
+          } catch (err) {
+            return {
+              error: `Failed to get container path: ${err instanceof Error ? err.message : String(err)}`,
+            };
+          }
+        }
+
+        // Android — try adb first, fall back to evalInApp
+        if (bundleId) {
+          try {
+            const homeOut = await ctx.exec(
+              `adb shell run-as "${bundleId}" sh -c 'echo $HOME' 2>/dev/null`
+            );
+            const home = homeOut.trim() || `/data/data/${bundleId}`;
+            return {
+              root:      home,
+              documents: `${home}/files`,
+              library:   home,
+              cache:     `${home}/cache`,
+              temp:      `${home}/cache`,
+            };
+          } catch {
+            // fall through to evalInApp
+          }
+        }
+
+        try {
+          const result = await ctx.evalInApp(
+            `(function() {
+              try {
+                var FS;
+                try { FS = require('expo-file-system'); } catch(e) {}
+                if (!FS) try { FS = require('react-native-fs'); } catch(e) {}
+                if (FS) return {
+                  documents: FS.documentDirectory  || FS.DocumentDirectoryPath  || null,
+                  cache:     FS.cacheDirectory     || FS.CachesDirectoryPath    || null,
+                  temp:      FS.cacheDirectory     || FS.TemporaryDirectoryPath || null,
+                  library:   FS.libraryDirectory   || FS.LibraryDirectoryPath   || null,
+                };
+                return { error: 'expo-file-system and react-native-fs not available' };
+              } catch(e) { return { error: e.message }; }
+            })()`
+          );
+          return result;
+        } catch (err) {
+          return {
+            error: `Failed to resolve app directories: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    });
+
+    // ── list_directory ────────────────────────────────────────────────────────
+
+    ctx.registerTool('list_directory', {
+      description:
+        'List files and directories in an app sandbox path. ' +
+        'Call get_app_directories first to obtain the root path.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({
+        path: z
+          .string()
+          .optional()
+          .describe(
+            'Absolute directory path to list. ' +
+            'Defaults to the app data container root (bundleId required).'
+          ),
+        bundleId: z
+          .string()
+          .optional()
+          .describe(
+            'App bundle ID (iOS) or package name (Android). ' +
+            'Required when path is omitted; also used for Android run-as access.'
+          ),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto'),
+        recursive: z
+          .boolean()
+          .default(false)
+          .describe('Recursively list subdirectories (returns raw text)'),
+      }),
+      handler: async ({ path, bundleId, platform, recursive }) => {
+        const p = platform === 'auto' ? await detectPlatform() : platform;
+        if (!p) return { error: 'No simulator/emulator detected' };
+
+        let targetPath = path;
+        if (!targetPath) {
+          if (!bundleId) return { error: 'Provide either path or bundleId' };
+          targetPath =
+            p === 'ios'
+              ? await getIosContainer(bundleId)
+              : `/data/data/${bundleId}`;
+        }
+
+        assertSafePath(targetPath);
+
+        try {
+          const flags = recursive ? '-laR' : '-la';
+          let output: string;
+
+          if (p === 'ios') {
+            output = await ctx.exec(`ls ${flags} "${targetPath}" 2>&1`);
+          } else {
+            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
+            output = await ctx.exec(
+              `adb shell ${runAs}ls ${flags} "${targetPath}" 2>&1`
+            );
+          }
+
+          if (recursive) return { path: targetPath, raw: output };
+          return parseLsOutput(output, targetPath);
+        } catch (err) {
+          return {
+            error: `Failed to list directory: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    });
+
+    // ── read_file ─────────────────────────────────────────────────────────────
+
+    ctx.registerTool('read_file', {
+      description:
+        'Read the contents of a file from the app sandbox. ' +
+        'Enforces a configurable size cap (default 50 KB, max 1 MB) to avoid flooding context.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({
+        path: z.string().describe('Absolute path to the file'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe('App package name (Android, for run-as access to private files)'),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto'),
+        encoding: z
+          .enum(['utf8', 'base64'])
+          .default('utf8')
+          .describe('Output encoding. Use base64 for binary files (images, SQLite, etc.)'),
+        maxBytes: z
+          .number()
+          .default(MAX_BYTES_DEFAULT)
+          .describe('Maximum bytes to read (default 50 KB, hard cap 1 MB)'),
+      }),
+      handler: async ({ path, bundleId, platform, encoding, maxBytes }) => {
+        assertSafePath(path);
+        const limit = Math.min(maxBytes, MAX_BYTES_CAP);
+        const p = platform === 'auto' ? await detectPlatform() : platform;
+        if (!p) return { error: 'No simulator/emulator detected' };
+
+        try {
+          let content: string;
+
+          if (p === 'ios') {
+            if (encoding === 'base64') {
+              content = await ctx.exec(`head -c ${limit} "${path}" | base64`);
+            } else {
+              content = await ctx.exec(`head -c ${limit} "${path}"`);
+            }
+          } else {
+            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
+            if (encoding === 'base64') {
+              content = await ctx.exec(
+                `adb shell "${runAs}sh -c 'dd if=${path} bs=1 count=${limit} 2>/dev/null | base64'"`
+              );
+            } else {
+              content = await ctx.exec(
+                `adb shell ${runAs}dd if="${path}" bs=1 count=${limit} 2>/dev/null`
+              );
+            }
+          }
+
+          return { path, content, encoding, bytesLimitApplied: limit };
+        } catch (err) {
+          return {
+            error: `Failed to read file: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    });
+
+    // ── get_file_info ─────────────────────────────────────────────────────────
+
+    ctx.registerTool('get_file_info', {
+      description:
+        'Get file or directory metadata: size, modification date, and whether it is a directory.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({
+        path: z.string().describe('Absolute path to the file or directory'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe('App package name (Android, for run-as)'),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto'),
+      }),
+      handler: async ({ path, bundleId, platform }) => {
+        assertSafePath(path);
+        const p = platform === 'auto' ? await detectPlatform() : platform;
+        if (!p) return { error: 'No simulator/emulator detected' };
+
+        try {
+          let output: string;
+          if (p === 'ios') {
+            output = await ctx.exec(`ls -lad "${path}" 2>&1`);
+          } else {
+            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
+            output = await ctx.exec(
+              `adb shell ${runAs}ls -lad "${path}" 2>&1`
+            );
+          }
+
+          const info = parseFileInfoLine(output, path);
+          if (info) return info;
+          // Fallback: return raw output if parsing failed
+          return { path, raw: output.trim() };
+        } catch (err) {
+          return {
+            error: `Failed to get file info: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    });
+
+    // ── delete_file ───────────────────────────────────────────────────────────
+
+    ctx.registerTool('delete_file', {
+      description:
+        'Delete a file from the app sandbox. ' +
+        'Requires confirm: true to prevent accidental deletion.',
+      annotations: { destructiveHint: true },
+      parameters: z.object({
+        path: z.string().describe('Absolute path to the file to delete'),
+        bundleId: z
+          .string()
+          .optional()
+          .describe('App package name (Android, for run-as)'),
+        platform: z.enum(['ios', 'android', 'auto']).default('auto'),
+        confirm: z
+          .boolean()
+          .describe('Must be set to true to confirm the deletion'),
+      }),
+      handler: async ({ path, bundleId, platform, confirm }) => {
+        if (!confirm) {
+          return {
+            error: 'Deletion not confirmed. Pass confirm: true to proceed.',
+          };
+        }
+        assertSafePath(path);
+        const p = platform === 'auto' ? await detectPlatform() : platform;
+        if (!p) return { error: 'No simulator/emulator detected' };
+
+        try {
+          if (p === 'ios') {
+            await ctx.exec(`rm -f "${path}"`);
+          } else {
+            const runAs = bundleId ? `run-as "${bundleId}" ` : '';
+            await ctx.exec(`adb shell ${runAs}rm "${path}"`);
+          }
+          return { success: true, deleted: path };
+        } catch (err) {
+          return {
+            error: `Failed to delete file: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    });
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,7 @@ import { debugGlobalsPlugin } from './plugins/debug-globals.js';
 import { inspectPointPlugin } from './plugins/inspect-point.js';
 import { devtoolsPlugin } from './plugins/devtools.js';
 import { permissionsPlugin } from './plugins/permissions.js';
+import { filesystemPlugin } from './plugins/filesystem.js';
 
 const logger = createLogger('server');
 
@@ -77,6 +78,7 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   debugGlobalsPlugin,
   inspectPointPlugin,
   devtoolsPlugin,
+  filesystemPlugin,
 ];
 
 export async function startServer(config: Required<MetroMCPConfig>): Promise<void> {


### PR DESCRIPTION
Implements five tools (get_app_directories, list_directory, read_file,
get_file_info, delete_file) that let callers inspect and read files from
the iOS Simulator data container (via xcrun simctl) and Android app-private
storage (via adb shell run-as). Includes path-traversal guard, a hard
1 MB read cap, and an evalInApp fallback for Android directory resolution.

https://claude.ai/code/session_012QS4orN9MZzsJY5DX7ecHh