### PR TITLE
Add community plugins page to docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
         items: [
           { text: 'Client SDK', link: '/sdk' },
           { text: 'Custom Plugins', link: '/plugins' },
+          { text: 'Community Plugins', link: '/community-plugins' },
           { text: 'Profiling', link: '/profiling' },
           { text: 'Test Recording', link: '/testing' },
         ],

--- a/docs/.vitepress/data/plugin-blacklist.ts
+++ b/docs/.vitepress/data/plugin-blacklist.ts
@@ -1,0 +1,4 @@
+/** Packages excluded from the community plugins listing. */
+export const PLUGIN_BLACKLIST: string[] = [
+  // 'metro-mcp-plugin-example',
+]

--- a/docs/.vitepress/data/plugins.data.ts
+++ b/docs/.vitepress/data/plugins.data.ts
@@ -1,4 +1,5 @@
 import { PLUGIN_BLACKLIST } from './plugin-blacklist'
+import { sanitizeExternalUrl } from '../utils/sanitizeExternalUrl'
 
 export interface CommunityPlugin {
   name: string
@@ -8,26 +9,6 @@ export interface CommunityPlugin {
   date: string
   links: { npm: string; homepage?: string; repository?: string }
   searchText: string
-}
-
-function sanitizeExternalUrl(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined
-
-  const trimmed = value.trim()
-  if (!trimmed) return undefined
-
-  const normalized = trimmed.startsWith('git+') ? trimmed.slice(4) : trimmed
-
-  try {
-    const parsed = new URL(normalized)
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return parsed.toString()
-    }
-  } catch {
-    return undefined
-  }
-
-  return undefined
 }
 
 export default {

--- a/docs/.vitepress/data/plugins.data.ts
+++ b/docs/.vitepress/data/plugins.data.ts
@@ -10,6 +10,26 @@ export interface CommunityPlugin {
   searchText: string
 }
 
+function sanitizeExternalUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const normalized = trimmed.startsWith('git+') ? trimmed.slice(4) : trimmed
+
+  try {
+    const parsed = new URL(normalized)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString()
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
 export default {
   async load(): Promise<CommunityPlugin[]> {
     const res = await fetch(
@@ -41,8 +61,8 @@ export default {
           date: p.date as string,
           links: {
             npm: `https://www.npmjs.com/package/${name}`,
-            homepage: p.links?.homepage as string | undefined,
-            repository: p.links?.repository as string | undefined,
+            homepage: sanitizeExternalUrl(p.links?.homepage),
+            repository: sanitizeExternalUrl(p.links?.repository),
           },
           searchText: `${name} ${description} ${author}`.toLowerCase(),
         }

--- a/docs/.vitepress/data/plugins.data.ts
+++ b/docs/.vitepress/data/plugins.data.ts
@@ -1,0 +1,51 @@
+import { PLUGIN_BLACKLIST } from './plugin-blacklist'
+
+export interface CommunityPlugin {
+  name: string
+  description: string
+  version: string
+  author: string
+  date: string
+  links: { npm: string; homepage?: string; repository?: string }
+  searchText: string
+}
+
+export default {
+  async load(): Promise<CommunityPlugin[]> {
+    const res = await fetch(
+      'https://registry.npmjs.org/-/v1/search?text=metro-mcp-plugin&size=100',
+    )
+
+    if (!res.ok) {
+      throw new Error(`npm registry error: ${res.status}`)
+    }
+
+    const { objects } = await res.json()
+
+    return objects
+      .map((o: any) => o.package)
+      .filter(
+        (p: any) =>
+          p.name.startsWith('metro-mcp-plugin-') &&
+          !PLUGIN_BLACKLIST.includes(p.name),
+      )
+      .map((p: any) => {
+        const name = p.name as string
+        const description = (p.description ?? '') as string
+        const author = (p.publisher?.username ?? p.author?.name ?? '') as string
+        return {
+          name,
+          description,
+          version: p.version as string,
+          author,
+          date: p.date as string,
+          links: {
+            npm: `https://www.npmjs.com/package/${name}`,
+            homepage: p.links?.homepage as string | undefined,
+            repository: p.links?.repository as string | undefined,
+          },
+          searchText: `${name} ${description} ${author}`.toLowerCase(),
+        }
+      })
+  },
+}

--- a/docs/.vitepress/theme/CommunityPlugins.vue
+++ b/docs/.vitepress/theme/CommunityPlugins.vue
@@ -2,26 +2,12 @@
 import { ref, computed } from 'vue'
 import { data as plugins } from '../data/plugins.data'
 import type { CommunityPlugin } from '../data/plugins.data'
+import { sanitizeExternalUrl } from '../utils/sanitizeExternalUrl'
 
 const query = ref('')
 
 type CommunityPluginWithSafeLinks = CommunityPlugin & {
   safeLinks: { repository?: string; homepage?: string }
-}
-
-function sanitizeExternalUrl(url: string | undefined): string | undefined {
-  if (!url) return undefined
-
-  try {
-    const parsed = new URL(url)
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return parsed.toString()
-    }
-  } catch {
-    return undefined
-  }
-
-  return undefined
 }
 
 const filtered = computed<CommunityPluginWithSafeLinks[]>(() => {

--- a/docs/.vitepress/theme/CommunityPlugins.vue
+++ b/docs/.vitepress/theme/CommunityPlugins.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { data as plugins } from '../data/plugins.data'
+import type { CommunityPlugin } from '../data/plugins.data'
+
+const query = ref('')
+
+const filtered = computed(() => {
+  const q = query.value.toLowerCase().trim()
+  if (!q) return plugins
+  return plugins.filter((p: CommunityPlugin) => p.searchText.includes(q))
+})
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <div class="community-plugins">
+    <div class="search-bar">
+      <input
+        v-model="query"
+        type="search"
+        placeholder="Search plugins..."
+        class="search-input"
+        aria-label="Search community plugins"
+      />
+      <span v-if="plugins.length > 0" class="plugin-count">
+        {{ filtered.length }} of {{ plugins.length }} plugins
+      </span>
+    </div>
+
+    <div v-if="plugins.length === 0" class="empty-state">
+      No community plugins found yet. Be the first to
+      <a href="https://github.com/steve228uk/metro-mcp/issues" target="_blank" rel="noopener">publish one</a>!
+    </div>
+
+    <div v-else-if="filtered.length === 0" class="empty-state">
+      No plugins match <strong>{{ query }}</strong>.
+    </div>
+
+    <ul v-else class="plugin-list">
+      <li v-for="plugin in filtered" :key="plugin.name" class="plugin-card">
+        <div class="plugin-header">
+          <a :href="plugin.links.npm" target="_blank" rel="noopener" class="plugin-name">
+            {{ plugin.name }}
+          </a>
+          <span class="plugin-version">v{{ plugin.version }}</span>
+        </div>
+
+        <p v-if="plugin.description" class="plugin-description">
+          {{ plugin.description }}
+        </p>
+
+        <div class="plugin-meta">
+          <span v-if="plugin.author" class="plugin-author">by {{ plugin.author }}</span>
+          <span v-if="plugin.date" class="plugin-date">{{ formatDate(plugin.date) }}</span>
+        </div>
+
+        <div v-if="plugin.links.repository || plugin.links.homepage" class="plugin-links">
+          <a
+            v-if="plugin.links.repository"
+            :href="plugin.links.repository"
+            target="_blank"
+            rel="noopener"
+            class="plugin-link"
+          >
+            repository
+          </a>
+          <a
+            v-if="plugin.links.homepage"
+            :href="plugin.links.homepage"
+            target="_blank"
+            rel="noopener"
+            class="plugin-link"
+          >
+            homepage
+          </a>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.community-plugins {
+  margin: 1.5rem 0;
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 1.5rem;
+}
+
+.search-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  border-color: var(--vp-c-brand-1);
+}
+
+.plugin-count {
+  font-size: 13px;
+  color: var(--vp-c-text-3);
+  white-space: nowrap;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-bg-soft);
+  border-radius: 12px;
+}
+
+.plugin-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.plugin-card {
+  padding: 16px 20px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+  transition: border-color 0.2s;
+}
+
+.plugin-card:hover {
+  border-color: var(--vp-c-brand-1);
+}
+
+.plugin-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.plugin-name {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  font-family: var(--vp-font-family-mono);
+}
+
+.plugin-name:hover {
+  text-decoration: underline;
+}
+
+.plugin-version {
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+}
+
+.plugin-description {
+  margin: 0 0 8px;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  line-height: 1.5;
+}
+
+.plugin-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+  margin-bottom: 10px;
+}
+
+.plugin-links {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.plugin-link {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.plugin-link:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/CommunityPlugins.vue
+++ b/docs/.vitepress/theme/CommunityPlugins.vue
@@ -5,10 +5,38 @@ import type { CommunityPlugin } from '../data/plugins.data'
 
 const query = ref('')
 
-const filtered = computed(() => {
+type CommunityPluginWithSafeLinks = CommunityPlugin & {
+  safeLinks: { repository?: string; homepage?: string }
+}
+
+function sanitizeExternalUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined
+
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString()
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
+const filtered = computed<CommunityPluginWithSafeLinks[]>(() => {
   const q = query.value.toLowerCase().trim()
-  if (!q) return plugins
-  return plugins.filter((p: CommunityPlugin) => p.searchText.includes(q))
+  const matching = !q
+    ? plugins
+    : plugins.filter((p: CommunityPlugin) => p.searchText.includes(q))
+
+  return matching.map((plugin: CommunityPlugin) => ({
+    ...plugin,
+    safeLinks: {
+      repository: sanitizeExternalUrl(plugin.links.repository),
+      homepage: sanitizeExternalUrl(plugin.links.homepage),
+    },
+  }))
 })
 
 function formatDate(iso: string) {
@@ -62,10 +90,10 @@ function formatDate(iso: string) {
           <span v-if="plugin.date" class="plugin-date">{{ formatDate(plugin.date) }}</span>
         </div>
 
-        <div v-if="plugin.links.repository || plugin.links.homepage" class="plugin-links">
+        <div v-if="plugin.safeLinks.repository || plugin.safeLinks.homepage" class="plugin-links">
           <a
-            v-if="plugin.links.repository"
-            :href="plugin.links.repository"
+            v-if="plugin.safeLinks.repository"
+            :href="plugin.safeLinks.repository"
             target="_blank"
             rel="noopener"
             class="plugin-link"
@@ -73,8 +101,8 @@ function formatDate(iso: string) {
             repository
           </a>
           <a
-            v-if="plugin.links.homepage"
-            :href="plugin.links.homepage"
+            v-if="plugin.safeLinks.homepage"
+            :href="plugin.safeLinks.homepage"
             target="_blank"
             rel="noopener"
             class="plugin-link"

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,8 +1,10 @@
 import { h } from 'vue'
+import type { App } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import QuickInstall from './QuickInstall.vue'
 import GitHubStars from './GitHubStars.vue'
 import PromptDemo from './PromptDemo.vue'
+import CommunityPlugins from './CommunityPlugins.vue'
 import './custom.css'
 
 export default {
@@ -14,5 +16,8 @@ export default {
       'home-hero-after': () => h('div', { class: 'mobile-hero-demo' }, [h(PromptDemo)]),
       'home-features-before': () => h(QuickInstall),
     })
+  },
+  enhanceApp({ app }: { app: App }) {
+    app.component('CommunityPlugins', CommunityPlugins)
   },
 }

--- a/docs/.vitepress/utils/sanitizeExternalUrl.ts
+++ b/docs/.vitepress/utils/sanitizeExternalUrl.ts
@@ -1,0 +1,19 @@
+export function sanitizeExternalUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const normalized = trimmed.startsWith('git+') ? trimmed.slice(4) : trimmed
+
+  try {
+    const parsed = new URL(normalized)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString()
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}

--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -1,0 +1,15 @@
+# Community Plugins
+
+A collection of community-built plugins for metro-mcp, auto-discovered from npm. Plugins are fetched from the npm registry at build time — any package following the `metro-mcp-plugin-*` naming convention will appear here automatically.
+
+<CommunityPlugins />
+
+---
+
+## Submit your plugin
+
+If your plugin isn't listed or you'd like to report an issue, please [open an issue or PR on GitHub](https://github.com/steve228uk/metro-mcp/issues).
+
+::: tip Want to create your own plugin?
+Check out the [Custom Plugins guide](/plugins) to learn how to build and publish a metro-mcp plugin.
+:::

--- a/src/server.ts
+++ b/src/server.ts
@@ -219,8 +219,14 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
       events: eventsClient,
       registerTool: <T extends z.ZodType>(name: string, toolConfig: ToolConfig<T>) => {
         try {
-          const inputSchema = toolConfig.parameters instanceof z.ZodObject
-            ? (toolConfig.parameters as z.ZodObject<z.ZodRawShape>).shape
+          // Use duck typing in addition to instanceof so plugins that bundle a
+          // different copy of zod (e.g. via file: deps or yarn link) still work.
+          const params = toolConfig.parameters as Record<string, unknown>;
+          const isZodObject =
+            params instanceof z.ZodObject ||
+            (typeof params.shape === 'object' && params.shape !== null);
+          const inputSchema = isZodObject
+            ? (toolConfig.parameters as unknown as z.ZodObject<z.ZodRawShape>).shape
             : { input: toolConfig.parameters };
 
           const registration = mcpServer.registerTool(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because the docs build now depends on a build-time fetch to the npm registry and renders third-party metadata/links (with URL sanitization), which could introduce flaky builds or unexpected content changes.
> 
> **Overview**
> Adds a new **Community Plugins** docs page and sidebar link that lists `metro-mcp-plugin-*` packages auto-discovered from the npm registry at build time.
> 
> Introduces a VitePress data loader (`plugins.data.ts`) with a configurable `PLUGIN_BLACKLIST`, and a `CommunityPlugins` Vue component that provides search/filtering plus safe external link rendering for repository/homepage URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e797e9b1e1d7a5796bb6a2579e79324f16c9ca05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->