### PR TITLE
Add environment plugin for inspecting app runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 | **errors** | 3 | Runtime exception collection + Metro bundle error detection |
 | **evaluate** | 1 | Execute JavaScript in the app runtime |
 | **device** | 4 | Device management, connection status, and app reload |
+| **environment** | 4 | Build flags, platform constants, env vars, and Expo config inspection |
 | **source** | 1 | Stack trace symbolication |
 | **redux** | 3 | Redux state inspection and action dispatch |
 | **components** | 5 | React component tree inspection |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Evaluate](#evaluate) · [Device](#device) · [Redux](#redux) · [Components](#components) · [Storage](#storage) · [Bundle](#bundle) · [Simulator](#simulator) · [Filesystem](#filesystem) · [Deep Link](#deep-link) · [Permissions](#permissions) · [UI Interact](#ui-interact) · [Navigation](#navigation) · [Accessibility](#accessibility) · [Profiler](#profiler) · [Test Recorder](#test-recorder) · [Commands](#commands) · [Resources](#resources) · [Prompts](#prompts)
+Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Evaluate](#evaluate) · [Device](#device) · [Environment](#environment) · [Redux](#redux) · [Components](#components) · [Storage](#storage) · [Bundle](#bundle) · [Simulator](#simulator) · [Filesystem](#filesystem) · [Deep Link](#deep-link) · [Permissions](#permissions) · [UI Interact](#ui-interact) · [Navigation](#navigation) · [Accessibility](#accessibility) · [Profiler](#profiler) · [Test Recorder](#test-recorder) · [Commands](#commands) · [Resources](#resources) · [Prompts](#prompts)
 
 ## Console
 
@@ -33,6 +33,13 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 - **`get_app_info`** — Bundle URL, platform, device name, VM type.
 - **`get_connection_status`** — CDP connection state and Metro status.
 - **`reload_app`** — Reload the app. Tries Metro's HTTP reload endpoint first, then falls back to `DevSettings.reload()` via CDP.
+
+## Environment
+
+- **`get_build_info`** — Return build-time and runtime flags: `__DEV__`, platform, OS version, React Native version, Hermes engine status, New Architecture flag, and expo-application fields (`bundleId`, `appVersion`, `buildNumber`) when available.
+- **`get_env_vars`** — Return a filtered subset of `process.env` from the running app. Credential-like keys (`SECRET`, `KEY`, `TOKEN`, `PASSWORD`, etc.) are redacted by default. Params: `filter` (key name substring), `includeAll` (include redacted keys).
+- **`get_platform_constants`** — Return the full `Platform.constants` object from React Native, including OS-specific build details and `reactNativeVersion`.
+- **`get_expo_config`** — Return `expo-constants` manifest / `expoConfig` fields if the app uses Expo, otherwise `null`. Skips internal fields (`plugins`, `hooks`, `_internal`, etc.).
 
 ## Source
 

--- a/src/plugins/environment.ts
+++ b/src/plugins/environment.ts
@@ -16,20 +16,25 @@ export const environmentPlugin = definePlugin({
         try {
           return await ctx.evalInApp(
             `(function() {
-  var RN = require('react-native');
-  var Platform = RN.Platform;
+  var constants = nativeModuleProxy.PlatformConstants.getConstants();
+  var systemName = constants.systemName || '';
   var result = {
     isDev: typeof __DEV__ !== 'undefined' ? __DEV__ : null,
-    platform: Platform.OS,
-    version: Platform.Version,
+    platform: systemName.toLowerCase() === 'ios' ? 'ios' : 'android',
+    version: constants.osVersion,
     hermesEnabled: typeof HermesInternal !== 'undefined',
     newArch: typeof nativeFabricUIManager !== 'undefined',
   };
   try {
-    var Application = require('expo-application');
-    result.bundleId = Application.applicationId;
-    result.appVersion = Application.nativeApplicationVersion;
-    result.buildNumber = Application.nativeBuildVersion;
+    var app = nativeModuleProxy.ExpoApplication;
+    if (app && app.getConstants) {
+      var appC = app.getConstants();
+      if (appC) {
+        result.bundleId = appC.applicationId;
+        result.appVersion = appC.nativeApplicationVersion;
+        result.buildNumber = appC.nativeBuildVersion;
+      }
+    }
   } catch(e) {}
   return result;
 })()`,
@@ -84,7 +89,7 @@ export const environmentPlugin = definePlugin({
       parameters: z.object({}),
       handler: async () => {
         try {
-          return await ctx.evalInApp(`require('react-native').Platform.constants`);
+          return await ctx.evalInApp(`nativeModuleProxy.PlatformConstants.getConstants()`);
         } catch (err) {
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }

--- a/src/plugins/environment.ts
+++ b/src/plugins/environment.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+import { definePlugin } from '../plugin.js';
+
+export const environmentPlugin = definePlugin({
+  name: 'environment',
+
+  description: 'Inspect app runtime environment: build flags, platform constants, Metro connection state, and a filtered subset of process.env',
+
+  async setup(ctx) {
+    ctx.registerTool('get_build_info', {
+      description:
+        'Return build-time and runtime flags for the running React Native app: __DEV__, platform, OS version, Hermes engine, New Architecture, and expo-application fields if available.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({}),
+      handler: async () => {
+        try {
+          const result = await ctx.evalInApp(
+            `(function() {
+  var RN = require('react-native');
+  var Platform = RN.Platform;
+  var result = {
+    isDev: typeof __DEV__ !== 'undefined' ? __DEV__ : null,
+    platform: Platform.OS,
+    version: Platform.Version,
+    hermesEnabled: typeof HermesInternal !== 'undefined',
+    newArch: typeof nativeFabricUIManager !== 'undefined',
+  };
+  try {
+    var Application = require('expo-application');
+    result.bundleId = Application.applicationId;
+    result.appVersion = Application.nativeApplicationVersion;
+    result.buildNumber = Application.nativeBuildVersion;
+  } catch(e) {}
+  return result;
+})()`,
+          );
+          return result;
+        } catch (err) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    });
+
+    ctx.registerTool('get_env_vars', {
+      description:
+        'Return a filtered subset of process.env from the running app. Credential-like keys (SECRET, KEY, TOKEN, PASSWORD, etc.) are redacted by default. Use filter to search by key name substring.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({
+        filter: z
+          .string()
+          .optional()
+          .describe('Substring to match against env var key names (case-insensitive)'),
+        includeAll: z
+          .boolean()
+          .default(false)
+          .describe('When true, includes credential keys that are otherwise redacted'),
+      }),
+      handler: async ({ filter, includeAll }) => {
+        const filterStr = filter ?? '';
+        const includeAllBool = includeAll ?? false;
+
+        const expression = `(function() {
+  var env = typeof process !== 'undefined' ? process.env : {};
+  var DENY = /SECRET|KEY|TOKEN|PASSWORD|PASS|PRIVATE|AUTH|CREDENTIAL|DSN/i;
+  var filter = ${JSON.stringify(filterStr)};
+  var includeAll = ${JSON.stringify(includeAllBool)};
+  var result = {};
+  Object.keys(env).forEach(function(k) {
+    if (!includeAll && DENY.test(k)) return;
+    if (filter && k.toLowerCase().indexOf(filter.toLowerCase()) === -1) return;
+    result[k] = env[k];
+  });
+  return result;
+})()`;
+
+        try {
+          const result = await ctx.evalInApp(expression);
+          return result;
+        } catch (err) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    });
+
+    ctx.registerTool('get_platform_constants', {
+      description: 'Return the full Platform.constants object from React Native, including OS-specific build details.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({}),
+      handler: async () => {
+        try {
+          const result = await ctx.evalInApp(`require('react-native').Platform.constants`);
+          return result;
+        } catch (err) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    });
+
+    ctx.registerTool('get_expo_config', {
+      description:
+        'Return expo-constants manifest/expoConfig fields if the app uses Expo, otherwise null.',
+      annotations: { readOnlyHint: true },
+      parameters: z.object({}),
+      handler: async () => {
+        try {
+          const result = await ctx.evalInApp(
+            `(function() {
+  try {
+    return require('expo-constants').default.expoConfig ||
+           require('expo-constants').default.manifest;
+  } catch(e) { return null; }
+})()`,
+          );
+          return result;
+        } catch (err) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    });
+  },
+});

--- a/src/plugins/environment.ts
+++ b/src/plugins/environment.ts
@@ -4,7 +4,7 @@ import { definePlugin } from '../plugin.js';
 export const environmentPlugin = definePlugin({
   name: 'environment',
 
-  description: 'Inspect app runtime environment: build flags, platform constants, Metro connection state, and a filtered subset of process.env',
+  description: 'Inspect app runtime environment: build flags, platform constants, and a filtered subset of process.env',
 
   async setup(ctx) {
     ctx.registerTool('get_build_info', {
@@ -14,7 +14,7 @@ export const environmentPlugin = definePlugin({
       parameters: z.object({}),
       handler: async () => {
         try {
-          const result = await ctx.evalInApp(
+          return await ctx.evalInApp(
             `(function() {
   var RN = require('react-native');
   var Platform = RN.Platform;
@@ -34,7 +34,6 @@ export const environmentPlugin = definePlugin({
   return result;
 })()`,
           );
-          return result;
         } catch (err) {
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }
@@ -56,26 +55,23 @@ export const environmentPlugin = definePlugin({
           .describe('When true, includes credential keys that are otherwise redacted'),
       }),
       handler: async ({ filter, includeAll }) => {
-        const filterStr = filter ?? '';
-        const includeAllBool = includeAll ?? false;
-
         const expression = `(function() {
   var env = typeof process !== 'undefined' ? process.env : {};
   var DENY = /SECRET|KEY|TOKEN|PASSWORD|PASS|PRIVATE|AUTH|CREDENTIAL|DSN/i;
-  var filter = ${JSON.stringify(filterStr)};
-  var includeAll = ${JSON.stringify(includeAllBool)};
+  var filter = ${JSON.stringify(filter ?? '')};
+  var filterLower = filter.toLowerCase();
+  var includeAll = ${JSON.stringify(includeAll)};
   var result = {};
   Object.keys(env).forEach(function(k) {
     if (!includeAll && DENY.test(k)) return;
-    if (filter && k.toLowerCase().indexOf(filter.toLowerCase()) === -1) return;
+    if (filter && !k.toLowerCase().includes(filterLower)) return;
     result[k] = env[k];
   });
   return result;
 })()`;
 
         try {
-          const result = await ctx.evalInApp(expression);
-          return result;
+          return await ctx.evalInApp(expression);
         } catch (err) {
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }
@@ -88,8 +84,7 @@ export const environmentPlugin = definePlugin({
       parameters: z.object({}),
       handler: async () => {
         try {
-          const result = await ctx.evalInApp(`require('react-native').Platform.constants`);
-          return result;
+          return await ctx.evalInApp(`require('react-native').Platform.constants`);
         } catch (err) {
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }
@@ -103,7 +98,7 @@ export const environmentPlugin = definePlugin({
       parameters: z.object({}),
       handler: async () => {
         try {
-          const result = await ctx.evalInApp(
+          return await ctx.evalInApp(
             `(function() {
   try {
     return require('expo-constants').default.expoConfig ||
@@ -111,7 +106,6 @@ export const environmentPlugin = definePlugin({
   } catch(e) { return null; }
 })()`,
           );
-          return result;
         } catch (err) {
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }

--- a/src/plugins/environment.ts
+++ b/src/plugins/environment.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 
+// Minified deep-clean helper — strips null/undefined/empty-string from objects and arrays recursively
+const CLEAN_FN = `function clean(v){if(v==null||v==='')return undefined;if(Array.isArray(v)){var a=v.map(clean).filter(function(x){return x!==undefined});return a.length?a:undefined;}if(typeof v==='object'){var o={};Object.keys(v).forEach(function(k){var c=clean(v[k]);if(c!==undefined)o[k]=c;});return Object.keys(o).length?o:undefined;}return v;}`;
+const FMT_RNV_FN = `function fmtRnv(v){return v.major+'.'+v.minor+'.'+v.patch;}`;
+
 export const environmentPlugin = definePlugin({
   name: 'environment',
 
@@ -9,19 +13,23 @@ export const environmentPlugin = definePlugin({
   async setup(ctx) {
     ctx.registerTool('get_build_info', {
       description:
-        'Return build-time and runtime flags for the running React Native app: __DEV__, platform, OS version, Hermes engine, New Architecture, and expo-application fields if available.',
+        'Return build-time and runtime flags for the running React Native app: __DEV__, platform, OS version, RN version, Hermes engine, New Architecture, and expo-application fields if available.',
       annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
         try {
           return await ctx.evalInApp(
             `(function() {
+  ${CLEAN_FN}
+  ${FMT_RNV_FN}
   var constants = nativeModuleProxy.PlatformConstants.getConstants();
   var systemName = constants.systemName || '';
+  var rnv = constants.reactNativeVersion;
   var result = {
     isDev: typeof __DEV__ !== 'undefined' ? __DEV__ : null,
     platform: systemName.toLowerCase() === 'ios' ? 'ios' : 'android',
     version: constants.osVersion,
+    rnVersion: rnv ? fmtRnv(rnv) : null,
     hermesEnabled: typeof HermesInternal !== 'undefined',
     newArch: typeof nativeFabricUIManager !== 'undefined',
   };
@@ -36,7 +44,7 @@ export const environmentPlugin = definePlugin({
       }
     }
   } catch(e) {}
-  return result;
+  return clean(result) || {};
 })()`,
           );
         } catch (err) {
@@ -70,7 +78,7 @@ export const environmentPlugin = definePlugin({
   Object.keys(env).forEach(function(k) {
     if (!includeAll && DENY.test(k)) return;
     if (filter && !k.toLowerCase().includes(filterLower)) return;
-    result[k] = env[k];
+    if (env[k] != null && env[k] !== '') result[k] = env[k];
   });
   return result;
 })()`;
@@ -89,7 +97,16 @@ export const environmentPlugin = definePlugin({
       parameters: z.object({}),
       handler: async () => {
         try {
-          return await ctx.evalInApp(`nativeModuleProxy.PlatformConstants.getConstants()`);
+          return await ctx.evalInApp(
+            `(function() {
+  ${CLEAN_FN}
+  ${FMT_RNV_FN}
+  var c = nativeModuleProxy.PlatformConstants.getConstants();
+  var out = Object.assign({}, c);
+  if (out.reactNativeVersion) out.reactNativeVersion = fmtRnv(out.reactNativeVersion);
+  return clean(out);
+})()`,
+          );
         } catch (err) {
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
         }
@@ -105,10 +122,18 @@ export const environmentPlugin = definePlugin({
         try {
           return await ctx.evalInApp(
             `(function() {
+  ${CLEAN_FN}
   try {
     var c = globalThis.expo && globalThis.expo.modules && globalThis.expo.modules.ExponentConstants;
     if (!c) return null;
-    return c.expoConfig || c.manifest || null;
+    var cfg = c.expoConfig || c.manifest || null;
+    if (!cfg) return null;
+    var SKIP = ['plugins', 'hooks', '_internal', 'doctor', 'extra', 'locales', 'web', 'platforms', 'nodeModulesDir'];
+    var r = {};
+    Object.keys(cfg).forEach(function(k) {
+      if (SKIP.indexOf(k) === -1) r[k] = cfg[k];
+    });
+    return clean(r) || null;
   } catch(e) { return null; }
 })()`,
           );

--- a/src/plugins/environment.ts
+++ b/src/plugins/environment.ts
@@ -106,8 +106,9 @@ export const environmentPlugin = definePlugin({
           return await ctx.evalInApp(
             `(function() {
   try {
-    return require('expo-constants').default.expoConfig ||
-           require('expo-constants').default.manifest;
+    var c = globalThis.expo && globalThis.expo.modules && globalThis.expo.modules.ExponentConstants;
+    if (!c) return null;
+    return c.expoConfig || c.manifest || null;
   } catch(e) { return null; }
 })()`,
           );

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,6 +50,7 @@ import { inspectPointPlugin } from './plugins/inspect-point.js';
 import { devtoolsPlugin } from './plugins/devtools.js';
 import { permissionsPlugin } from './plugins/permissions.js';
 import { filesystemPlugin } from './plugins/filesystem.js';
+import { environmentPlugin } from './plugins/environment.js';
 
 const logger = createLogger('server');
 
@@ -79,6 +80,7 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   inspectPointPlugin,
   devtoolsPlugin,
   filesystemPlugin,
+  environmentPlugin,
 ];
 
 export async function startServer(config: Required<MetroMCPConfig>): Promise<void> {


### PR DESCRIPTION
## Summary
This PR adds a new `environmentPlugin` that provides tools for inspecting the runtime environment of React Native applications, including build flags, platform information, environment variables, and Expo configuration.

## Key Changes
- **New plugin**: `src/plugins/environment.ts` with four inspection tools:
  - `get_build_info`: Returns build-time and runtime flags (__DEV__, platform, OS version, Hermes engine status, New Architecture support, and Expo app metadata if available)
  - `get_env_vars`: Returns a filtered subset of process.env with automatic redaction of credential-like keys (SECRET, KEY, TOKEN, PASSWORD, etc.), with optional filtering by key name and override to include all keys
  - `get_platform_constants`: Returns the full React Native Platform.constants object with OS-specific build details
  - `get_expo_config`: Returns Expo manifest/expoConfig fields if the app uses Expo, otherwise null
- **Server integration**: Registered the new plugin in `src/server.ts` as a built-in plugin

## Implementation Details
- All tools are read-only (marked with `readOnlyHint: true`)
- Environment variable inspection includes security-conscious defaults: credential-like keys are automatically redacted unless explicitly requested via the `includeAll` parameter
- Tools gracefully handle errors and missing dependencies (e.g., when Expo is not available)
- Uses `ctx.evalInApp()` to execute code in the app runtime context, ensuring accurate platform-specific information

https://claude.ai/code/session_01QVME98agMHaSVFUTd3YoD1