### PR TITLE
fix: Use metro-bridge for doctor

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,7 +52,7 @@ Runs the following checks and reports pass/fail for each:
 |---|---|
 | Node.js version | Must be >=18 |
 | Config file | Looks for `metro-mcp.config.ts` or `.js` in the current directory |
-| Metro connectivity | HTTP request to the configured host:port |
+| Metro connectivity | Uses `metro-bridge` status discovery for the configured host:port, including the `localhost` to `127.0.0.1` fallback |
 | Plugin paths | Verifies local plugin file paths from your config exist on disk |
 
 Exit code is `0` if all checks pass, `1` if any fail.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "transport": {
         "type": "stdio"
       }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as http from 'node:http';
 import { intro, log, note, outro } from '@clack/prompts';
+import { checkMetroStatus } from 'metro-bridge';
 import { loadConfig } from '../config.js';
 
 function checkNodeVersion(): { ok: boolean; message: string } {
@@ -13,20 +13,12 @@ function checkNodeVersion(): { ok: boolean; message: string } {
   return { ok: false, message: `Node.js ${ver} — requires >=18` };
 }
 
-function checkMetro(host: string, port: number): Promise<{ ok: boolean; message: string }> {
-  return new Promise((resolve) => {
-    const req = http.get({ host, port, path: '/', timeout: 3000 }, (res) => {
-      resolve({ ok: true, message: `Metro reachable at ${host}:${port} (HTTP ${res.statusCode})` });
-      res.resume();
-    });
-    req.on('timeout', () => {
-      req.destroy();
-      resolve({ ok: false, message: `Metro not reachable at ${host}:${port} — connection timed out` });
-    });
-    req.on('error', (err) => {
-      resolve({ ok: false, message: `Metro not reachable at ${host}:${port} — ${err.message}` });
-    });
-  });
+async function checkMetro(host: string, port: number): Promise<{ ok: boolean; message: string }> {
+  const status = await checkMetroStatus(host, port);
+  if (status !== null) {
+    return { ok: true, message: `Metro reachable at ${host}:${port} (${status.trim() || 'status ok'})` };
+  }
+  return { ok: false, message: `Metro not reachable at ${host}:${port}` };
 }
 
 function findConfigFile(): string | null {


### PR DESCRIPTION
Doctor used to use an HTTP request to connect to the configured port. It now uses `metro-bridge` status discovery.