### PR TITLE
Add pinned packages support to community plugins loader

### DIFF
--- a/docs/.vitepress/data/plugins.data.ts
+++ b/docs/.vitepress/data/plugins.data.ts
@@ -11,6 +11,57 @@ export interface CommunityPlugin {
   searchText: string
 }
 
+// Packages to fetch directly from the npm registry, bypassing search indexing delays.
+const PINNED_PACKAGES = ['metro-mcp-plugin-zustand', 'metro-mcp-plugin-mmkv']
+
+function mapPackage(p: any): CommunityPlugin {
+  const name = p.name as string
+  const description = (p.description ?? '') as string
+  const author = (p.publisher?.username ?? p.author?.name ?? '') as string
+  return {
+    name,
+    description,
+    version: p.version as string,
+    author,
+    date: p.date as string,
+    links: {
+      npm: `https://www.npmjs.com/package/${name}`,
+      homepage: sanitizeExternalUrl(p.links?.homepage),
+      repository: sanitizeExternalUrl(p.links?.repository),
+    },
+    searchText: `${name} ${description} ${author}`.toLowerCase(),
+  }
+}
+
+async function fetchPinnedPackages(): Promise<CommunityPlugin[]> {
+  const results = await Promise.allSettled(
+    PINNED_PACKAGES.map(async (name) => {
+      const res = await fetch(`https://registry.npmjs.org/${name}/latest`)
+      if (!res.ok) return null
+      const p = await res.json()
+      // Normalise to the shape mapPackage expects
+      return mapPackage({
+        name: p.name,
+        description: p.description,
+        version: p.version,
+        date: p.time?.modified ?? p.time?.created ?? '',
+        publisher: { username: p._npmUser?.name },
+        author: p.author,
+        links: {
+          homepage: p.homepage,
+          repository:
+            typeof p.repository === 'string'
+              ? p.repository
+              : p.repository?.url,
+        },
+      })
+    }),
+  )
+  return results
+    .filter((r) => r.status === 'fulfilled' && r.value !== null)
+    .map((r) => (r as PromiseFulfilledResult<CommunityPlugin>).value)
+}
+
 export default {
   async load(): Promise<CommunityPlugin[]> {
     const res = await fetch(
@@ -23,30 +74,21 @@ export default {
 
     const { objects } = await res.json()
 
-    return objects
+    const fromSearch = objects
       .map((o: any) => o.package)
       .filter(
         (p: any) =>
           p.name.startsWith('metro-mcp-plugin-') &&
           !PLUGIN_BLACKLIST.includes(p.name),
       )
-      .map((p: any) => {
-        const name = p.name as string
-        const description = (p.description ?? '') as string
-        const author = (p.publisher?.username ?? p.author?.name ?? '') as string
-        return {
-          name,
-          description,
-          version: p.version as string,
-          author,
-          date: p.date as string,
-          links: {
-            npm: `https://www.npmjs.com/package/${name}`,
-            homepage: sanitizeExternalUrl(p.links?.homepage),
-            repository: sanitizeExternalUrl(p.links?.repository),
-          },
-          searchText: `${name} ${description} ${author}`.toLowerCase(),
-        }
-      })
+      .map(mapPackage)
+
+    const pinned = await fetchPinnedPackages()
+
+    // Merge pinned packages, skipping any already returned by the search.
+    const searchNames = new Set(fromSearch.map((p: CommunityPlugin) => p.name))
+    const extra = pinned.filter((p) => !searchNames.has(p.name))
+
+    return [...fromSearch, ...extra]
   },
 }

--- a/docs/.vitepress/data/plugins.data.ts
+++ b/docs/.vitepress/data/plugins.data.ts
@@ -89,6 +89,6 @@ export default {
     const searchNames = new Set(fromSearch.map((p: CommunityPlugin) => p.name))
     const extra = pinned.filter((p) => !searchNames.has(p.name))
 
-    return [...fromSearch, ...extra]
+    return [...fromSearch, ...extra].sort((a, b) => a.name.localeCompare(b.name))
   },
 }


### PR DESCRIPTION
## Summary
This change adds support for pinning specific community plugins to ensure they appear in the plugin list even if they haven't been indexed by the npm search API yet. This bypasses search indexing delays for critical packages.

## Key Changes
- **Introduced `PINNED_PACKAGES` constant**: Defines a list of packages (`metro-mcp-plugin-zustand`, `metro-mcp-plugin-mmkv`) that should be fetched directly from the npm registry
- **Extracted `mapPackage()` function**: Refactored the package transformation logic into a reusable utility function to avoid duplication between search results and pinned packages
- **Added `fetchPinnedPackages()` function**: Fetches pinned packages directly from the npm registry API, normalizing their data structure to match the expected format
- **Updated plugin loading logic**: Combines results from both the npm search API and pinned packages, deduplicating by package name and sorting alphabetically

## Implementation Details
- Uses `Promise.allSettled()` to gracefully handle failures when fetching individual pinned packages
- Normalizes npm registry response format to match the shape expected by `mapPackage()`
- Deduplicates results by maintaining a Set of package names from search results before merging with pinned packages
- Final results are sorted alphabetically by package name for consistent ordering

https://claude.ai/code/session_01DZQviXPT8RQJZsZV9rz3HQ