### PR TITLE
Add minimum height support for MCP app resources

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": "Stephen Radford",
   "homepage": "https://metromcp.dev",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "author": {
     "name": "Stephen Radford",

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -358,11 +358,14 @@ Non-MCP-Apps hosts (CLI, simple clients) ignore `appUri` and display the tool's 
 ctx.registerAppResource('ui://my-plugin/dashboard', {
   name: 'My Dashboard',
   description: 'Interactive data viewer',
+  minHeight: 560, // Optional; defaults to 420px
   handler: async () => MY_HTML,
 });
 ```
 
-The HTML is served with MIME type `text/html;profile=mcp-app` automatically. The URI must start with `ui://`. Use `ui://your-plugin-name/...` as a namespace to avoid collisions with built-in apps (`ui://metro/...`).
+The HTML is served with MIME type `text/html;profile=mcp-app` automatically. metro-mcp also gives app iframes a default minimum height of `420px` and sends MCP Apps `ui/notifications/size-changed` notifications so hosts do not collapse the frame before content renders.
+
+The URI must start with `ui://`. Use `ui://your-plugin-name/...` as a namespace to avoid collisions with built-in apps (`ui://metro/...`).
 
 ### Linking a tool to an app
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -80,6 +80,8 @@ export interface ResourceConfig {
 export interface AppResourceConfig {
   name: string;
   description: string;
+  /** Minimum iframe height requested via CSS and Apps size notifications. Defaults to 420px. */
+  minHeight?: number;
   /** Returns the full HTML document string for the app. */
   handler: () => Promise<string>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { MetroEventsClient } from './metro/events.js';
 import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
 import { extractCDPExceptionMessage } from './utils/cdp.js';
+import { withAppSizing } from './utils/apps.js';
 import { version } from './version.js';
 
 // Built-in plugins
@@ -316,7 +317,13 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
             { description: appConfig.description },
             async () => {
               const html = await appConfig.handler();
-              return { contents: [{ uri, text: html, mimeType: RESOURCE_MIME_TYPE }] };
+              return {
+                contents: [{
+                  uri,
+                  text: withAppSizing(html, appConfig.minHeight),
+                  mimeType: RESOURCE_MIME_TYPE,
+                }],
+              };
             }
           );
           registrations.push(registration);

--- a/src/utils/apps.ts
+++ b/src/utils/apps.ts
@@ -87,6 +87,92 @@ export const BRIDGE_BOOTSTRAP_JS = `(function() {
   };
 })();`;
 
+export const DEFAULT_APP_MIN_HEIGHT = 420;
+
+const APP_SIZING_ATTRIBUTE = 'data-metro-mcp-app-sizing';
+const APP_SIZING_SELECTORS = ['html', 'body', '#app', '.layout'];
+
+function normalizeAppMinHeight(minHeight: number): number {
+  if (Number.isFinite(minHeight) && minHeight > 0) return Math.round(minHeight);
+  return DEFAULT_APP_MIN_HEIGHT;
+}
+
+function insertBeforeClosingTag(html: string, closingTag: string, insertion: string, whenMissing: 'append' | 'prepend'): string {
+  const index = html.indexOf(closingTag);
+  if (index !== -1) {
+    return `${html.slice(0, index)}${insertion}${html.slice(index)}`;
+  }
+  return whenMissing === 'append' ? `${html}${insertion}` : `${insertion}${html}`;
+}
+
+/**
+ * Ensure MCP App resources have a non-collapsing initial height and can ask
+ * hosts to resize via the official Apps size notification.
+ */
+export function withAppSizing(html: string, minHeight = DEFAULT_APP_MIN_HEIGHT): string {
+  if (html.includes(APP_SIZING_ATTRIBUTE)) return html;
+
+  const safeMinHeight = normalizeAppMinHeight(minHeight);
+  const selectorList = APP_SIZING_SELECTORS.join(',');
+
+  const sizingStyle = `<style ${APP_SIZING_ATTRIBUTE}>
+${selectorList}{min-height:${safeMinHeight}px}
+</style>
+`;
+
+  const sizingScript = `<script ${APP_SIZING_ATTRIBUTE}>
+(function(){
+  var minHeight = ${safeMinHeight};
+  var sizingSelectors = ${JSON.stringify(APP_SIZING_SELECTORS)};
+  var lastWidth = 0;
+  var lastHeight = 0;
+  var scheduled = false;
+  function measureHeight(){
+    var height = minHeight;
+    for (var i = 0; i < sizingSelectors.length; i++) {
+      var element = document.querySelector(sizingSelectors[i]);
+      if (element) height = Math.max(height, element.scrollHeight);
+    }
+    return height;
+  }
+  function postSize(){
+    scheduled = false;
+    var width = Math.ceil(window.innerWidth || document.documentElement.clientWidth || 0);
+    var height = measureHeight();
+    if (width === lastWidth && height === lastHeight) return;
+    lastWidth = width;
+    lastHeight = height;
+    window.parent.postMessage({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/size-changed',
+      params: { width: width, height: height }
+    }, '*');
+  }
+  function schedulePostSize(){
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(postSize);
+  }
+  if ('ResizeObserver' in window) {
+    var observer = new ResizeObserver(schedulePostSize);
+    observer.observe(document.documentElement);
+    if (document.body) observer.observe(document.body);
+    var app = document.getElementById('app');
+    if (app) observer.observe(app);
+  }
+  window.addEventListener('load', schedulePostSize);
+  window.addEventListener('resize', schedulePostSize);
+  schedulePostSize();
+  setTimeout(schedulePostSize, 100);
+  setTimeout(schedulePostSize, 500);
+})();
+</script>
+`;
+
+  const withStyle = insertBeforeClosingTag(html, '</head>', sizingStyle, 'prepend');
+  return insertBeforeClosingTag(withStyle, '</body>', sizingScript, 'append');
+}
+
 /**
  * Wrap a body HTML snippet in a complete, self-contained MCP App document.
  * Includes the postMessage bridge, CSS reset, and theme-aware custom properties.


### PR DESCRIPTION
## Summary
- Add a shared MCP app sizing helper that applies a default `420px` minimum height and emits `ui/notifications/size-changed` so hosts keep app iframes from collapsing.
- Wire the helper into MCP app resource registration and expose `minHeight` on `AppResourceConfig` for overrides.
- Update plugin docs and release metadata to `0.11.1`.

## Testing
- Local validation passed with `bun run build:apps`, `bun run typecheck`, and `bun run build`.
- Verified the sizing helper is idempotent and injects both the minimum-height CSS and the official size-change notification.