### PR TITLE
Add CLI commands for plugin scaffolding and project setup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "metro-mcp",
       "dependencies": {
+        "@clack/prompts": "^1.2.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
@@ -64,6 +65,10 @@
     "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
+
+    "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
     "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
 
@@ -343,7 +348,13 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@1.2.1", "", {}, "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow=="],
+
+    "fast-string-width": ["fast-string-width@1.1.0", "", { "dependencies": { "fast-string-truncated-width": "^1.2.0" } }, "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.1.6", "", { "dependencies": { "fast-string-width": "^1.1.0" } }, "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -520,6 +531,8 @@
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       {
         text: 'Reference',
         items: [
+          { text: 'CLI', link: '/cli' },
           { text: 'Tools', link: '/tools' },
           { text: 'Changelog', link: '/changelog' },
         ],

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,132 @@
+# CLI Reference
+
+metro-mcp is invoked via `bunx` or `npx`. It has several subcommands for scaffolding and diagnostics, plus flags for configuring the MCP server.
+
+## Subcommands
+
+### `create-plugin`
+
+Scaffold a new `metro-mcp-plugin-*` package interactively.
+
+```bash
+bunx metro-mcp create-plugin
+```
+
+Prompts for:
+- **Plugin name suffix** — becomes the directory and package name (`metro-mcp-plugin-<name>`)
+- **Description** — optional
+- **Author** — defaults to `git config user.name`
+- **Version** — defaults to `0.1.0`
+
+Generates a complete plugin package with `src/index.ts` (hello-world plugin), `package.json`, `tsconfig.json`, `README.md`, `LICENSE`, and `.gitignore`, then runs `bun install` automatically.
+
+See [Custom Plugins](/plugins) for the full plugin authoring guide.
+
+---
+
+### `init`
+
+Create a `metro-mcp.config.ts` in the current directory.
+
+```bash
+bunx metro-mcp init
+```
+
+Prompts for Metro host and port, then writes a config file with sensible defaults and commented-out examples for plugins and other options. Aborts if a config file already exists.
+
+See [Configuration](/configuration) for all available config options.
+
+---
+
+### `doctor`
+
+Check the health of your metro-mcp setup.
+
+```bash
+bunx metro-mcp doctor
+```
+
+Runs the following checks and reports pass/fail for each:
+
+| Check | Details |
+|---|---|
+| Node.js version | Must be >=18 |
+| Config file | Looks for `metro-mcp.config.ts` or `.js` in the current directory |
+| Metro connectivity | HTTP request to the configured host:port |
+| Plugin paths | Verifies local plugin file paths from your config exist on disk |
+
+Exit code is `0` if all checks pass, `1` if any fail.
+
+---
+
+### `validate-plugin`
+
+Validate that a plugin file exports a valid `PluginDefinition`.
+
+```bash
+bunx metro-mcp validate-plugin <path>
+```
+
+**Example:**
+
+```bash
+bunx metro-mcp validate-plugin ./src/index.ts
+bunx metro-mcp validate-plugin ./node_modules/metro-mcp-plugin-mmkv/dist/index.js
+```
+
+Checks that the file:
+1. Exists and can be imported
+2. Exports an object (as default or named export) with a `name` string and a `setup` function
+
+Prints the plugin's name, version, and description if valid. Exit code is `0` on success, `1` on failure.
+
+---
+
+## MCP server options
+
+When run without a subcommand, metro-mcp starts the MCP server:
+
+```bash
+bunx metro-mcp [options]
+```
+
+| Flag | Description |
+|---|---|
+| `--host`, `-H <host>` | Metro bundler host (default: `localhost`) |
+| `--port`, `-p <port>` | Metro bundler port (default: `8081`) |
+| `--config`, `-c <path>` | Path to a config file (absolute or relative to CWD) |
+| `--plugin <path>` | Load a plugin by path — repeatable |
+| `--help` | Print usage |
+
+**Examples:**
+
+```bash
+# Default — connects to Metro on localhost:8081
+bunx metro-mcp
+
+# Custom port (Expo default)
+bunx metro-mcp --port 19000
+
+# Explicit config file
+bunx metro-mcp --config /path/to/metro-mcp.config.ts
+
+# Load a plugin without a config file
+bunx metro-mcp --plugin ./my-plugin.ts
+
+# Multiple plugins
+bunx metro-mcp --plugin ./plugin-a.ts --plugin ./plugin-b.ts
+```
+
+## Environment variables
+
+See [Configuration](/configuration#environment-variables) for the full list of environment variables.
+
+Key ones at a glance:
+
+| Variable | Description |
+|---|---|
+| `METRO_HOST` | Metro bundler host |
+| `METRO_PORT` | Metro bundler port |
+| `METRO_MCP_CONFIG` | Path to config file |
+| `METRO_MCP_PLUGINS` | Colon-separated plugin paths |
+| `DEBUG` | Enable debug logging |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,8 +1,28 @@
 # Custom Plugins
 
-metro-mcp is plugin-based. You can extend it with local files or npm packages.
+metro-mcp is plugin-based. You can extend it with your own MCP tools, resources, and prompts — either as local files or published npm packages.
 
-## Creating a plugin
+## Quickstart
+
+Scaffold a new plugin package interactively:
+
+```bash
+bunx metro-mcp create-plugin
+```
+
+This prompts for a name, description, and author, then generates a ready-to-use package in a new directory (`metro-mcp-plugin-<name>/`) with a hello-world plugin, build config, README, and LICENSE.
+
+```
+✓ Plugin metro-mcp-plugin-my-plugin ready!
+
+Next steps:
+  cd metro-mcp-plugin-my-plugin
+  bun run build
+```
+
+## Plugin structure
+
+A plugin is a `definePlugin()` call with a `name` and an async `setup` function:
 
 ```typescript
 import { definePlugin } from 'metro-mcp';
@@ -11,76 +31,270 @@ import { z } from 'zod';
 export default definePlugin({
   name: 'my-plugin',
   version: '1.0.0',
+  description: 'Does useful things',
 
   async setup(ctx) {
-    // Access CDP connection
-    ctx.cdp.on('Runtime.consoleAPICalled', (params) => {
-      // Handle console events
-    });
-
-    // Register MCP tools
     ctx.registerTool('my_tool', {
       description: 'Does something useful',
       parameters: z.object({
         input: z.string().describe('Input value'),
       }),
       handler: async ({ input }) => {
-        const result = await ctx.cdp.send('Runtime.evaluate', {
-          expression: `doSomething(${JSON.stringify(input)})`,
-          returnByValue: true,
-        });
-        return result;
+        return `You said: ${input}`;
       },
     });
-
-    // Register resources
-    ctx.registerResource('metro://my-data', {
-      name: 'My Data',
-      description: 'Custom data source',
-      handler: async () => JSON.stringify({ data: 'hello' }),
-    });
-
-    // Run shell commands
-    const output = await ctx.exec('xcrun simctl list');
-
-    // Token-efficient formatting helpers
-    ctx.format.summarize(items, 5);
-    ctx.format.compact(obj);
-    ctx.format.truncate(str, 100);
   },
 });
 ```
 
+The `setup` function receives a `PluginContext` and is called once when the server starts. Register all your tools, resources, and prompts here.
+
+## Registering tools
+
+Tools are the primary way to expose functionality to AI clients.
+
+```typescript
+ctx.registerTool('evaluate_expression', {
+  description: 'Evaluate a JS expression in the running app',
+  parameters: z.object({
+    expression: z.string().describe('JavaScript expression'),
+    awaitPromise: z.boolean().default(true),
+  }),
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+  },
+  handler: async ({ expression, awaitPromise }, toolCtx) => {
+    const result = await ctx.evalInApp(expression, { awaitPromise });
+    return result ?? 'undefined';
+  },
+});
+```
+
+### Tool annotations
+
+Annotations are hints for AI clients about how the tool behaves. They help clients decide when to auto-approve tool calls.
+
+| Annotation | Type | Description |
+|---|---|---|
+| `title` | `string` | Human-readable display name |
+| `readOnlyHint` | `boolean` | Tool does not modify state (safe to auto-approve) |
+| `destructiveHint` | `boolean` | Tool may perform irreversible actions |
+| `idempotentHint` | `boolean` | Calling multiple times with same args has no extra effect |
+| `openWorldHint` | `boolean` | Tool may interact with external systems |
+
+### Progress reporting
+
+The handler receives a second `ctx` argument with an optional `sendProgress` helper for long-running operations:
+
+```typescript
+handler: async ({ items }, { sendProgress }) => {
+  for (let i = 0; i < items.length; i++) {
+    await processItem(items[i]);
+    await sendProgress?.(i + 1, items.length, `Processing ${items[i]}`);
+  }
+  return 'Done';
+},
+```
+
+## Registering resources
+
+Resources expose readable data to AI clients (component trees, logs, state snapshots, etc.).
+
+```typescript
+ctx.registerResource('metro://my-plugin/state', {
+  name: 'App State',
+  description: 'Current application state snapshot',
+  mimeType: 'application/json',  // defaults to 'application/json'
+  handler: async () => {
+    const state = await ctx.evalInApp('JSON.stringify(global.__REDUX_STORE__?.getState())');
+    return state as string;
+  },
+  onSubscribe: (uri) => {
+    ctx.logger.info(`Client subscribed to ${uri}`);
+  },
+  onUnsubscribe: (uri) => {
+    ctx.logger.info(`Client unsubscribed from ${uri}`);
+  },
+});
+```
+
+### Push updates
+
+When your resource data changes, notify subscribed clients:
+
+```typescript
+async setup(ctx) {
+  // Listen for CDP events and push updates
+  ctx.cdp.on('Runtime.consoleAPICalled', () => {
+    ctx.notifyResourceUpdated('metro://my-plugin/logs');
+  });
+
+  ctx.registerResource('metro://my-plugin/logs', {
+    name: 'Plugin Logs',
+    description: 'Streaming log output',
+    handler: async () => JSON.stringify(logBuffer),
+  });
+},
+```
+
+## Registering prompts
+
+Prompts are pre-built message templates that AI clients can invoke.
+
+```typescript
+ctx.registerPrompt('debug_crash', {
+  description: 'Gather context for a crash report',
+  arguments: [
+    { name: 'error', description: 'The error message', required: true },
+  ],
+  handler: async ({ error }) => [
+    {
+      role: 'user',
+      content: `The app crashed with: ${error}\n\nPlease check the recent logs and component tree to diagnose the issue.`,
+    },
+  ],
+});
+```
+
+## Plugin context API
+
+The `ctx` object passed to `setup` provides everything you need to interact with the app:
+
+### `ctx.cdp` — Chrome DevTools Protocol
+
+Send CDP commands and listen to CDP events directly:
+
+```typescript
+// Send a command
+const result = await ctx.cdp.send('Runtime.evaluate', {
+  expression: 'window.__MY_GLOBAL__',
+  returnByValue: true,
+});
+
+// Listen for events
+ctx.cdp.on('Runtime.consoleAPICalled', (params) => {
+  console.log('Console event:', params);
+});
+
+// Check connection status
+if (ctx.cdp.isConnected) {
+  const target = ctx.cdp.getTarget(); // MetroTarget | null
+}
+```
+
+### `ctx.events` — Metro bundler events
+
+Listen to Metro build events over WebSocket:
+
+```typescript
+ctx.events.on('bundling_error', (event) => {
+  ctx.logger.error('Bundle error:', event);
+});
+
+ctx.events.on('bundle_transform_progressed', (event) => {
+  // Build progress
+});
+```
+
+### `ctx.evalInApp` — Evaluate JavaScript
+
+Run JavaScript in the connected app and return the result:
+
+```typescript
+const value = await ctx.evalInApp('global.__MY_STORE__.getState()');
+
+// Await promises returned by the expression
+const data = await ctx.evalInApp('fetch("/api/data").then(r => r.json())', {
+  awaitPromise: true,
+  timeout: 15000,
+});
+```
+
+### `ctx.metro` — Metro HTTP access
+
+Make HTTP requests to the Metro bundler:
+
+```typescript
+const { host, port } = ctx.metro;
+const response = await ctx.metro.fetch('/status');
+const data = await response.json();
+```
+
+### `ctx.exec` — Shell commands
+
+Run shell commands and capture output:
+
+```typescript
+const devices = await ctx.exec('xcrun simctl list devices --json');
+const parsed = JSON.parse(devices);
+```
+
+### `ctx.format` — Formatting helpers
+
+Token-efficient helpers for formatting data to return to AI clients:
+
+| Method | Description |
+|---|---|
+| `format.summarize(items, lastN?)` | `"47 items. Last 5: ..."` — avoids flooding context with large arrays |
+| `format.compact(obj)` | `"key=value key2=value2"` — flat key-value string |
+| `format.truncate(str, maxLen)` | Truncate with `...` |
+| `format.structureOnly(tree)` | Strip props/state from a component tree, keep structure |
+
+### `ctx.logger` — Plugin logger
+
+Prefixed logger for your plugin's output:
+
+```typescript
+ctx.logger.info('Plugin ready');
+ctx.logger.warn('Something unexpected');
+ctx.logger.error('Failed to connect', err);
+ctx.logger.debug('Raw CDP response', data);  // Only shown with DEBUG=1
+```
+
+### Device helpers
+
+```typescript
+// Returns a stable key for the active device, e.g. "8081-abc123"
+const key = ctx.getActiveDeviceKey();
+
+// Returns a human-readable name, e.g. "iPhone 16 Pro Simulator"
+const name = ctx.getActiveDeviceName();
+```
+
 ## Loading plugins
+
+### Via config file
 
 ```typescript
 // metro-mcp.config.ts
 import { defineConfig } from 'metro-mcp';
 
 export default defineConfig({
-  metro: { host: 'localhost', port: 8081 },
   plugins: [
-    'metro-mcp-plugin-custom',  // npm package
-    './my-custom-plugin.ts',    // local file
+    'metro-mcp-plugin-my-plugin',  // npm package
+    './local-plugin.ts',           // local file (relative to config)
   ],
 });
 ```
 
-npm packages use the `metro-mcp-plugin-*` naming convention.
-
-## Loading plugins without a config file
-
-Load plugins via CLI or env var — useful when you want to load a plugin without creating a config file, or for clients that don't support MCP roots:
+### Via CLI flag
 
 ```bash
-# Single plugin
 bunx metro-mcp --plugin ./my-plugin.ts
+```
 
-# Multiple plugins (colon-separated env var)
+Repeatable — pass `--plugin` multiple times to load several plugins.
+
+### Via environment variable
+
+```bash
 METRO_MCP_PLUGINS=./plugin-a.ts:metro-mcp-plugin-foo bunx metro-mcp
 ```
 
-In an MCP server config:
+Plugins from CLI flags and env vars are appended after any plugins in the config file.
+
+### In an MCP client config
 
 ```json
 {
@@ -93,4 +307,35 @@ In an MCP server config:
 }
 ```
 
-Plugins specified this way are appended after any plugins defined in the config file.
+## Package naming
+
+npm packages must follow the `metro-mcp-plugin-*` naming convention. When a plugin path in your config doesn't start with `.` or `/`, metro-mcp resolves it as an npm package name.
+
+```typescript
+plugins: [
+  'metro-mcp-plugin-mmkv',    // resolves from node_modules
+  './local-plugin.ts',        // resolves as a local file
+]
+```
+
+## Publishing to npm
+
+The `create-plugin` scaffold generates a package ready to publish:
+
+```bash
+# Build the plugin
+bun run build
+
+# Publish to npm
+npm publish
+```
+
+The generated `package.json` lists `metro-mcp` and `zod` as `peerDependencies` — users provide them through their metro-mcp installation, so there's no version conflict.
+
+## Validating a plugin
+
+Use the [`validate-plugin` CLI command](/cli#validate-plugin) to check that your plugin file exports a valid `PluginDefinition` before loading it into the server:
+
+```bash
+bunx metro-mcp validate-plugin ./src/index.ts
+```

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "author": "Stephen Radford",
   "license": "MIT",
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/commands/create-plugin.ts
+++ b/src/commands/create-plugin.ts
@@ -1,0 +1,265 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { cancel, group, intro, isCancel, log, note, outro, spinner, text } from '@clack/prompts';
+import { version as metroMCPVersion } from '../version.js';
+
+function getGitAuthor(): string {
+  try {
+    return execSync('git config user.name', { stdio: ['pipe', 'pipe', 'pipe'] })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+function generatePackageJson(opts: {
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+}): string {
+  const pkg = {
+    name: `metro-mcp-plugin-${opts.name}`,
+    version: opts.version,
+    ...(opts.description && { description: opts.description }),
+    ...(opts.author && { author: opts.author }),
+    license: 'MIT',
+    type: 'module',
+    main: './dist/index.js',
+    exports: {
+      '.': {
+        import: './dist/index.js',
+      },
+    },
+    files: ['dist', 'README.md'],
+    scripts: {
+      build: 'bun build src/index.ts --outfile dist/index.js --target node --external metro-mcp --external zod',
+      prepublishOnly: 'bun run build',
+    },
+    keywords: ['metro-mcp', 'mcp', 'react-native'],
+    peerDependencies: {
+      'metro-mcp': '>=0.9.0',
+      zod: '>=3.24.4',
+    },
+    devDependencies: {
+      '@types/bun': '^1.2.0',
+      'metro-mcp': `^${metroMCPVersion}`,
+    },
+    engines: {
+      node: '>=18.0.0',
+    },
+  };
+  return JSON.stringify(pkg, null, 2) + '\n';
+}
+
+function generateTsConfig(): string {
+  return (
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+          skipLibCheck: true,
+          outDir: './dist',
+        },
+        include: ['src/**/*'],
+      },
+      null,
+      2,
+    ) + '\n'
+  );
+}
+
+function generatePlugin(opts: { name: string; version: string; description: string }): string {
+  const desc = opts.description || `A metro-mcp plugin`;
+  return `import { definePlugin } from 'metro-mcp';
+import { z } from 'zod';
+
+export default definePlugin({
+  name: 'metro-mcp-plugin-${opts.name}',
+  version: '${opts.version}',
+  description: '${desc}',
+
+  async setup(ctx) {
+    ctx.registerTool('hello_world', {
+      description: 'A sample tool — replace with your own logic',
+      parameters: z.object({
+        name: z.string().default('world').describe('Name to greet'),
+      }),
+      handler: async ({ name }) => {
+        return \`Hello, \${name}! This is the ${opts.name} metro-mcp plugin.\`;
+      },
+    });
+
+    // Uncomment to register a resource:
+    // ctx.registerResource('metro://${opts.name}/data', {
+    //   name: '${opts.name} Data',
+    //   description: 'Custom data source',
+    //   handler: async () => JSON.stringify({ hello: 'world' }),
+    // });
+  },
+});
+`;
+}
+
+function generateReadme(opts: { name: string; description: string }): string {
+  const fullName = `metro-mcp-plugin-${opts.name}`;
+  const desc = opts.description || `A plugin for [metro-mcp](https://metromcp.dev).`;
+  return `# ${fullName}
+
+${desc}
+
+## Installation
+
+\`\`\`bash
+bun add ${fullName}
+\`\`\`
+
+## Usage
+
+Add to your \`metro-mcp.config.ts\`:
+
+\`\`\`typescript
+import { defineConfig } from 'metro-mcp';
+
+export default defineConfig({
+  plugins: ['${fullName}'],
+});
+\`\`\`
+
+## Development
+
+\`\`\`bash
+bun install
+bun run build
+\`\`\`
+`;
+}
+
+function generateLicense(author: string): string {
+  const year = new Date().getFullYear();
+  const copyright = author ? `${year} ${author}` : `${year}`;
+  return `MIT License
+
+Copyright (c) ${copyright}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+}
+
+function generateGitignore(): string {
+  return `node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store
+`;
+}
+
+export async function runCreatePlugin(): Promise<void> {
+  intro('Create metro-mcp plugin');
+
+  const gitAuthor = getGitAuthor();
+
+  const answers = await group(
+    {
+      nameSuffix: () =>
+        text({
+          message: 'Plugin name suffix',
+          placeholder: 'my-plugin',
+          validate: (value) => {
+            if (!value || value.trim().length === 0) return 'Plugin name is required';
+            if (!/^[a-z0-9][a-z0-9-]*$/.test(value.trim())) {
+              return 'Must be lowercase alphanumeric with hyphens only (e.g. my-plugin)';
+            }
+          },
+        }),
+      description: () =>
+        text({
+          message: 'Description',
+          placeholder: 'A metro-mcp plugin',
+        }),
+      author: () =>
+        text({
+          message: 'Author',
+          initialValue: gitAuthor,
+          placeholder: gitAuthor || 'Your Name',
+        }),
+      version: () =>
+        text({
+          message: 'Version',
+          initialValue: '0.1.0',
+          placeholder: '0.1.0',
+        }),
+    },
+    {
+      onCancel: () => {
+        cancel('Cancelled');
+        process.exit(0);
+      },
+    },
+  );
+
+  const name = answers.nameSuffix.trim();
+  const version = answers.version.trim() || '0.1.0';
+  const description = answers.description.trim();
+  const author = answers.author.trim();
+  const packageName = `metro-mcp-plugin-${name}`;
+  const targetDir = path.join(process.cwd(), packageName);
+
+  if (fs.existsSync(targetDir)) {
+    log.error(`Directory "${packageName}" already exists.`);
+    process.exit(1);
+  }
+
+  const s = spinner();
+  s.start('Creating plugin files');
+
+  try {
+    fs.mkdirSync(path.join(targetDir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(targetDir, 'package.json'), generatePackageJson({ name, version, description, author }));
+    fs.writeFileSync(path.join(targetDir, 'tsconfig.json'), generateTsConfig());
+    fs.writeFileSync(path.join(targetDir, 'src', 'index.ts'), generatePlugin({ name, version, description }));
+    fs.writeFileSync(path.join(targetDir, 'README.md'), generateReadme({ name, description }));
+    fs.writeFileSync(path.join(targetDir, 'LICENSE'), generateLicense(author));
+    fs.writeFileSync(path.join(targetDir, '.gitignore'), generateGitignore());
+    s.stop('Plugin files created');
+  } catch (err) {
+    s.error('Failed to create plugin files');
+    log.error(String(err));
+    process.exit(1);
+  }
+
+  const installSpinner = spinner();
+  installSpinner.start('Installing dependencies');
+  try {
+    execSync('bun install', { cwd: targetDir, stdio: 'pipe' });
+    installSpinner.stop('Dependencies installed');
+  } catch {
+    installSpinner.error('Failed to install dependencies');
+    log.warn(`Run \`bun install\` manually inside ${packageName}/`);
+  }
+
+  note(`cd ${packageName}\nbun run build`, 'Next steps');
+
+  outro(`Plugin ${packageName} ready!`);
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,119 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as http from 'node:http';
+import { intro, log, note, outro } from '@clack/prompts';
+import { loadConfig } from '../config.js';
+
+function checkNodeVersion(): { ok: boolean; message: string } {
+  const ver = process.versions.node;
+  const major = parseInt(ver.split('.')[0], 10);
+  if (major >= 18) {
+    return { ok: true, message: `Node.js ${ver}` };
+  }
+  return { ok: false, message: `Node.js ${ver} — requires >=18` };
+}
+
+function checkMetro(host: string, port: number): Promise<{ ok: boolean; message: string }> {
+  return new Promise((resolve) => {
+    const req = http.get({ host, port, path: '/', timeout: 3000 }, (res) => {
+      resolve({ ok: true, message: `Metro reachable at ${host}:${port} (HTTP ${res.statusCode})` });
+      res.resume();
+    });
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ ok: false, message: `Metro not reachable at ${host}:${port} — connection timed out` });
+    });
+    req.on('error', (err) => {
+      resolve({ ok: false, message: `Metro not reachable at ${host}:${port} — ${err.message}` });
+    });
+  });
+}
+
+function findConfigFile(): string | null {
+  const cwd = process.cwd();
+  for (const name of ['metro-mcp.config.ts', 'metro-mcp.config.js']) {
+    if (fs.existsSync(path.join(cwd, name))) return name;
+  }
+  return null;
+}
+
+function checkPluginPaths(plugins: string[]): Array<{ path: string; ok: boolean }> {
+  return plugins
+    .filter((p) => !p.startsWith('metro-mcp-plugin-') && !p.includes('node_modules'))
+    .map((p) => ({
+      path: p,
+      ok: fs.existsSync(path.resolve(process.cwd(), p)),
+    }));
+}
+
+export async function runDoctor(): Promise<void> {
+  intro('metro-mcp doctor');
+
+  let passed = 0;
+  let failed = 0;
+
+  // Node.js version check
+  const nodeResult = checkNodeVersion();
+  if (nodeResult.ok) {
+    log.success(nodeResult.message);
+    passed++;
+  } else {
+    log.error(nodeResult.message);
+    failed++;
+  }
+
+  // Config file check
+  const configFile = findConfigFile();
+  if (configFile) {
+    log.success(`Config file found: ${configFile}`);
+    passed++;
+  } else {
+    log.warn('No config file found (metro-mcp.config.ts) — using defaults');
+  }
+
+  // Load config to get metro host/port and plugin paths
+  let config: Awaited<ReturnType<typeof loadConfig>>;
+  try {
+    config = await loadConfig([]);
+  } catch {
+    log.error('Failed to load config');
+    outro(`${passed} passed, ${failed + 1} failed`);
+    process.exit(1);
+  }
+
+  // Metro connectivity check
+  const metroResult = await checkMetro(config.metro.host ?? 'localhost', config.metro.port ?? 8081);
+  if (metroResult.ok) {
+    log.success(metroResult.message);
+    passed++;
+  } else {
+    log.error(metroResult.message);
+    failed++;
+  }
+
+  // Plugin path checks (local paths only)
+  const pluginChecks = checkPluginPaths(config.plugins);
+  for (const check of pluginChecks) {
+    if (check.ok) {
+      log.success(`Plugin found: ${check.path}`);
+      passed++;
+    } else {
+      log.error(`Plugin not found: ${check.path}`);
+      failed++;
+    }
+  }
+
+  if (failed === 0) {
+    outro(`All checks passed`);
+  } else {
+    note(
+      [
+        'Run metro-mcp --help to see available options.',
+        'Visit https://metromcp.dev for documentation.',
+      ].join('\n'),
+      'Need help?',
+    );
+    outro(`${passed} passed, ${failed} failed`);
+    process.exit(1);
+  }
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { cancel, group, intro, log, outro, text } from '@clack/prompts';
+
+const CONFIG_FILENAMES = ['metro-mcp.config.ts', 'metro-mcp.config.js'];
+
+function generateConfig(host: string, port: number): string {
+  return `import { defineConfig } from 'metro-mcp';
+
+export default defineConfig({
+  metro: {
+    host: '${host}',
+    port: ${port},
+  },
+  // plugins: [
+  //   'metro-mcp-plugin-example',
+  //   './local-plugin.ts',
+  // ],
+});
+`;
+}
+
+export async function runInit(): Promise<void> {
+  intro('Initialize metro-mcp config');
+
+  const cwd = process.cwd();
+
+  for (const filename of CONFIG_FILENAMES) {
+    if (fs.existsSync(path.join(cwd, filename))) {
+      log.warn(`${filename} already exists — remove it first to re-initialize.`);
+      process.exit(0);
+    }
+  }
+
+  const answers = await group(
+    {
+      host: () =>
+        text({
+          message: 'Metro host',
+          initialValue: 'localhost',
+          placeholder: 'localhost',
+        }),
+      port: () =>
+        text({
+          message: 'Metro port',
+          initialValue: '8081',
+          placeholder: '8081',
+          validate: (value) => {
+            const n = parseInt(value ?? '', 10);
+            if (isNaN(n) || n < 1 || n > 65535) return 'Must be a valid port number (1–65535)';
+          },
+        }),
+    },
+    {
+      onCancel: () => {
+        cancel('Cancelled');
+        process.exit(0);
+      },
+    },
+  );
+
+  const host = answers.host.trim() || 'localhost';
+  const port = parseInt(answers.port.trim(), 10) || 8081;
+  const configPath = path.join(cwd, 'metro-mcp.config.ts');
+
+  try {
+    fs.writeFileSync(configPath, generateConfig(host, port));
+    log.success(`Created metro-mcp.config.ts`);
+  } catch (err) {
+    log.error(`Failed to write config: ${err}`);
+    process.exit(1);
+  }
+
+  outro('Done! Edit metro-mcp.config.ts to add plugins or tweak settings.');
+}

--- a/src/commands/validate-plugin.ts
+++ b/src/commands/validate-plugin.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { intro, log, outro } from '@clack/prompts';
+
+export async function runValidatePlugin(pluginPath: string | undefined): Promise<void> {
+  intro('Validate metro-mcp plugin');
+
+  if (!pluginPath) {
+    log.error('No plugin path provided.');
+    log.message('Usage: metro-mcp validate-plugin <path>');
+    process.exit(1);
+  }
+
+  const resolved = path.resolve(process.cwd(), pluginPath);
+
+  if (!fs.existsSync(resolved)) {
+    log.error(`File not found: ${resolved}`);
+    process.exit(1);
+  }
+
+  log.step(`Validating ${pluginPath}`);
+
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import(resolved);
+  } catch (err) {
+    log.error(`Failed to import plugin: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  // Accept default export, or the first named export that looks like a PluginDefinition
+  const isPluginShape = (v: unknown) =>
+    typeof v === 'object' && v !== null && 'name' in v && 'setup' in v;
+
+  const exported =
+    isPluginShape(mod.default)
+      ? mod.default
+      : Object.values(mod).find(isPluginShape) ?? mod.default ?? mod;
+
+  if (typeof exported !== 'object' || exported === null) {
+    log.error('Plugin must export an object (use definePlugin())');
+    process.exit(1);
+  }
+
+  const plugin = exported as Record<string, unknown>;
+
+  const errors: string[] = [];
+
+  if (typeof plugin.name !== 'string' || plugin.name.trim() === '') {
+    errors.push('Missing or invalid "name" property (must be a non-empty string)');
+  }
+
+  if (typeof plugin.setup !== 'function') {
+    errors.push('Missing or invalid "setup" property (must be a function)');
+  }
+
+  if (errors.length > 0) {
+    for (const err of errors) {
+      log.error(err);
+    }
+    process.exit(1);
+  }
+
+  log.success(`name: "${plugin.name}"`);
+  if (typeof plugin.version === 'string') log.success(`version: "${plugin.version}"`);
+  if (typeof plugin.description === 'string') log.success(`description: "${plugin.description}"`);
+  log.success('setup: function');
+
+  outro('Plugin is valid');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,12 @@ async function main() {
     process.exit(0);
   }
 
+  // Catch unknown subcommands (args that look like commands, not flags)
+  if (subcommand && !subcommand.startsWith('-')) {
+    console.error(`Unknown command: ${subcommand}\nRun \`metro-mcp --help\` for usage.`);
+    process.exit(1);
+  }
+
   if (args.includes('--help') || args.includes('-h')) {
     console.error(`
 metro-mcp — React Native MCP Server

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,41 @@ const logger = createLogger('main');
 
 async function main() {
   const args = process.argv.slice(2);
+  const subcommand = args[0];
+
+  if (subcommand === 'create-plugin') {
+    const { runCreatePlugin } = await import('./commands/create-plugin.js');
+    await runCreatePlugin();
+    process.exit(0);
+  }
+
+  if (subcommand === 'init') {
+    const { runInit } = await import('./commands/init.js');
+    await runInit();
+    process.exit(0);
+  }
+
+  if (subcommand === 'doctor') {
+    const { runDoctor } = await import('./commands/doctor.js');
+    await runDoctor();
+    process.exit(0);
+  }
+
+  if (subcommand === 'validate-plugin') {
+    const { runValidatePlugin } = await import('./commands/validate-plugin.js');
+    await runValidatePlugin(args[1]);
+    process.exit(0);
+  }
 
   if (args.includes('--help') || args.includes('-h')) {
     console.error(`
 metro-mcp — React Native MCP Server
+
+Commands:
+  create-plugin           Scaffold a new metro-mcp plugin package
+  init                    Create a metro-mcp.config.ts in the current project
+  doctor                  Check Metro connectivity and config health
+  validate-plugin <path>  Validate a plugin file exports a valid PluginDefinition
 
 Usage:
   metro-mcp [options]


### PR DESCRIPTION
## Summary
This PR adds four new CLI subcommands to metro-mcp to improve the developer experience for plugin creation and project management.

## Key Changes
- **`create-plugin` command**: Scaffolds a new metro-mcp plugin package with all necessary boilerplate (package.json, tsconfig.json, sample plugin code, README, LICENSE, .gitignore) and automatically installs dependencies
- **`init` command**: Initializes a metro-mcp.config.ts file in the current project with configurable Metro host/port settings
- **`doctor` command**: Diagnostic tool that checks Node.js version, config file presence, Metro connectivity, and validates local plugin paths
- **`validate-plugin` command**: Validates that a plugin file exports a valid PluginDefinition with required `name` and `setup` properties
- **Updated help text**: Added command documentation to the `--help` output and added error handling for unknown subcommands

## Implementation Details
- All commands use `@clack/prompts` for interactive CLI prompts with validation
- Plugin scaffolding generates TypeScript configuration and a sample plugin using the `definePlugin` API with Zod schema validation
- Generated plugins are configured to build with Bun and include proper peer dependencies on metro-mcp and zod
- Doctor command performs async Metro connectivity checks via HTTP and provides detailed diagnostic output
- Plugin validation accepts both default and named exports, checking for required plugin shape properties
- Git author name is auto-detected for plugin scaffolding when available

https://claude.ai/code/session_01YWrth38WyTPSXG2Bj3qBuw