### PR TITLE
Add shared MCP multiplexing for concurrent clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ If you use several MCP clients, [`add-mcp`](https://github.com/neondatabase/add-
 npx add-mcp metro-mcp --all -g -y
 ```
 
+metro-mcp supports multiple agents at the same time. Standard stdio installs start or reuse a local shared daemon, so Codex, Claude Code, Cursor, and other clients can connect concurrently to the same running Metro app and see the same logs, network requests, errors, and runtime state.
+
+### Shared HTTP server / Supergateway
+
+If you want to expose one long-lived MCP endpoint yourself, start the shared server explicitly:
+
+```bash
+npx -y metro-mcp serve --mcp-port 8765
+```
+
+This serves Streamable HTTP at `http://127.0.0.1:8765/mcp` and legacy SSE at `http://127.0.0.1:8765/sse`. Tools such as [`supergateway`](https://github.com/supercorp-ai/supergateway) can point at the Streamable HTTP endpoint instead of launching a fresh stdio process per request.
+
 ### With custom Metro port
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,10 +84,16 @@ Prints the plugin's name, version, and description if valid. Exit code is `0` on
 
 ## MCP server options
 
-When run without a subcommand, metro-mcp starts the MCP server:
+When run without a subcommand, metro-mcp starts a stdio MCP server that attaches to a shared localhost daemon. Multiple clients with the same options reuse that daemon and share the same Metro/CDP runtime:
 
 ```bash
 bunx metro-mcp [options]
+```
+
+To run the shared HTTP server in the foreground:
+
+```bash
+bunx metro-mcp serve --mcp-port 8765
 ```
 
 | Flag | Description |
@@ -96,6 +102,8 @@ bunx metro-mcp [options]
 | `--port`, `-p <port>` | Metro bundler port (default: `8081`) |
 | `--config`, `-c <path>` | Path to a config file (absolute or relative to CWD) |
 | `--plugin <path>` | Load a plugin by path — repeatable |
+| `--mcp-port <port>` | Port for `serve` mode (default: random, env: `METRO_MCP_MCP_PORT`) |
+| `--stdio-direct` | Disable multiplexing and run the legacy single-process stdio server |
 | `--help` | Print usage |
 
 **Examples:**
@@ -115,6 +123,9 @@ bunx metro-mcp --plugin ./my-plugin.ts
 
 # Multiple plugins
 bunx metro-mcp --plugin ./plugin-a.ts --plugin ./plugin-b.ts
+
+# Foreground Streamable HTTP endpoint for supergateway or custom clients
+bunx metro-mcp serve --mcp-port 8765
 ```
 
 ## Environment variables
@@ -129,4 +140,6 @@ Key ones at a glance:
 | `METRO_PORT` | Metro bundler port |
 | `METRO_MCP_CONFIG` | Path to config file |
 | `METRO_MCP_PLUGINS` | Colon-separated plugin paths |
+| `METRO_MCP_MCP_PORT` | Port for `serve` mode |
+| `METRO_MCP_MULTIPLEX` | Set to `false` to disable the stdio daemon/proxy |
 | `DEBUG` | Enable debug logging |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,8 @@
 | `METRO_MCP_PLUGINS` | — | Colon-separated plugin paths to load (e.g. `./my-plugin.ts:metro-mcp-plugin-foo`) |
 | `METRO_MCP_PROXY_ENABLED` | `true` | Enable the CDP proxy for Chrome DevTools coexistence |
 | `METRO_MCP_PROXY_PORT` | `0` (random) | Fixed port for the CDP proxy. Use `0` for a random available port |
+| `METRO_MCP_MCP_PORT` | `0` (random) | Fixed port for `metro-mcp serve` Streamable HTTP/SSE endpoint |
+| `METRO_MCP_MULTIPLEX` | `true` | Set to `false` to run the legacy single-process stdio server |
 | `DEBUG` | — | Enable debug logging |
 
 ## CLI Arguments
@@ -26,6 +28,31 @@ bunx metro-mcp --host 192.168.1.100 --port 19000
 | `--port`, `-p` | Metro bundler port |
 | `--config`, `-c` | Path to config file (overrides `METRO_MCP_CONFIG`) |
 | `--plugin` | Load a plugin by path (repeatable) |
+| `--mcp-port` | Port for `metro-mcp serve` |
+| `--stdio-direct` | Disable stdio multiplexing for this process |
+
+## Multi-client and HTTP mode
+
+Standard stdio configuration is still recommended for Codex, Claude Code, Cursor, VS Code, and OpenCode:
+
+```json
+{
+  "mcpServers": {
+    "metro-mcp": {
+      "command": "npx",
+      "args": ["-y", "metro-mcp"]
+    }
+  }
+}
+```
+
+Each stdio process connects to a shared local daemon when the Metro/config options match. For tools that need an explicit HTTP endpoint, run:
+
+```bash
+npx -y metro-mcp serve --mcp-port 8765
+```
+
+Streamable HTTP is available at `http://127.0.0.1:8765/mcp`; legacy SSE is available at `http://127.0.0.1:8765/sse`.
 
 ## Config File
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,15 +42,17 @@ This routes Chrome DevTools through the proxy so both connections remain active.
 
 ## MCP running in multiple agents
 
-Running metro-mcp in more than one AI agent simultaneously (e.g. Claude Code **and** Cursor) causes conflicts — both agents share the same Metro CDP connection and buffers, leading to missed events, duplicate data, and confusing state.
+metro-mcp supports multiple AI agents simultaneously for the same running app. Standard stdio installs start or reuse a shared localhost daemon, so Claude Code, Codex, Cursor, VS Code, and other clients connect to the same Metro/CDP runtime and share buffers.
 
-**Only run metro-mcp in one agent at a time.** If you need to switch agents, stop the MCP in one before starting it in the other. In Claude Code:
+If one agent was started with different Metro flags or config, it may create a separate daemon. Use the same `--port`, `--host`, `--config`, and plugin settings in each MCP client when you want them to share one runtime.
+
+If you need to inspect active MCP servers in Claude Code:
 
 ```
 /mcp
 ```
 
-This shows active MCP servers — remove metro-mcp if you're switching to another editor.
+This shows active MCP servers and lets you restart metro-mcp for that client.
 
 ## Restart the MCP server
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,217 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { createLogger } from './utils/logger.js';
+
+const logger = createLogger('daemon');
+
+const CONFIG_DIR = path.join(os.homedir(), '.config', 'metro-mcp');
+const DAEMON_KEY_ENV = 'METRO_MCP_DAEMON_KEY';
+const STARTUP_LOCK_TIMEOUT_MS = 10_000;
+const STARTUP_LOCK_STALE_MS = 30_000;
+const DAEMON_ENV_KEYS = [
+  'METRO_HOST',
+  'METRO_PORT',
+  'METRO_MCP_CONFIG',
+  'METRO_MCP_PLUGINS',
+  'METRO_MCP_PROXY_PORT',
+  'METRO_MCP_PROXY_ENABLED',
+] as const;
+
+interface DaemonRecord {
+  pid: number;
+  host: string;
+  port: number;
+  url: string;
+  key: string;
+  args: string[];
+  startedAt: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function selectedEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {};
+  for (const key of DAEMON_ENV_KEYS) {
+    env[key] = process.env[key];
+  }
+  return env;
+}
+
+export function getDaemonKey(args: string[]): string {
+  const hash = createHash('sha256');
+  hash.update(JSON.stringify({ args, env: selectedEnv() }));
+  return hash.digest('hex').slice(0, 16);
+}
+
+export function getDaemonRecordPath(key: string): string {
+  return path.join(CONFIG_DIR, `daemon-${key}.json`);
+}
+
+function getDaemonLockPath(key: string): string {
+  return path.join(CONFIG_DIR, `daemon-${key}.lock`);
+}
+
+export function writeDaemonRecord(record: DaemonRecord): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(getDaemonRecordPath(record.key), JSON.stringify(record, null, 2));
+}
+
+function removeDaemonRecord(key: string): void {
+  try {
+    fs.unlinkSync(getDaemonRecordPath(key));
+  } catch {
+    // Already gone.
+  }
+}
+
+async function isRecordLive(record: DaemonRecord): Promise<boolean> {
+  try {
+    process.kill(record.pid, 0);
+  } catch {
+    return false;
+  }
+
+  try {
+    const healthUrl = new URL('/health', record.url);
+    const response = await fetch(healthUrl, { signal: AbortSignal.timeout(1000) });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function readLiveRecord(key: string): Promise<DaemonRecord | null> {
+  try {
+    const record = JSON.parse(fs.readFileSync(getDaemonRecordPath(key), 'utf8')) as DaemonRecord;
+    if (await isRecordLive(record)) return record;
+  } catch {
+    // Missing or corrupt record.
+  }
+  removeDaemonRecord(key);
+  return null;
+}
+
+async function waitForRecord(key: string): Promise<DaemonRecord> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const record = await readLiveRecord(key);
+    if (record) return record;
+    await sleep(100);
+  }
+  throw new Error('Timed out waiting for metro-mcp daemon to start');
+}
+
+async function withStartupLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  const lockPath = getDaemonLockPath(key);
+  const deadline = Date.now() + STARTUP_LOCK_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    let fd: number | null = null;
+    try {
+      fd = fs.openSync(lockPath, 'wx');
+      fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+      return await fn();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > STARTUP_LOCK_STALE_MS) {
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      await sleep(100);
+    } finally {
+      if (fd !== null) {
+        try { fs.closeSync(fd); } catch { /* ignore */ }
+        try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+      }
+    }
+  }
+
+  throw new Error('Timed out waiting for metro-mcp daemon startup lock');
+}
+
+async function ensureDaemon(args: string[]): Promise<DaemonRecord> {
+  const key = getDaemonKey(args);
+  const existing = await readLiveRecord(key);
+  if (existing) return existing;
+
+  return withStartupLock(key, async () => {
+    const lockedExisting = await readLiveRecord(key);
+    if (lockedExisting) return lockedExisting;
+
+    const entry = process.argv[1];
+    if (!entry) throw new Error('Cannot locate metro-mcp entrypoint for daemon startup');
+
+    const child = spawn(process.execPath, [entry, 'serve', ...args], {
+      detached: true,
+      stdio: 'ignore',
+      env: {
+        ...process.env,
+        [DAEMON_KEY_ENV]: key,
+      },
+    });
+    child.unref();
+
+    logger.info('Started metro-mcp daemon');
+    return waitForRecord(key);
+  });
+}
+
+export function getDaemonKeyFromEnv(args: string[]): string {
+  return process.env[DAEMON_KEY_ENV] || getDaemonKey(args);
+}
+
+export async function startStdioProxy(args: string[]): Promise<void> {
+  const record = await ensureDaemon(args);
+  const stdio = new StdioServerTransport();
+  const daemonTransport = new StreamableHTTPClientTransport(new URL(record.url));
+  let closing = false;
+
+  async function closeQuietly(transport: { close(): Promise<void> }): Promise<void> {
+    await transport.close().catch(() => {});
+  }
+
+  async function close(): Promise<void> {
+    if (closing) return;
+    closing = true;
+    await Promise.all([
+      closeQuietly(stdio),
+      closeQuietly(daemonTransport),
+    ]);
+    process.exit(0);
+  }
+
+  stdio.onmessage = (message: JSONRPCMessage) => {
+    daemonTransport.send(message).catch((err) => {
+      logger.error('Failed to forward stdio message to daemon:', err);
+      void close();
+    });
+  };
+  daemonTransport.onmessage = (message: JSONRPCMessage) => {
+    stdio.send(message).catch((err) => {
+      logger.error('Failed to forward daemon message to stdio:', err);
+      void close();
+    });
+  };
+  stdio.onerror = (err) => logger.error('stdio transport error:', err);
+  daemonTransport.onerror = (err) => logger.error('daemon transport error:', err);
+  stdio.onclose = () => void close();
+  daemonTransport.onclose = () => void close();
+
+  await daemonTransport.start();
+  await stdio.start();
+  logger.info(`Connected stdio client to metro-mcp daemon ${record.url}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { loadConfig } from './config.js';
-import { startServer } from './server.js';
+import { startHttpServer, startServer } from './server.js';
+import { getDaemonKeyFromEnv, startStdioProxy, writeDaemonRecord } from './daemon.js';
 import { createLogger } from './utils/logger.js';
 
 const logger = createLogger('main');
@@ -33,8 +34,10 @@ async function main() {
     process.exit(0);
   }
 
+  const serverArgs = subcommand === 'serve' ? args.slice(1) : args;
+
   // Catch unknown subcommands (args that look like commands, not flags)
-  if (subcommand && !subcommand.startsWith('-')) {
+  if (subcommand && subcommand !== 'serve' && !subcommand.startsWith('-')) {
     console.error(`Unknown command: ${subcommand}\nRun \`metro-mcp --help\` for usage.`);
     process.exit(1);
   }
@@ -44,6 +47,7 @@ async function main() {
 metro-mcp — React Native MCP Server
 
 Commands:
+  serve                   Start the shared localhost MCP HTTP server
   create-plugin           Scaffold a new metro-mcp plugin package
   init                    Create a metro-mcp.config.ts in the current project
   doctor                  Check Metro connectivity and config health
@@ -57,6 +61,8 @@ Options:
   --port, -p <port>       Metro port (default: 8081, env: METRO_PORT)
   --config, -c <path>     Path to config file (env: METRO_MCP_CONFIG)
   --plugin <path>         Load a plugin (repeatable, env: METRO_MCP_PLUGINS)
+  --mcp-port <port>       Port for \`serve\` mode (default: random, env: METRO_MCP_MCP_PORT)
+  --stdio-direct          Run one legacy stdio server process without multiplexing
   --help                  Show this help message
 
 Environment Variables:
@@ -64,10 +70,13 @@ Environment Variables:
   METRO_PORT              Metro bundler port
   METRO_MCP_CONFIG        Path to config file (absolute or relative to CWD)
   METRO_MCP_PLUGINS       Colon-separated plugin paths
+  METRO_MCP_MCP_PORT      Port for the shared MCP HTTP server
+  METRO_MCP_MULTIPLEX     Set to "false" to disable the stdio daemon/proxy
   DEBUG                   Enable debug logging
 
 Examples:
   metro-mcp
+  metro-mcp serve --mcp-port 8765
   metro-mcp --port 19000
   metro-mcp --config /path/to/metro-mcp.config.ts
   METRO_MCP_CONFIG=/path/to/metro-mcp.config.ts metro-mcp
@@ -77,13 +86,53 @@ Examples:
   }
 
   try {
-    const config = await loadConfig(args);
+    const config = await loadConfig(serverArgs);
     logger.info(`Starting metro-mcp (Metro: ${config.metro.host}:${config.metro.port})`);
-    await startServer(config, args);
+
+    if (subcommand === 'serve') {
+      const mcpPort = resolveMcpPort(serverArgs);
+      const key = getDaemonKeyFromEnv(serverArgs);
+      await startHttpServer(config, serverArgs, {
+        port: mcpPort,
+        onListening: ({ host, port, url }) => {
+          writeDaemonRecord({
+            pid: process.pid,
+            host,
+            port,
+            url,
+            key,
+            args: serverArgs,
+            startedAt: new Date().toISOString(),
+          });
+        },
+      });
+      return;
+    }
+
+    if (serverArgs.includes('--stdio-direct') || process.env.METRO_MCP_MULTIPLEX === 'false') {
+      await startServer(config, serverArgs.filter((arg) => arg !== '--stdio-direct'));
+      return;
+    }
+
+    await startStdioProxy(serverArgs);
   } catch (err) {
     logger.error('Fatal error:', err);
     process.exit(1);
   }
+}
+
+function parseOptionalInt(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function resolveMcpPort(args: string[]): number {
+  const fromEnv = parseOptionalInt(process.env.METRO_MCP_MCP_PORT);
+  if (fromEnv !== undefined) return fromEnv;
+  const index = args.indexOf('--mcp-port');
+  if (index === -1) return 0;
+  return parseOptionalInt(args[index + 1]) ?? 0;
 }
 
 main();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,18 +1,21 @@
-import { exec } from 'child_process';
+import { randomUUID } from 'node:crypto';
+import { exec } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
 import { resolve } from 'node:path';
-import { promisify } from 'util';
-import fs from 'fs';
+import { promisify } from 'node:util';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { SubscribeRequestSchema, UnsubscribeRequestSchema, RootsListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { SubscribeRequestSchema, UnsubscribeRequestSchema, RootsListChangedNotificationSchema, isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import {
   registerAppResource as registerMcpAppResource,
   registerAppTool as registerMcpAppTool,
   RESOURCE_MIME_TYPE,
 } from '@modelcontextprotocol/ext-apps/server';
-
-const execAsync = promisify(exec);
 import { z } from 'zod';
 import type {
   MetroMCPConfig,
@@ -62,6 +65,7 @@ import { permissionsPlugin } from './plugins/permissions.js';
 import { filesystemPlugin } from './plugins/filesystem.js';
 import { environmentPlugin } from './plugins/environment.js';
 
+const execAsync = promisify(exec);
 const logger = createLogger('server');
 
 const BUILT_IN_PLUGINS: PluginDefinition[] = [
@@ -93,8 +97,23 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   environmentPlugin,
 ];
 
-export async function startServer(config: Required<MetroMCPConfig>, args: string[] = []): Promise<void> {
-  const mcpServer = new McpServer(
+type RuntimeRegistration = (session: McpSession) => { remove: () => void };
+
+interface McpSession {
+  id: string;
+  server: McpServer;
+  subscribedResources: Set<string>;
+  registrations: Array<{ remove: () => void }>;
+}
+
+interface HttpServerOptions {
+  host?: string;
+  port?: number;
+  onListening?: (info: { host: string; port: number; url: string }) => void;
+}
+
+function createMcpServer(): McpServer {
+  return new McpServer(
     {
       name: 'metro-mcp',
       version,
@@ -103,31 +122,43 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
       instructions: `React Native runtime debugging MCP server. Connects to Metro bundler via Chrome DevTools Protocol to provide console logs, network requests, component tree inspection, state management debugging, device control, and more. Use list_devices to see connected targets, then use other tools to inspect and interact with the running app.`,
     }
   );
+}
 
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString('utf8');
+  return raw ? JSON.parse(raw) : undefined;
+}
+
+async function closeQuietly(closable: { close(): Promise<void> }): Promise<void> {
+  await closable.close().catch(() => {});
+}
+
+export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>, args: string[] = []) {
+  let config = initialConfig;
   const cdpSession = new CDPSession();
   const eventsClient = new MetroEventsClient();
   const formatUtils = createFormatUtils();
-
-  // Track URIs that clients have subscribed to for live update notifications
-  const subscribedResources = new Set<string>();
-
-  // Wire up resource subscription handlers so clients can receive push notifications
-  // when resource content changes (e.g. new logs, errors, network requests).
-  mcpServer.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
-    subscribedResources.add(req.params.uri);
-    logger.debug(`Client subscribed to resource: ${req.params.uri}`);
-    return {};
-  });
-
-  mcpServer.server.setRequestHandler(UnsubscribeRequestSchema, async (req) => {
-    subscribedResources.delete(req.params.uri);
-    logger.debug(`Client unsubscribed from resource: ${req.params.uri}`);
-    return {};
-  });
+  const sessions = new Set<McpSession>();
+  const runtimeRegistrations: RuntimeRegistration[] = [];
+  let projectRoot: string | null = null;
+  let reloadInProgress = false;
+  let isInitializingPlugins = false;
+  let runtimeClosed = false;
 
   function notifyResourceUpdated(uri: string): void {
-    if (subscribedResources.has(uri)) {
-      mcpServer.server.sendResourceUpdated({ uri }).catch(() => {});
+    for (const session of sessions) {
+      if (session.subscribedResources.has(uri)) {
+        session.server.server.sendResourceUpdated({ uri }).catch(() => {});
+      }
     }
   }
 
@@ -215,9 +246,39 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
     await enableCDPDomains();
   });
 
-  // Tracks all plugin registrations (tools, resources, prompts) so they can be
-  // removed and re-registered when the active project root changes.
-  const registrations: Array<{ remove: () => void }> = [];
+  function clearSessionRegistrations(session: McpSession): void {
+    for (const reg of session.registrations) {
+      try { reg.remove(); } catch { /* ignore */ }
+    }
+    session.registrations.length = 0;
+  }
+
+  function materializeSession(session: McpSession): void {
+    clearSessionRegistrations(session);
+    for (const register of runtimeRegistrations) {
+      try {
+        session.registrations.push(register(session));
+      } catch (err) {
+        logger.error(`Failed to materialize MCP registration for session ${session.id}:`, err);
+      }
+    }
+  }
+
+  function materializeAllSessions(): void {
+    for (const session of sessions) {
+      materializeSession(session);
+    }
+  }
+
+  function addRuntimeRegistration(
+    register: RuntimeRegistration,
+    registrationLogger: ReturnType<typeof createLogger>,
+    debugMessage: string,
+  ): void {
+    runtimeRegistrations.push(register);
+    if (!isInitializingPlugins) materializeAllSessions();
+    registrationLogger.debug(debugMessage);
+  }
 
   // Create the plugin context factory
   function createPluginContext(plugin: PluginDefinition, cfg: Required<MetroMCPConfig>): PluginContext {
@@ -267,43 +328,47 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
             }
           };
 
-          let registration: { remove: () => void };
-          if (toolConfig.appUri) {
-            registration = registerMcpAppTool(
-              mcpServer,
-              name,
-              {
-                ...toolDefinition,
-                _meta: { ui: { resourceUri: toolConfig.appUri } },
-              },
-              handler,
-            );
-          } else {
-            registration = mcpServer.registerTool(
-              name,
-              toolDefinition,
-              handler,
-            );
-          }
-          registrations.push(registration);
-          pluginLogger.debug(`Registered tool: ${name}`);
+          addRuntimeRegistration(
+            (session) => {
+              if (toolConfig.appUri) {
+                return registerMcpAppTool(
+                  session.server,
+                  name,
+                  {
+                    ...toolDefinition,
+                    _meta: { ui: { resourceUri: toolConfig.appUri } },
+                  },
+                  handler,
+                );
+              }
+              return session.server.registerTool(
+                name,
+                toolDefinition,
+                handler,
+              );
+            },
+            pluginLogger,
+            `Registered tool: ${name}`,
+          );
         } catch (err) {
           pluginLogger.error(`Failed to register tool ${name}:`, err);
         }
       },
       registerResource: (uri: string, resourceConfig: ResourceConfig) => {
         try {
-          const registration = mcpServer.resource(
-            resourceConfig.name,
-            uri,
-            { description: resourceConfig.description, mimeType: resourceConfig.mimeType || 'application/json' },
-            async () => {
-              const content = await resourceConfig.handler();
-              return { contents: [{ uri, text: content, mimeType: resourceConfig.mimeType || 'application/json' }] };
-            }
+          addRuntimeRegistration(
+            (session) => session.server.resource(
+              resourceConfig.name,
+              uri,
+              { description: resourceConfig.description, mimeType: resourceConfig.mimeType || 'application/json' },
+              async () => {
+                const content = await resourceConfig.handler();
+                return { contents: [{ uri, text: content, mimeType: resourceConfig.mimeType || 'application/json' }] };
+              }
+            ),
+            pluginLogger,
+            `Registered resource: ${uri}`,
           );
-          registrations.push(registration);
-          pluginLogger.debug(`Registered resource: ${uri}`);
         } catch (err) {
           pluginLogger.error(`Failed to register resource ${uri}:`, err);
         }
@@ -311,25 +376,27 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
       registerAppResource: (uri: string, appConfig: AppResourceConfig) => {
         try {
           const preferredFrameSizeMeta = createPreferredFrameSizeMeta(appConfig.minHeight);
-          const registration = registerMcpAppResource(
-            mcpServer,
-            appConfig.name,
-            uri,
-            { description: appConfig.description, _meta: preferredFrameSizeMeta },
-            async () => {
-              const html = await appConfig.handler();
-              return {
-                contents: [{
-                  uri,
-                  text: withAppSizing(html, appConfig.minHeight),
-                  mimeType: RESOURCE_MIME_TYPE,
-                  _meta: preferredFrameSizeMeta,
-                }],
-              };
-            }
+          addRuntimeRegistration(
+            (session) => registerMcpAppResource(
+              session.server,
+              appConfig.name,
+              uri,
+              { description: appConfig.description, _meta: preferredFrameSizeMeta },
+              async () => {
+                const html = await appConfig.handler();
+                return {
+                  contents: [{
+                    uri,
+                    text: withAppSizing(html, appConfig.minHeight),
+                    mimeType: RESOURCE_MIME_TYPE,
+                    _meta: preferredFrameSizeMeta,
+                  }],
+                };
+              }
+            ),
+            pluginLogger,
+            `Registered app resource: ${uri}`,
           );
-          registrations.push(registration);
-          pluginLogger.debug(`Registered app resource: ${uri}`);
         } catch (err) {
           pluginLogger.error(`Failed to register app resource ${uri}:`, err);
         }
@@ -343,22 +410,24 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
               argsShape[arg.name] = arg.required ? z.string() : z.string().optional();
             }
           }
-          const registration = mcpServer.prompt(
-            name,
-            promptConfig.description,
-            argsShape,
-            async (args) => {
-              const messages = await promptConfig.handler(args as Record<string, string>);
-              return {
-                messages: messages.map((m) => ({
-                  role: m.role as 'user' | 'assistant',
-                  content: { type: 'text' as const, text: m.content },
-                })),
-              };
-            }
+          addRuntimeRegistration(
+            (session) => session.server.prompt(
+              name,
+              promptConfig.description,
+              argsShape,
+              async (args) => {
+                const messages = await promptConfig.handler(args as Record<string, string>);
+                return {
+                  messages: messages.map((m) => ({
+                    role: m.role as 'user' | 'assistant',
+                    content: { type: 'text' as const, text: m.content },
+                  })),
+                };
+              }
+            ),
+            pluginLogger,
+            `Registered prompt: ${name}`,
           );
-          registrations.push(registration);
-          pluginLogger.debug(`Registered prompt: ${name}`);
         } catch (err) {
           pluginLogger.error(`Failed to register prompt ${name}:`, err);
         }
@@ -433,11 +502,10 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
   // Load and initialize all plugins. Clears existing registrations first so this
   // can be called again when the active project root changes.
   async function initPlugins(cfg: Required<MetroMCPConfig>, rootPath?: string): Promise<void> {
-    // Remove all existing tool/resource/prompt registrations
-    for (const reg of registrations) {
-      try { reg.remove(); } catch { /* ignore */ }
+    runtimeRegistrations.length = 0;
+    for (const session of sessions) {
+      clearSessionRegistrations(session);
     }
-    registrations.length = 0;
 
     const baseDir = rootPath ?? process.cwd();
     const allPlugins = [...BUILT_IN_PLUGINS];
@@ -460,15 +528,21 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
       }
     }
 
-    for (const plugin of allPlugins) {
-      try {
-        const ctx = createPluginContext(plugin, cfg);
-        await plugin.setup(ctx);
-        logger.debug(`Initialized plugin: ${plugin.name}`);
-      } catch (err) {
-        logger.error(`Failed to initialize plugin ${plugin.name}:`, err);
+    isInitializingPlugins = true;
+    try {
+      for (const plugin of allPlugins) {
+        try {
+          const ctx = createPluginContext(plugin, cfg);
+          await plugin.setup(ctx);
+          logger.debug(`Initialized plugin: ${plugin.name}`);
+        } catch (err) {
+          logger.error(`Failed to initialize plugin ${plugin.name}:`, err);
+        }
       }
+    } finally {
+      isInitializingPlugins = false;
     }
+    materializeAllSessions();
   }
 
   await initPlugins(config);
@@ -668,25 +742,27 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
     } catch { /* no stale lock */ }
   }
 
-  // Start MCP transport
-  const transport = new StdioServerTransport();
-  await mcpServer.connect(transport);
-  logger.info('MCP server started');
-
-  // Reload config + plugins from the client's active project root. A concurrency
-  // guard prevents interleaved runs if roots-changed fires while a reload is already
-  // in progress (IDE batch-sends notifications on project switch).
-  let reloadInProgress = false;
-  async function reloadFromRoots(suppressErrors = false): Promise<void> {
+  // Reload config + plugins from the first client's active project root. v1 shares
+  // one runtime across sessions, so later clients must target the same app.
+  async function reloadFromRoots(session: McpSession, suppressErrors = false): Promise<void> {
     if (reloadInProgress) return;
     reloadInProgress = true;
     try {
-      const { roots } = await mcpServer.server.listRoots();
+      const { roots } = await session.server.server.listRoots();
       const firstRoot = roots[0];
       if (!firstRoot) return;
       const rootPath = new URL(firstRoot.uri).pathname;
+      if (projectRoot && projectRoot !== rootPath) {
+        logger.warn(
+          `Ignoring roots change for ${rootPath}; metro-mcp multiplexing is already bound to ${projectRoot}`
+        );
+        return;
+      }
+      if (projectRoot === rootPath) return;
+      projectRoot = rootPath;
       logger.info(`Reloading plugins from: ${rootPath}`);
       const newConfig = await loadConfig(args, rootPath);
+      config = newConfig;
       await initPlugins(newConfig, rootPath);
       logger.info(`Plugins reloaded for: ${rootPath}`);
     } catch (err) {
@@ -696,19 +772,73 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
     }
   }
 
-  // Reload all plugins when the client's active project root changes.
-  // This lets a single global metro-mcp install automatically pick up the
-  // metro-mcp.config.ts from whichever project the user is working in.
-  mcpServer.server.setNotificationHandler(RootsListChangedNotificationSchema, () => reloadFromRoots());
+  async function connectSession(transport: Transport): Promise<McpSession> {
+    const session: McpSession = {
+      id: randomUUID(),
+      server: createMcpServer(),
+      subscribedResources: new Set<string>(),
+      registrations: [],
+    };
 
-  // On first client connection, load config from the initial project root (if any).
-  // This handles the case where the user opens an IDE with a project already open.
-  mcpServer.server.oninitialized = () => reloadFromRoots(true);
+    session.server.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
+      session.subscribedResources.add(req.params.uri);
+      logger.debug(`Client subscribed to resource: ${req.params.uri}`);
+      return {};
+    });
+
+    session.server.server.setRequestHandler(UnsubscribeRequestSchema, async (req) => {
+      session.subscribedResources.delete(req.params.uri);
+      logger.debug(`Client unsubscribed from resource: ${req.params.uri}`);
+      return {};
+    });
+
+    session.server.server.setNotificationHandler(RootsListChangedNotificationSchema, () => reloadFromRoots(session));
+    session.server.server.oninitialized = () => reloadFromRoots(session, true);
+
+    const previousClose = transport.onclose;
+    transport.onclose = () => {
+      previousClose?.();
+      clearSessionRegistrations(session);
+      sessions.delete(session);
+      logger.debug(`MCP session closed: ${session.id}`);
+    };
+
+    materializeSession(session);
+    sessions.add(session);
+    await session.server.connect(transport);
+    logger.info(`MCP session connected: ${session.id}`);
+    return session;
+  }
+
+  async function startStdio(): Promise<void> {
+    await connectSession(new StdioServerTransport());
+    logger.info('MCP stdio session started');
+  }
+
+  function closeRuntime(): void {
+    if (runtimeClosed) return;
+    runtimeClosed = true;
+    process.off('SIGINT', handleSigint);
+    process.off('SIGTERM', handleSigterm);
+    process.off('exit', handleExit);
+    for (const session of sessions) {
+      clearSessionRegistrations(session);
+      session.server.close().catch(() => {});
+    }
+    sessions.clear();
+    eventsClient.disconnect();
+    cleanProxyLock();
+    cdpMultiplexer?.stop();
+  }
+
+  const handleSigint = () => { closeRuntime(); process.exit(0); };
+  const handleSigterm = () => { closeRuntime(); process.exit(0); };
+  const handleExit = () => { closeRuntime(); };
 
   // Clean up on shutdown
-  process.on('SIGINT', () => { cleanProxyLock(); cdpMultiplexer?.stop(); process.exit(0); });
-  process.on('SIGTERM', () => { cleanProxyLock(); cdpMultiplexer?.stop(); process.exit(0); });
-  process.on('exit', () => { cleanProxyLock(); });
+  process.on('SIGINT', handleSigint);
+  process.on('SIGTERM', handleSigterm);
+  process.on('exit', handleExit);
 
   // Try connecting to Metro (non-blocking — server works without connection).
   // If the initial attempt fails before creating any WebSocket (e.g. app not
@@ -717,4 +847,152 @@ export async function startServer(config: Required<MetroMCPConfig>, args: string
   void connectToMetro().then((connected) => {
     if (!connected) scheduleReconnect();
   });
+
+  return {
+    connectSession,
+    startStdio,
+    close: closeRuntime,
+  };
+}
+
+export async function startServer(config: Required<MetroMCPConfig>, args: string[] = []): Promise<void> {
+  const runtime = await createMetroRuntime(config, args);
+  await runtime.startStdio();
+}
+
+export async function startHttpServer(
+  config: Required<MetroMCPConfig>,
+  args: string[] = [],
+  options: HttpServerOptions = {},
+): Promise<{ host: string; port: number; url: string; close: () => Promise<void> }> {
+  const runtime = await createMetroRuntime(config, args);
+  const host = options.host ?? '127.0.0.1';
+  const requestedPort = options.port ?? 0;
+  const streamableTransports = new Map<string, StreamableHTTPServerTransport>();
+  const sseTransports = new Map<string, SSEServerTransport>();
+
+  function getSessionIdHeader(req: http.IncomingMessage): string | undefined {
+    const sessionId = req.headers['mcp-session-id'];
+    return Array.isArray(sessionId) ? sessionId[0] : sessionId;
+  }
+
+  async function createStreamableTransport(): Promise<StreamableHTTPServerTransport> {
+    let transport: StreamableHTTPServerTransport;
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (initializedSessionId) => {
+        streamableTransports.set(initializedSessionId, transport);
+      },
+    });
+    transport.onclose = () => {
+      const closedSessionId = transport.sessionId;
+      if (closedSessionId) streamableTransports.delete(closedSessionId);
+    };
+    await runtime.connectSession(transport);
+    return transport;
+  }
+
+  async function handleStreamableMcpRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const sessionKey = getSessionIdHeader(req);
+    let transport = sessionKey ? streamableTransports.get(sessionKey) : undefined;
+    let parsedBody: unknown;
+
+    if (req.method === 'POST') {
+      parsedBody = await readJsonBody(req);
+    }
+
+    if (!transport) {
+      if (req.method !== 'POST' || !parsedBody || !isInitializeRequest(parsedBody)) {
+        sendJson(res, 400, {
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Bad Request: No valid MCP session' },
+          id: null,
+        });
+        return;
+      }
+      transport = await createStreamableTransport();
+    }
+
+    await transport.handleRequest(req, res, parsedBody);
+  }
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? host}`);
+
+    try {
+      if (url.pathname === '/health') {
+        sendJson(res, 200, { ok: true, name: 'metro-mcp', version });
+        return;
+      }
+
+      if (url.pathname === '/mcp') {
+        await handleStreamableMcpRequest(req, res);
+        return;
+      }
+
+      if (url.pathname === '/sse' && req.method === 'GET') {
+        const transport = new SSEServerTransport('/messages', res);
+        sseTransports.set(transport.sessionId, transport);
+        transport.onclose = () => {
+          sseTransports.delete(transport.sessionId);
+        };
+        await runtime.connectSession(transport);
+        return;
+      }
+
+      if (url.pathname === '/messages' && req.method === 'POST') {
+        const sessionId = url.searchParams.get('sessionId');
+        const transport = sessionId ? sseTransports.get(sessionId) : undefined;
+        if (!transport) {
+          res.writeHead(404).end('No transport found for sessionId');
+          return;
+        }
+        await transport.handlePostMessage(req, res);
+        return;
+      }
+
+      res.writeHead(404).end('Not found');
+    } catch (err) {
+      logger.error('HTTP MCP request failed:', err);
+      if (!res.headersSent) {
+        sendJson(res, 500, {
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      } else {
+        res.end();
+      }
+    }
+  });
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(requestedPort, host, () => {
+      server.off('error', rejectListen);
+      resolveListen();
+    });
+  });
+
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : requestedPort;
+  const url = `http://${host}:${port}/mcp`;
+  options.onListening?.({ host, port, url });
+  logger.info(`MCP HTTP server listening on ${url}`);
+
+  return {
+    host,
+    port,
+    url,
+    close: async () => {
+      for (const transport of streamableTransports.values()) {
+        await closeQuietly(transport);
+      }
+      for (const transport of sseTransports.values()) {
+        await closeQuietly(transport);
+      }
+      runtime.close();
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- Introduce a shared local MCP daemon so stdio clients can connect concurrently to the same Metro runtime.
- Add an explicit `serve` mode with Streamable HTTP and legacy SSE endpoints for Supergateway and other HTTP-based clients.
- Refactor session handling so each inbound MCP connection gets its own server instance while sharing Metro/CDP state, buffers, and subscriptions.
- Update docs to reflect the new multi-client flow and the `metro-mcp serve` workflow.

## Testing
- TypeScript typecheck passed.
- Full build passed, including app bundling, JS/bin output, and type generation.
- Local smoke test verified `/health` and MCP initialization against the new HTTP server path.