### PR TITLE
Custom plugin improvements

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,13 +29,13 @@ bunx metro-mcp --host 192.168.1.100 --port 19000
 
 ## Config File
 
-metro-mcp loads `metro-mcp.config.ts` (or `.js`) from the **current working directory** at startup.
+metro-mcp looks for `metro-mcp.config.ts` (or `.js`) in your project root. In **Claude Code, Cursor, and VS Code**, the project root is discovered automatically via MCP roots — no path configuration needed.
 
 ::: tip TypeScript vs JavaScript
 `metro-mcp.config.ts` only works when running via `bunx` (Bun runtime). Use `metro-mcp.config.js` if running via `npx` / Node.js.
 :::
 
-**For global MCP installs** (the typical setup in Claude Code and Cursor), the server's CWD is not reliably set to your project root. Specify the config path explicitly instead:
+If your client doesn't support MCP roots, or you want to point at a config in a non-standard location, pass the path explicitly:
 
 ```json
 {
@@ -49,7 +49,7 @@ metro-mcp loads `metro-mcp.config.ts` (or `.js`) from the **current working dire
 }
 ```
 
-Or via CLI when adding the MCP server:
+Or via CLI:
 
 ```bash
 claude mcp add metro-mcp -- bunx metro-mcp --config /Users/you/my-project/metro-mcp.config.ts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@
 |----------|---------|-------------|
 | `METRO_HOST` | `localhost` | Metro bundler host |
 | `METRO_PORT` | `8081` | Metro bundler port |
+| `METRO_MCP_CONFIG` | — | Path to config file (absolute or relative to CWD) |
+| `METRO_MCP_PLUGINS` | — | Colon-separated plugin paths to load (e.g. `./my-plugin.ts:metro-mcp-plugin-foo`) |
 | `METRO_MCP_PROXY_ENABLED` | `true` | Enable the CDP proxy for Chrome DevTools coexistence |
 | `METRO_MCP_PROXY_PORT` | `0` (random) | Fixed port for the CDP proxy. Use `0` for a random available port |
 | `DEBUG` | — | Enable debug logging |
@@ -20,12 +22,48 @@ bunx metro-mcp --host 192.168.1.100 --port 19000
 
 | Argument | Description |
 |----------|-------------|
-| `--host`, `-h` | Metro bundler host |
+| `--host`, `-H` | Metro bundler host |
 | `--port`, `-p` | Metro bundler port |
+| `--config`, `-c` | Path to config file (overrides `METRO_MCP_CONFIG`) |
+| `--plugin` | Load a plugin by path (repeatable) |
 
 ## Config File
 
-Create `metro-mcp.config.ts` in your project root:
+metro-mcp loads `metro-mcp.config.ts` (or `.js`) from the **current working directory** at startup.
+
+::: tip TypeScript vs JavaScript
+`metro-mcp.config.ts` only works when running via `bunx` (Bun runtime). Use `metro-mcp.config.js` if running via `npx` / Node.js.
+:::
+
+**For global MCP installs** (the typical setup in Claude Code and Cursor), the server's CWD is not reliably set to your project root. Specify the config path explicitly instead:
+
+```json
+{
+  "mcpServers": {
+    "metro-mcp": {
+      "command": "bunx",
+      "args": ["metro-mcp"],
+      "env": { "METRO_MCP_CONFIG": "/Users/you/my-project/metro-mcp.config.ts" }
+    }
+  }
+}
+```
+
+Or via CLI when adding the MCP server:
+
+```bash
+claude mcp add metro-mcp -- bunx metro-mcp --config /Users/you/my-project/metro-mcp.config.ts
+```
+
+Run with `DEBUG=1` to see exactly where the server is looking for config:
+
+```bash
+DEBUG=1 bunx metro-mcp
+# logs: Config search CWD: /some/path
+# logs: Loaded config from /full/path/metro-mcp.config.ts
+```
+
+Create the config file:
 
 ```typescript
 import { defineConfig } from 'metro-mcp';

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -41,24 +41,17 @@ Or use the one-click install buttons:
 
 ### With a config file
 
-For global MCP installs (the typical setup), the server's CWD is not reliably set to your project root, so pass the config path explicitly:
+In Claude Code, Cursor, and VS Code, metro-mcp automatically discovers `metro-mcp.config.ts` (or `.js`) from your project root — no extra configuration needed. Just add the file and it will be picked up.
+
+```bash
+# Install metro-mcp as usual
+claude mcp add metro-mcp -- bunx metro-mcp
+```
+
+If your client doesn't support MCP roots, pass the config path explicitly:
 
 ```bash
 claude mcp add metro-mcp -- bunx metro-mcp --config /Users/you/my-project/metro-mcp.config.ts
-```
-
-Or set it via `METRO_MCP_CONFIG` in your MCP server config (useful in Cursor / VS Code):
-
-```json
-{
-  "mcpServers": {
-    "metro-mcp": {
-      "command": "bunx",
-      "args": ["metro-mcp"],
-      "env": { "METRO_MCP_CONFIG": "/Users/you/my-project/metro-mcp.config.ts" }
-    }
-  }
-}
 ```
 
 See [Configuration](/configuration) for all options.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -39,6 +39,30 @@ Or use the one-click install buttons:
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=metro-mcp&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22metro-mcp%22%5D%2C%22env%22%3A%7B%7D%7D)
 [![Install in Cursor](https://img.shields.io/badge/Install_in-Cursor-000000?style=flat-square&logoColor=white)](https://cursor.com/en/install-mcp?name=metro-mcp&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIm1ldHJvLW1jcCJdLCJlbnYiOnt9fQ==)
 
+### With a config file
+
+For global MCP installs (the typical setup), the server's CWD is not reliably set to your project root, so pass the config path explicitly:
+
+```bash
+claude mcp add metro-mcp -- bunx metro-mcp --config /Users/you/my-project/metro-mcp.config.ts
+```
+
+Or set it via `METRO_MCP_CONFIG` in your MCP server config (useful in Cursor / VS Code):
+
+```json
+{
+  "mcpServers": {
+    "metro-mcp": {
+      "command": "bunx",
+      "args": ["metro-mcp"],
+      "env": { "METRO_MCP_CONFIG": "/Users/you/my-project/metro-mcp.config.ts" }
+    }
+  }
+}
+```
+
+See [Configuration](/configuration) for all options.
+
 ### With a custom Metro port
 
 ```bash

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,7 +5,7 @@ metro-mcp is plugin-based. You can extend it with local files or npm packages.
 ## Creating a plugin
 
 ```typescript
-import { definePlugin } from 'metro-mcp/plugin';
+import { definePlugin } from 'metro-mcp';
 import { z } from 'zod';
 
 export default definePlugin({

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -67,3 +67,30 @@ export default defineConfig({
 ```
 
 npm packages use the `metro-mcp-plugin-*` naming convention.
+
+## Loading plugins without a config file
+
+Load plugins via CLI or env var — useful for global installs where auto-discovery of a project config file isn't reliable:
+
+```bash
+# Single plugin
+bunx metro-mcp --plugin ./my-plugin.ts
+
+# Multiple plugins (colon-separated env var)
+METRO_MCP_PLUGINS=./plugin-a.ts:metro-mcp-plugin-foo bunx metro-mcp
+```
+
+In an MCP server config:
+
+```json
+{
+  "mcpServers": {
+    "metro-mcp": {
+      "command": "bunx",
+      "args": ["metro-mcp", "--plugin", "./my-plugin.ts"]
+    }
+  }
+}
+```
+
+Plugins specified this way are appended after any plugins defined in the config file.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -70,7 +70,7 @@ npm packages use the `metro-mcp-plugin-*` naming convention.
 
 ## Loading plugins without a config file
 
-Load plugins via CLI or env var — useful for global installs where auto-discovery of a project config file isn't reliable:
+Load plugins via CLI or env var — useful when you want to load a plugin without creating a config file, or for clients that don't support MCP roots:
 
 ```bash
 # Single plugin

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
     "url": "https://github.com/steve228uk/metro-mcp/issues"
   },
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/plugin.js",
+  "types": "./dist/plugin.d.ts",
   "bin": {
     "metro-mcp": "dist/bin/metro-mcp.js"
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/plugin.d.ts",
+      "require": "./dist/plugin.cjs",
+      "import": "./dist/plugin.js"
     },
     "./plugin": {
       "types": "./dist/plugin.d.ts",
@@ -74,5 +75,6 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import type { MetroMCPConfig } from './plugin.js';
 import { createLogger } from './utils/logger.js';
 
@@ -26,8 +27,11 @@ const DEFAULT_CONFIG: Required<MetroMCPConfig> = {
 
 /**
  * Load configuration from environment variables, CLI args, and config file.
+ * @param rootPath - Directory to search for a config file. Overrides CWD for
+ *   auto-discovery but is ignored when an explicit --config / METRO_MCP_CONFIG path
+ *   is provided.
  */
-export async function loadConfig(args: string[]): Promise<Required<MetroMCPConfig>> {
+export async function loadConfig(args: string[], rootPath?: string): Promise<Required<MetroMCPConfig>> {
   const config = structuredClone(DEFAULT_CONFIG);
 
   // Environment variables
@@ -51,6 +55,9 @@ export async function loadConfig(args: string[]): Promise<Required<MetroMCPConfi
   }
 
   // CLI args
+  let configFilePath: string | undefined;
+  const extraPlugins: string[] = [];
+
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if ((arg === '--host' || arg === '-h') && args[i + 1]) {
@@ -61,22 +68,57 @@ export async function loadConfig(args: string[]): Promise<Required<MetroMCPConfi
         config.metro.port = port;
         config.metro.autoDiscover = false;
       }
+    } else if ((arg === '--config' || arg === '-c') && args[i + 1]) {
+      configFilePath = args[++i];
+    } else if (arg === '--plugin' && args[i + 1]) {
+      extraPlugins.push(args[++i]);
     }
   }
 
-  // Try to load config file
-  const configPaths = ['metro-mcp.config.ts', 'metro-mcp.config.js'];
-  for (const configPath of configPaths) {
+  // Env var fallbacks (CLI flags take precedence)
+  if (!configFilePath && process.env.METRO_MCP_CONFIG) {
+    configFilePath = process.env.METRO_MCP_CONFIG;
+  }
+  if (process.env.METRO_MCP_PLUGINS) {
+    extraPlugins.push(...process.env.METRO_MCP_PLUGINS.split(':').filter(Boolean));
+  }
+
+  // Load config file
+  const cwd = rootPath ?? process.cwd();
+  logger.debug(`Config search CWD: ${cwd}`);
+
+  if (configFilePath) {
+    // Explicit path — throw on failure (user asserted this file exists)
+    const fullPath = resolve(cwd, configFilePath);
     try {
-      const fullPath = `${process.cwd()}/${configPath}`;
       const mod = await import(fullPath);
       const fileConfig: MetroMCPConfig = mod.default || mod;
       mergeConfig(config, fileConfig);
-      logger.info(`Loaded config from ${configPath}`);
-      break;
-    } catch {
-      // Config file not found or invalid, continue
+      logger.info(`Loaded config from ${fullPath}`);
+    } catch (err) {
+      throw new Error(`Failed to load config from ${fullPath}: ${err}`);
     }
+  } else {
+    // Auto-discover from CWD
+    // Note: .ts files only load under Bun runtime; use .js with npx/Node.js
+    const configPaths = ['metro-mcp.config.ts', 'metro-mcp.config.js'];
+    for (const configPath of configPaths) {
+      try {
+        const fullPath = resolve(cwd, configPath);
+        const mod = await import(fullPath);
+        const fileConfig: MetroMCPConfig = mod.default || mod;
+        mergeConfig(config, fileConfig);
+        logger.info(`Loaded config from ${fullPath}`);
+        break;
+      } catch {
+        // Config file not found or invalid, continue
+      }
+    }
+  }
+
+  // Append any plugins from CLI/env (additive — supplements config file plugins)
+  if (extraPlugins.length > 0) {
+    config.plugins = [...config.plugins, ...extraPlugins];
   }
 
   return config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,19 +16,24 @@ Usage:
   metro-mcp [options]
 
 Options:
-  --host, -H <host>    Metro host (default: localhost, env: METRO_HOST)
-  --port, -p <port>    Metro port (default: 8081, env: METRO_PORT)
-  --intercept-fetch    Enable fetch interception for network tracking
-  --help               Show this help message
+  --host, -H <host>       Metro host (default: localhost, env: METRO_HOST)
+  --port, -p <port>       Metro port (default: 8081, env: METRO_PORT)
+  --config, -c <path>     Path to config file (env: METRO_MCP_CONFIG)
+  --plugin <path>         Load a plugin (repeatable, env: METRO_MCP_PLUGINS)
+  --help                  Show this help message
 
 Environment Variables:
-  METRO_HOST           Metro bundler host
-  METRO_PORT           Metro bundler port
-  DEBUG                Enable debug logging
+  METRO_HOST              Metro bundler host
+  METRO_PORT              Metro bundler port
+  METRO_MCP_CONFIG        Path to config file (absolute or relative to CWD)
+  METRO_MCP_PLUGINS       Colon-separated plugin paths
+  DEBUG                   Enable debug logging
 
 Examples:
   metro-mcp
   metro-mcp --port 19000
+  metro-mcp --config /path/to/metro-mcp.config.ts
+  METRO_MCP_CONFIG=/path/to/metro-mcp.config.ts metro-mcp
   METRO_PORT=8082 metro-mcp
 `);
     process.exit(0);
@@ -37,7 +42,7 @@ Examples:
   try {
     const config = await loadConfig(args);
     logger.info(`Starting metro-mcp (Metro: ${config.metro.host}:${config.metro.port})`);
-    await startServer(config);
+    await startServer(config, args);
   } catch (err) {
     logger.error('Fatal error:', err);
     process.exit(1);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,10 @@
 import { exec } from 'child_process';
+import { resolve } from 'node:path';
 import { promisify } from 'util';
 import fs from 'fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { SubscribeRequestSchema, UnsubscribeRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { SubscribeRequestSchema, UnsubscribeRequestSchema, RootsListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 
 const execAsync = promisify(exec);
 import { z } from 'zod';
@@ -18,6 +19,7 @@ import type {
 } from './plugin.js';
 import { CDPSession, CDPMultiplexer, scanMetroPorts, selectBestTarget, fetchTargets, supportsMultipleDebuggers } from 'metro-bridge';
 import type { MetroTarget } from 'metro-bridge';
+import { loadConfig } from './config.js';
 import { MetroEventsClient } from './metro/events.js';
 import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
@@ -83,7 +85,7 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   environmentPlugin,
 ];
 
-export async function startServer(config: Required<MetroMCPConfig>): Promise<void> {
+export async function startServer(config: Required<MetroMCPConfig>, args: string[] = []): Promise<void> {
   const mcpServer = new McpServer(
     {
       name: 'metro-mcp',
@@ -205,8 +207,12 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     await enableCDPDomains();
   });
 
+  // Tracks all plugin registrations (tools, resources, prompts) so they can be
+  // removed and re-registered when the active project root changes.
+  const registrations: Array<{ remove: () => void }> = [];
+
   // Create the plugin context factory
-  function createPluginContext(plugin: PluginDefinition): PluginContext {
+  function createPluginContext(plugin: PluginDefinition, cfg: Required<MetroMCPConfig>): PluginContext {
     const pluginLogger = createLogger(plugin.name);
     return {
       cdp: cdpSession,
@@ -217,7 +223,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
             ? (toolConfig.parameters as z.ZodObject<z.ZodRawShape>).shape
             : { input: toolConfig.parameters };
 
-          mcpServer.registerTool(
+          const registration = mcpServer.registerTool(
             name,
             {
               description: toolConfig.description,
@@ -246,6 +252,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
               }
             }
           );
+          registrations.push(registration);
           pluginLogger.debug(`Registered tool: ${name}`);
         } catch (err) {
           pluginLogger.error(`Failed to register tool ${name}:`, err);
@@ -253,7 +260,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
       },
       registerResource: (uri: string, resourceConfig: ResourceConfig) => {
         try {
-          mcpServer.resource(
+          const registration = mcpServer.resource(
             resourceConfig.name,
             uri,
             { description: resourceConfig.description, mimeType: resourceConfig.mimeType || 'application/json' },
@@ -262,6 +269,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
               return { contents: [{ uri, text: content, mimeType: resourceConfig.mimeType || 'application/json' }] };
             }
           );
+          registrations.push(registration);
           pluginLogger.debug(`Registered resource: ${uri}`);
         } catch (err) {
           pluginLogger.error(`Failed to register resource ${uri}:`, err);
@@ -276,7 +284,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
               argsShape[arg.name] = arg.required ? z.string() : z.string().optional();
             }
           }
-          mcpServer.prompt(
+          const registration = mcpServer.prompt(
             name,
             promptConfig.description,
             argsShape,
@@ -290,6 +298,7 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
               };
             }
           );
+          registrations.push(registration);
           pluginLogger.debug(`Registered prompt: ${name}`);
         } catch (err) {
           pluginLogger.error(`Failed to register prompt ${name}:`, err);
@@ -342,13 +351,13 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
           throw err;
         }
       },
-      config: config as unknown as Record<string, unknown>,
+      config: cfg as unknown as Record<string, unknown>,
       logger: pluginLogger,
       metro: {
-        host: config.metro.host!,
-        port: config.metro.port!,
+        host: cfg.metro.host!,
+        port: cfg.metro.port!,
         fetch: async (path: string) => {
-          return fetch(`http://${config.metro.host}:${config.metro.port}${path}`);
+          return fetch(`http://${cfg.metro.host}:${cfg.metro.port}${path}`);
         },
       },
       exec: async (command: string) => {
@@ -362,33 +371,44 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
     };
   }
 
-  // Load and initialize all plugins
-  const allPlugins = [...BUILT_IN_PLUGINS];
+  // Load and initialize all plugins. Clears existing registrations first so this
+  // can be called again when the active project root changes.
+  async function initPlugins(cfg: Required<MetroMCPConfig>, rootPath?: string): Promise<void> {
+    // Remove all existing tool/resource/prompt registrations
+    for (const reg of registrations) {
+      try { reg.remove(); } catch { /* ignore */ }
+    }
+    registrations.length = 0;
 
-  // Load external plugins from config
-  for (const pluginPath of config.plugins) {
-    try {
-      const mod = await import(pluginPath);
-      const plugin: PluginDefinition = mod.default || mod;
-      if (plugin?.name && typeof plugin?.setup === 'function') {
-        allPlugins.push(plugin);
-        logger.info(`Loaded external plugin: ${plugin.name}`);
+    const baseDir = rootPath ?? process.cwd();
+    const allPlugins = [...BUILT_IN_PLUGINS];
+
+    for (const pluginPath of cfg.plugins) {
+      try {
+        const resolvedPath = pluginPath.startsWith('.') ? resolve(baseDir, pluginPath) : pluginPath;
+        const mod = await import(resolvedPath);
+        const plugin: PluginDefinition = mod.default || mod;
+        if (plugin?.name && typeof plugin?.setup === 'function') {
+          allPlugins.push(plugin);
+          logger.info(`Loaded external plugin: ${plugin.name}`);
+        }
+      } catch (err) {
+        logger.error(`Failed to load plugin ${pluginPath}:`, err);
       }
-    } catch (err) {
-      logger.error(`Failed to load plugin ${pluginPath}:`, err);
+    }
+
+    for (const plugin of allPlugins) {
+      try {
+        const ctx = createPluginContext(plugin, cfg);
+        await plugin.setup(ctx);
+        logger.debug(`Initialized plugin: ${plugin.name}`);
+      } catch (err) {
+        logger.error(`Failed to initialize plugin ${plugin.name}:`, err);
+      }
     }
   }
 
-  // Initialize plugins
-  for (const plugin of allPlugins) {
-    try {
-      const ctx = createPluginContext(plugin);
-      await plugin.setup(ctx);
-      logger.debug(`Initialized plugin: ${plugin.name}`);
-    } catch (err) {
-      logger.error(`Failed to initialize plugin ${plugin.name}:`, err);
-    }
-  }
+  await initPlugins(config);
 
   // Singleton proxy lock — prevents multiple metro-mcp instances from competing
   // for Metro's single CDP WebSocket, which causes a connect/disconnect spam loop.
@@ -589,6 +609,38 @@ export async function startServer(config: Required<MetroMCPConfig>): Promise<voi
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);
   logger.info('MCP server started');
+
+  // Reload config + plugins from the client's active project root. A concurrency
+  // guard prevents interleaved runs if roots-changed fires while a reload is already
+  // in progress (IDE batch-sends notifications on project switch).
+  let reloadInProgress = false;
+  async function reloadFromRoots(suppressErrors = false): Promise<void> {
+    if (reloadInProgress) return;
+    reloadInProgress = true;
+    try {
+      const { roots } = await mcpServer.server.listRoots();
+      const firstRoot = roots[0];
+      if (!firstRoot) return;
+      const rootPath = new URL(firstRoot.uri).pathname;
+      logger.info(`Reloading plugins from: ${rootPath}`);
+      const newConfig = await loadConfig(args, rootPath);
+      await initPlugins(newConfig, rootPath);
+      logger.info(`Plugins reloaded for: ${rootPath}`);
+    } catch (err) {
+      if (!suppressErrors) logger.error('Failed to reload plugins on roots change:', err);
+    } finally {
+      reloadInProgress = false;
+    }
+  }
+
+  // Reload all plugins when the client's active project root changes.
+  // This lets a single global metro-mcp install automatically pick up the
+  // metro-mcp.config.ts from whichever project the user is working in.
+  mcpServer.server.setNotificationHandler(RootsListChangedNotificationSchema, () => reloadFromRoots());
+
+  // On first client connection, load config from the initial project root (if any).
+  // This handles the case where the user opens an IDE with a project already open.
+  mcpServer.server.oninitialized = () => reloadFromRoots(true);
 
   // Clean up on shutdown
   process.on('SIGINT', () => { cleanProxyLock(); cdpMultiplexer?.stop(); process.exit(0); });


### PR DESCRIPTION
This PR exports `definePlugin` and `defineConfig` from `index.ts` so the user no longer needs to import `metro-mcp/plugin` to access these.

It also fixes issues with loading the config file from the CWD using absolute paths instead of relative.

Users can now also load a config file from a specific path or plugins via an ENV var.