### PR TITLE
Sanitize community plugin external links

### DIFF
--- a/docs/.vitepress/data/plugins.data.ts
+++ b/docs/.vitepress/data/plugins.data.ts
@@ -10,6 +10,26 @@ export interface CommunityPlugin {
   searchText: string
 }
 
+function sanitizeExternalUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const normalized = trimmed.startsWith('git+') ? trimmed.slice(4) : trimmed
+
+  try {
+    const parsed = new URL(normalized)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString()
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
 export default {
   async load(): Promise<CommunityPlugin[]> {
     const res = await fetch(
@@ -41,8 +61,8 @@ export default {
           date: p.date as string,
           links: {
             npm: `https://www.npmjs.com/package/${name}`,
-            homepage: p.links?.homepage as string | undefined,
-            repository: p.links?.repository as string | undefined,
+            homepage: sanitizeExternalUrl(p.links?.homepage),
+            repository: sanitizeExternalUrl(p.links?.repository),
           },
           searchText: `${name} ${description} ${author}`.toLowerCase(),
         }

--- a/docs/.vitepress/theme/CommunityPlugins.vue
+++ b/docs/.vitepress/theme/CommunityPlugins.vue
@@ -5,10 +5,38 @@ import type { CommunityPlugin } from '../data/plugins.data'
 
 const query = ref('')
 
-const filtered = computed(() => {
+type CommunityPluginWithSafeLinks = CommunityPlugin & {
+  safeLinks: { repository?: string; homepage?: string }
+}
+
+function sanitizeExternalUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined
+
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString()
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
+const filtered = computed<CommunityPluginWithSafeLinks[]>(() => {
   const q = query.value.toLowerCase().trim()
-  if (!q) return plugins
-  return plugins.filter((p: CommunityPlugin) => p.searchText.includes(q))
+  const matching = !q
+    ? plugins
+    : plugins.filter((p: CommunityPlugin) => p.searchText.includes(q))
+
+  return matching.map((plugin: CommunityPlugin) => ({
+    ...plugin,
+    safeLinks: {
+      repository: sanitizeExternalUrl(plugin.links.repository),
+      homepage: sanitizeExternalUrl(plugin.links.homepage),
+    },
+  }))
 })
 
 function formatDate(iso: string) {
@@ -62,10 +90,10 @@ function formatDate(iso: string) {
           <span v-if="plugin.date" class="plugin-date">{{ formatDate(plugin.date) }}</span>
         </div>
 
-        <div v-if="plugin.links.repository || plugin.links.homepage" class="plugin-links">
+        <div v-if="plugin.safeLinks.repository || plugin.safeLinks.homepage" class="plugin-links">
           <a
-            v-if="plugin.links.repository"
-            :href="plugin.links.repository"
+            v-if="plugin.safeLinks.repository"
+            :href="plugin.safeLinks.repository"
             target="_blank"
             rel="noopener"
             class="plugin-link"
@@ -73,8 +101,8 @@ function formatDate(iso: string) {
             repository
           </a>
           <a
-            v-if="plugin.links.homepage"
-            :href="plugin.links.homepage"
+            v-if="plugin.safeLinks.homepage"
+            :href="plugin.safeLinks.homepage"
             target="_blank"
             rel="noopener"
             class="plugin-link"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk doc-site change that only affects how external `homepage`/`repository` URLs are derived and rendered; main risk is unintentionally hiding links that don’t parse as http(s).
> 
> **Overview**
> **Sanitizes community plugin external links** by validating `homepage` and `repository` URLs from the npm registry and only allowing `http:`/`https:` (including normalizing `git+` prefixes).
> 
> The community plugins UI now renders these sanitized values via a new `safeLinks` field, so invalid or non-http(s) URLs are omitted from the link list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20bf45f97ca798d510fe0c549cdd5a214c6c9b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->