### PR TITLE
Bump package version and MCP app metadata support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -119,6 +119,31 @@ ctx.registerResource('metro://my-plugin/state', {
 });
 ```
 
+### MCP App resources
+
+Resources with `ui://` URIs are treated as MCP Apps. metro-mcp sets their MIME type
+to `text/html;profile=mcp-app`, adds a preferred frame size hint, and injects a
+small resize helper so iframe hosts such as Cursor can keep the app visible:
+
+```typescript
+import { z } from 'zod';
+
+ctx.registerTool('show_panel', {
+  description: 'Show the plugin panel',
+  parameters: z.object({}),
+  _meta: { ui: { resourceUri: 'ui://my-plugin/panel' } },
+  handler: async () => 'Opening panel...',
+});
+
+ctx.registerResource('ui://my-plugin/panel', {
+  name: 'Plugin Panel',
+  description: 'Interactive plugin UI',
+  handler: async () => `
+    <div id="root">...</div>
+  `,
+});
+```
+
 ### Push updates
 
 When your resource data changes, notify subscribed clients:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -32,6 +32,98 @@ export interface ComponentNode {
 
 // ── Tool / Resource / Prompt Registration ──
 
+export const DEFAULT_APP_FRAME_HEIGHT = 420;
+export const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
+export const MCP_UI_PREFERRED_FRAME_SIZE_META_KEY = 'mcpui.dev/ui-preferred-frame-size';
+const MCP_APP_FRAME_SIZING_MARKER = 'data-metro-mcp-app-frame-sizing';
+
+export type MCPMetadata = Record<string, unknown>;
+
+export interface MCPAppFrameSize {
+  width?: number | string;
+  height?: number | string;
+}
+
+export interface MCPAppFrameSizingOptions {
+  minHeight?: number;
+  rootSelector?: string;
+}
+
+export function createMCPAppResourceMeta(
+  frameSize: MCPAppFrameSize = { width: '100%', height: DEFAULT_APP_FRAME_HEIGHT },
+  meta: MCPMetadata = {}
+): MCPMetadata {
+  return {
+    [MCP_UI_PREFERRED_FRAME_SIZE_META_KEY]: frameSize,
+    ...meta,
+  };
+}
+
+export function resolveMCPAppFrameHeight(meta?: MCPMetadata): number {
+  const frameSize = meta?.[MCP_UI_PREFERRED_FRAME_SIZE_META_KEY];
+  if (!frameSize || typeof frameSize !== 'object') return DEFAULT_APP_FRAME_HEIGHT;
+
+  const height = (frameSize as MCPAppFrameSize).height;
+  if (typeof height === 'number' && Number.isFinite(height)) return height;
+  if (typeof height === 'string') {
+    const parsed = Number.parseInt(height, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return DEFAULT_APP_FRAME_HEIGHT;
+}
+
+function insertBeforeClosingTag(html: string, closingTag: string, insertion: string, appendWhenMissing: boolean): string {
+  if (html.includes(closingTag)) return html.replace(closingTag, `${insertion}${closingTag}`);
+  return appendWhenMissing ? `${html}${insertion}` : `${insertion}${html}`;
+}
+
+export function withMCPAppFrameSizing(html: string, options: MCPAppFrameSizingOptions = {}): string {
+  if (html.includes(MCP_APP_FRAME_SIZING_MARKER)) return html;
+
+  const minHeight = options.minHeight ?? DEFAULT_APP_FRAME_HEIGHT;
+  const rootSelector = options.rootSelector ?? '#root';
+  const sizingStyle = `<style ${MCP_APP_FRAME_SIZING_MARKER}>
+html, body, ${rootSelector} {
+  min-height: ${minHeight}px;
+}
+</style>`;
+  const sizingScript = `<script ${MCP_APP_FRAME_SIZING_MARKER}>
+(() => {
+  const minHeight = ${JSON.stringify(minHeight)};
+  const rootSelector = ${JSON.stringify(rootSelector)};
+  let lastHeight;
+  const postSize = () => {
+    const root = document.querySelector(rootSelector);
+    const contentHeight = Math.max(
+      document.documentElement.scrollHeight,
+      document.body ? document.body.scrollHeight : 0,
+      root ? root.scrollHeight : 0
+    );
+    const height = Math.max(contentHeight, minHeight);
+    if (height === lastHeight) return;
+    lastHeight = height;
+    window.parent.postMessage({ type: 'ui-size-change', payload: { height } }, '*');
+    window.parent.postMessage({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/size-changed',
+      params: { height },
+    }, '*');
+  };
+  if ('ResizeObserver' in window) {
+    const resizeObserver = new ResizeObserver(postSize);
+    resizeObserver.observe(document.documentElement);
+    if (document.body) resizeObserver.observe(document.body);
+  }
+  window.addEventListener('load', postSize);
+  postSize();
+})();
+</script>`;
+
+  const htmlWithStyle = insertBeforeClosingTag(html, '</head>', sizingStyle, false);
+  return insertBeforeClosingTag(htmlWithStyle, '</body>', sizingScript, true);
+}
+
 export interface ToolAnnotations {
   /** Human-readable name for display in client UIs */
   title?: string;
@@ -54,6 +146,8 @@ export interface ToolConfig<T extends z.ZodType = z.ZodType> {
   description: string;
   parameters: T;
   annotations?: ToolAnnotations;
+  /** MCP descriptor metadata, such as output templates for UI resources. */
+  _meta?: MCPMetadata;
   handler: (args: z.infer<T>, ctx: ToolHandlerContext) => Promise<unknown>;
 }
 
@@ -61,6 +155,8 @@ export interface ResourceConfig {
   name: string;
   description: string;
   mimeType?: string;
+  /** MCP resource metadata passed through to clients that support it. */
+  _meta?: MCPMetadata;
   handler: () => Promise<string>;
   /** Called when a client subscribes to this resource URI */
   onSubscribe?: (uri: string) => void;

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,14 @@ import { SubscribeRequestSchema, UnsubscribeRequestSchema, RootsListChangedNotif
 
 const execAsync = promisify(exec);
 import { z } from 'zod';
+import {
+  MCP_APP_MIME_TYPE,
+  createMCPAppResourceMeta,
+  resolveMCPAppFrameHeight,
+  withMCPAppFrameSizing,
+} from './plugin.js';
 import type {
+  MCPMetadata,
   MetroMCPConfig,
   PluginContext,
   PluginDefinition,
@@ -55,6 +62,18 @@ import { filesystemPlugin } from './plugins/filesystem.js';
 import { environmentPlugin } from './plugins/environment.js';
 
 const logger = createLogger('server');
+
+function isMCPAppResource(uri: string, mimeType?: string): boolean {
+  return uri.startsWith('ui://') || mimeType === MCP_APP_MIME_TYPE;
+}
+
+function withMeta<T extends object>(value: T, meta?: MCPMetadata): T & { _meta?: MCPMetadata } {
+  return meta ? { ...value, _meta: meta } : value;
+}
+
+function createDefaultMCPAppResourceMeta(meta?: MCPMetadata): MCPMetadata {
+  return createMCPAppResourceMeta(undefined, meta);
+}
 
 const BUILT_IN_PLUGINS: PluginDefinition[] = [
   consolePlugin,
@@ -231,11 +250,11 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
 
           const registration = mcpServer.registerTool(
             name,
-            {
+            withMeta({
               description: toolConfig.description,
               inputSchema,
               annotations: toolConfig.annotations,
-            },
+            }, toolConfig._meta),
             async (args, extra) => {
               // Build a sendProgress helper if the client sent a progressToken
               const progressToken = extra._meta?.progressToken;
@@ -266,13 +285,36 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
       },
       registerResource: (uri: string, resourceConfig: ResourceConfig) => {
         try {
+          const isAppResource = isMCPAppResource(uri, resourceConfig.mimeType);
+          const resolvedMimeType = isAppResource ? MCP_APP_MIME_TYPE : (resourceConfig.mimeType || 'application/json');
+          const resolvedResourceMeta = isAppResource
+            ? createDefaultMCPAppResourceMeta(resourceConfig._meta)
+            : resourceConfig._meta;
+          const frameSizingOptions = isAppResource
+            ? { minHeight: resolveMCPAppFrameHeight(resolvedResourceMeta) }
+            : undefined;
+          const registrationOptions = withMeta({
+            description: resourceConfig.description,
+            mimeType: resolvedMimeType,
+          }, resolvedResourceMeta);
+
           const registration = mcpServer.resource(
             resourceConfig.name,
             uri,
-            { description: resourceConfig.description, mimeType: resourceConfig.mimeType || 'application/json' },
+            registrationOptions,
             async () => {
               const content = await resourceConfig.handler();
-              return { contents: [{ uri, text: content, mimeType: resourceConfig.mimeType || 'application/json' }] };
+              const text = isAppResource
+                ? withMCPAppFrameSizing(content, frameSizingOptions)
+                : content;
+
+              return {
+                contents: [withMeta({
+                  uri,
+                  text,
+                  mimeType: resolvedMimeType,
+                }, resolvedResourceMeta)],
+              };
             }
           );
           registrations.push(registration);


### PR DESCRIPTION
## Summary
- Bumped the package to `0.1.1`.
- Kept the MCP App iframe-height work wired through `ui://` resources so Cursor gets a preferred frame size and resize hints.
- Added lightweight helpers for MCP app metadata and frame sizing in the plugin/server layers.

## Testing
- Not run (not requested).