### PR TITLE
Reduce idle CPU and heap growth in subscribed sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dev": "bun run --watch src/index.ts",
     "test": "bun run build:apps && bun test",
     "clean": "rm -rf dist",
+    "prepare": "bun run build",
     "build": "bun run build:apps && bun run clean && bun run build:js && bun run build:bin && bun run build:types",
     "build:apps": "bun run scripts/build-apps.ts",
     "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external @modelcontextprotocol/ext-apps --external zod --external ws && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external @modelcontextprotocol/ext-apps --external zod",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun run --watch src/index.ts",
+    "test": "bun run build:apps && bun test",
     "clean": "rm -rf dist",
     "build": "bun run build:apps && bun run clean && bun run build:js && bun run build:bin && bun run build:types",
     "build:apps": "bun run scripts/build-apps.ts",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/plugins/console.test.ts
+++ b/src/plugins/console.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import { formatCDPArgs, formatCDPArgsDeep, MAX_CONSOLE_MESSAGE_CHARS } from './console.js';
+import { TRUNCATED_MARKER } from '../utils/payload.js';
+
+test('formats console strings with a bounded retained size', () => {
+  const message = formatCDPArgs([
+    { type: 'string', value: 'x'.repeat(MAX_CONSOLE_MESSAGE_CHARS * 2) },
+  ]);
+
+  expect(message.length).toBeLessThanOrEqual(MAX_CONSOLE_MESSAGE_CHARS);
+  expect(message).toContain(TRUNCATED_MARKER);
+});
+
+test('deep console object resolution is bounded before storage', async () => {
+  const message = await formatCDPArgsDeep(
+    async () => ({
+      result: {
+        value: 'y'.repeat(MAX_CONSOLE_MESSAGE_CHARS * 2),
+      },
+    }),
+    [{ type: 'object', objectId: 'object-1' }],
+  );
+
+  expect(message.length).toBeLessThanOrEqual(MAX_CONSOLE_MESSAGE_CHARS);
+  expect(message).toContain(TRUNCATED_MARKER);
+});

--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -2,7 +2,12 @@ import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { DeviceBufferManager } from '../utils/buffer.js';
 import { formatTime } from '../utils/format.js';
+import { byteLength, stringifyBounded, truncateString } from '../utils/payload.js';
 import { buildConsoleHtml } from '../apps/console.js';
+
+export const MAX_CONSOLE_MESSAGE_CHARS = 16 * 1024;
+export const MAX_CONSOLE_STACK_CHARS = 32 * 1024;
+const MAX_CONSOLE_BUFFER_BYTES = 2 * 1024 * 1024;
 
 interface LogEntry {
   timestamp: number;
@@ -57,22 +62,22 @@ function formatPreview(preview: CDPObjectPreview): string | null {
  * Used as the immediate fallback before async deep resolution completes.
  */
 function formatRemoteObject(obj: CDPRemoteObject): string {
-  if (obj.type === 'string') return obj.value as string;
+  if (obj.type === 'string') return truncateString(obj.value as string, MAX_CONSOLE_MESSAGE_CHARS);
   if (obj.type === 'number') return String(obj.value);
   if (obj.type === 'boolean') return String(obj.value);
   if (obj.type === 'undefined') return 'undefined';
   if (obj.subtype === 'null') return 'null';
   if (obj.preview) {
     const formatted = formatPreview(obj.preview);
-    if (formatted) return formatted;
+    if (formatted) return truncateString(formatted, MAX_CONSOLE_MESSAGE_CHARS);
   }
-  if (obj.description) return obj.description;
-  if (obj.value !== undefined) return JSON.stringify(obj.value);
+  if (obj.description) return truncateString(obj.description, MAX_CONSOLE_MESSAGE_CHARS);
+  if (obj.value !== undefined) return stringifyBounded(obj.value, MAX_CONSOLE_MESSAGE_CHARS);
   return (obj.className as string) || (obj.type as string) || '[object]';
 }
 
-function formatCDPArgs(args: unknown[]): string {
-  return args
+export function formatCDPArgs(args: unknown[]): string {
+  const message = args
     .map((arg) => {
       if (typeof arg === 'object' && arg !== null) {
         return formatRemoteObject(arg as CDPRemoteObject);
@@ -80,6 +85,7 @@ function formatCDPArgs(args: unknown[]): string {
       return String(arg);
     })
     .join(' ');
+  return truncateString(message, MAX_CONSOLE_MESSAGE_CHARS);
 }
 
 async function resolveRemoteObject(
@@ -89,18 +95,31 @@ async function resolveRemoteObject(
   try {
     const result = (await cdpSend('Runtime.callFunctionOn', {
       objectId,
-      functionDeclaration:
-        'function() { try { return JSON.stringify(this); } catch(e) { return "[unserializable]"; } }',
+      functionDeclaration: buildStringifyRemoteObjectFunction(MAX_CONSOLE_MESSAGE_CHARS),
       returnByValue: true,
     })) as Record<string, unknown>;
     const inner = result.result as Record<string, unknown> | undefined;
-    return inner?.value ? (inner.value as string) : null;
+    return inner?.value ? truncateString(inner.value as string, MAX_CONSOLE_MESSAGE_CHARS) : null;
   } catch {
     return null;
   }
 }
 
-async function formatCDPArgsDeep(
+function buildStringifyRemoteObjectFunction(maxChars: number): string {
+  return `function() {
+    try {
+      var value = JSON.stringify(this);
+      if (typeof value === 'string' && value.length > ${maxChars}) {
+        return value.slice(0, ${maxChars}) + "\\n[truncated " + (value.length - ${maxChars}) + " chars]";
+      }
+      return value;
+    } catch(e) {
+      return "[unserializable]";
+    }
+  }`;
+}
+
+export async function formatCDPArgsDeep(
   cdpSend: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
   args: unknown[],
 ): Promise<string> {
@@ -115,7 +134,16 @@ async function formatCDPArgsDeep(
       return formatRemoteObject(remoteObj);
     }),
   );
-  return parts.join(' ');
+  return truncateString(parts.join(' '), MAX_CONSOLE_MESSAGE_CHARS);
+}
+
+function formatStackTrace(stackTrace: unknown): string | undefined {
+  if (!stackTrace) return undefined;
+  return stringifyBounded((stackTrace as Record<string, unknown>).callFrames, MAX_CONSOLE_STACK_CHARS);
+}
+
+function logEntrySize(entry: LogEntry): number {
+  return byteLength(entry.message) + byteLength(entry.stackTrace) + 64;
 }
 
 export const consolePlugin = definePlugin({
@@ -124,8 +152,21 @@ export const consolePlugin = definePlugin({
   description: 'Console log collection and filtering',
 
   async setup(ctx) {
-    const buffers = new DeviceBufferManager<LogEntry>(500);
+    const buffers = new DeviceBufferManager<LogEntry>(500, {
+      maxBytesPerDevice: MAX_CONSOLE_BUFFER_BYTES,
+      sizeOf: logEntrySize,
+    });
     const cdpSend = ctx.cdp.send.bind(ctx.cdp);
+
+    function pushInfoMessage(message: string): void {
+      const key = ctx.getActiveDeviceKey();
+      if (!key) return;
+      buffers.getOrCreate(key).push({
+        timestamp: Date.now(),
+        level: 'info',
+        message,
+      });
+    }
 
     ctx.cdp.on('Runtime.consoleAPICalled', (params) => {
       const key = ctx.getActiveDeviceKey();
@@ -136,9 +177,7 @@ export const consolePlugin = definePlugin({
         timestamp: Date.now(),
         level: params.type as string,
         message: formatCDPArgs(args),
-        stackTrace: params.stackTrace
-          ? JSON.stringify((params.stackTrace as Record<string, unknown>).callFrames)
-          : undefined,
+        stackTrace: formatStackTrace(params.stackTrace),
       };
       buffers.getOrCreate(key).push(entry);
       ctx.notifyResourceUpdated('metro://logs');
@@ -150,7 +189,10 @@ export const consolePlugin = definePlugin({
       if (hasResolvable) {
         formatCDPArgsDeep(cdpSend, args)
           .then((deep) => {
-            if (deep !== entry.message) entry.message = deep;
+            if (deep !== entry.message) {
+              entry.message = deep;
+              buffers.recalculateByteSize(key);
+            }
           })
           .catch(() => {});
       }
@@ -159,26 +201,14 @@ export const consolePlugin = definePlugin({
     // Mark when Metro starts rebuilding — a reload is imminent.
     ctx.events.on('bundle_transform_progressed', (event) => {
       if (event.transformedFileCount === 1) {
-        const key = ctx.getActiveDeviceKey();
-        if (!key) return;
-        buffers.getOrCreate(key).push({
-          timestamp: Date.now(),
-          level: 'info',
-          message: '── Metro rebuilding ── (file change detected)',
-        });
+        pushInfoMessage('── Metro rebuilding ── (file change detected)');
       }
     });
 
     // Insert a visible boundary marker when the CDP connection is re-established,
     // so it's clear where a gap in logs may have occurred.
     ctx.cdp.on('reconnected', () => {
-      const key = ctx.getActiveDeviceKey();
-      if (!key) return;
-      buffers.getOrCreate(key).push({
-        timestamp: Date.now(),
-        level: 'info',
-        message: '── CDP reconnected ── (logs during the disconnection gap may be missing)',
-      });
+      pushInfoMessage('── CDP reconnected ── (logs during the disconnection gap may be missing)');
     });
 
     ctx.registerAppResource('ui://metro/console', {
@@ -227,10 +257,10 @@ export const consolePlugin = definePlugin({
       }),
       handler: async ({ device }) => {
         if (device === 'all') {
-          buffers.clear();
+          buffers.clearResolved(device, ctx.getActiveDeviceKey());
           return 'Console logs cleared for all devices.';
         }
-        buffers.clear(device || ctx.getActiveDeviceKey() || undefined);
+        buffers.clearResolved(device, ctx.getActiveDeviceKey());
         return 'Console logs cleared.';
       },
     });

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -3,7 +3,12 @@ import { definePlugin } from '../plugin.js';
 import { CircularBuffer, DeviceBufferManager } from '../utils/buffer.js';
 import { formatTime } from '../utils/format.js';
 import { extractCDPExceptionMessage } from '../utils/cdp.js';
+import { byteLength, stringifyBounded, truncateString } from '../utils/payload.js';
 import { buildErrorsHtml } from '../apps/errors.js';
+
+const MAX_ERROR_MESSAGE_CHARS = 16 * 1024;
+const MAX_ERROR_STACK_CHARS = 64 * 1024;
+const MAX_ERRORS_BUFFER_BYTES = 1024 * 1024;
 
 interface ErrorEntry {
   timestamp: number;
@@ -29,6 +34,10 @@ const BUNDLE_ERROR_PATTERNS = [
   /Unexpected token/,
 ];
 
+function errorEntrySize(entry: ErrorEntry): number {
+  return byteLength(entry.message) + byteLength(entry.stack) + byteLength(entry.symbolicatedStack) + 64;
+}
+
 function parseErrorLocation(message: string): { file?: string; lineNumber?: number; column?: number } {
   const fileMatch = message.match(/(?:in |from )([^\s:]+(?:\.tsx?|\.jsx?|\.json))/);
   const lineMatch = message.match(/(?:line |:)(\d+)/);
@@ -46,7 +55,10 @@ export const errorsPlugin = definePlugin({
   description: 'Exception collection with auto-symbolication',
 
   async setup(ctx) {
-    const buffers = new DeviceBufferManager<ErrorEntry>(100);
+    const buffers = new DeviceBufferManager<ErrorEntry>(100, {
+      maxBytesPerDevice: MAX_ERRORS_BUFFER_BYTES,
+      sizeOf: errorEntrySize,
+    });
     // Bundle errors are per-Metro-server, not per-device, so a single buffer is fine.
     const bundleErrors = new CircularBuffer<BundleError>(100);
 
@@ -55,7 +67,10 @@ export const errorsPlugin = definePlugin({
     ctx.cdp.on('Runtime.consoleAPICalled', (params) => {
       if (params.type === 'error') {
         const args = (params.args as Array<Record<string, unknown>>) || [];
-        const message = args.map((a) => a.value || a.description || '').join(' ');
+        const message = truncateString(
+          args.map((a) => a.value || a.description || '').join(' '),
+          MAX_ERROR_MESSAGE_CHARS,
+        );
         for (const pattern of BUNDLE_ERROR_PATTERNS) {
           if (pattern.test(message)) {
             bundleErrors.push({
@@ -71,7 +86,7 @@ export const errorsPlugin = definePlugin({
     });
 
     ctx.events.on('bundling_error', (event) => {
-      const message = (event.message as string) || 'Unknown bundling error';
+      const message = truncateString((event.message as string) || 'Unknown bundling error', MAX_ERROR_MESSAGE_CHARS);
       bundleErrors.push({
         timestamp: Date.now(),
         type: 'BundlingError',
@@ -81,15 +96,18 @@ export const errorsPlugin = definePlugin({
     });
 
     ctx.cdp.on('Runtime.exceptionThrown', async (params) => {
-      const message = extractCDPExceptionMessage(
-        params.exceptionDetails as Record<string, unknown>,
-        'Unknown error'
+      const message = truncateString(
+        extractCDPExceptionMessage(
+          params.exceptionDetails as Record<string, unknown>,
+          'Unknown error'
+        ),
+        MAX_ERROR_MESSAGE_CHARS,
       );
 
       const exceptionDetails = params.exceptionDetails as Record<string, unknown>;
       const stackTrace = exceptionDetails?.stackTrace as Record<string, unknown>;
       const stack = stackTrace?.callFrames
-        ? JSON.stringify(stackTrace.callFrames)
+        ? stringifyBounded(stackTrace.callFrames, MAX_ERROR_STACK_CHARS)
         : undefined;
 
       const entry: ErrorEntry = {
@@ -115,7 +133,7 @@ export const errorsPlugin = definePlugin({
             );
             if (symResponse.ok) {
               const result = (await symResponse.json()) as Record<string, unknown>;
-              entry.symbolicatedStack = JSON.stringify(result.stack);
+              entry.symbolicatedStack = stringifyBounded(result.stack, MAX_ERROR_STACK_CHARS);
             }
           }
         } catch {
@@ -180,10 +198,10 @@ export const errorsPlugin = definePlugin({
       }),
       handler: async ({ device }) => {
         if (device === 'all') {
-          buffers.clear();
+          buffers.clearResolved(device, ctx.getActiveDeviceKey());
           return 'Error buffer cleared for all devices.';
         }
-        buffers.clear(device || ctx.getActiveDeviceKey() || undefined);
+        buffers.clearResolved(device, ctx.getActiveDeviceKey());
         return 'Error buffer cleared.';
       },
     });

--- a/src/plugins/network.test.ts
+++ b/src/plugins/network.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from 'bun:test';
+import { networkPlugin } from './network.js';
+import type { ComponentNode, PluginContext } from '../plugin.js';
+
+type Handler = (params: Record<string, unknown>) => void;
+
+test('network plugin fetches response bodies only on explicit request', async () => {
+  const handlers = new Map<string, Handler[]>();
+  const tools = new Map<string, { handler: (args: Record<string, unknown>) => Promise<unknown> }>();
+  const cdpSends: Array<{ method: string; params?: Record<string, unknown> }> = [];
+
+  const emit = (event: string, params: Record<string, unknown>) => {
+    for (const handler of handlers.get(event) ?? []) {
+      handler(params);
+    }
+  };
+
+  const registerTool: PluginContext['registerTool'] = (name, config) => {
+    tools.set(name, {
+      handler: config.handler as (args: Record<string, unknown>) => Promise<unknown>,
+    });
+  };
+
+  const ctx: PluginContext = {
+    cdp: {
+      on: (event: string, handler: Handler) => {
+        const existing = handlers.get(event) ?? [];
+        existing.push(handler);
+        handlers.set(event, existing);
+      },
+      off: () => {},
+      get isConnected() {
+        return true;
+      },
+      getTarget: () => null,
+      send: async (method: string, params?: Record<string, unknown>) => {
+        cdpSends.push({ method, params });
+        return { body: '{"ok":true}', base64Encoded: false };
+      },
+    },
+    events: {
+      on: () => {},
+      off: () => {},
+      isConnected: () => true,
+    },
+    registerTool,
+    registerResource: () => {},
+    registerAppResource: () => {},
+    registerPrompt: () => {},
+    config: {},
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
+    metro: {
+      host: 'localhost',
+      port: 8081,
+      fetch: async () => new Response(),
+    },
+    exec: async () => '',
+    format: {
+      summarize: () => '',
+      compact: (value: unknown) => JSON.stringify(value),
+      truncate: (value: string) => value,
+      structureOnly: (value: ComponentNode) => value,
+    },
+    evalInApp: async () => null,
+    getActiveDeviceKey: () => '8081-device',
+    getActiveDeviceName: () => 'device',
+    notifyResourceUpdated: () => {},
+  };
+
+  await networkPlugin.setup(ctx);
+
+  emit('Network.requestWillBeSent', {
+    requestId: 'request-1',
+    request: { url: 'https://example.test/api', method: 'GET', headers: {} },
+    type: 'Fetch',
+  });
+  emit('Network.responseReceived', {
+    requestId: 'request-1',
+    response: { status: 200, statusText: 'OK', headers: {} },
+  });
+  emit('Network.loadingFinished', {
+    requestId: 'request-1',
+    encodedDataLength: 12,
+  });
+
+  expect(cdpSends).toEqual([]);
+
+  const getResponseBody = tools.get('get_response_body');
+  expect(getResponseBody).toBeDefined();
+  const result = await getResponseBody!.handler({ url: 'example.test', index: -1 });
+
+  expect(cdpSends).toEqual([
+    { method: 'Network.getResponseBody', params: { requestId: 'request-1' } },
+  ]);
+  expect(result).toEqual({
+    url: 'https://example.test/api',
+    status: 200,
+    body: { ok: true },
+  });
+});

--- a/src/plugins/network.test.ts
+++ b/src/plugins/network.test.ts
@@ -4,7 +4,7 @@ import type { ComponentNode, PluginContext } from '../plugin.js';
 
 type Handler = (params: Record<string, unknown>) => void;
 
-test('network plugin fetches response bodies only on explicit request', async () => {
+async function createNetworkHarness(responseBody: string) {
   const handlers = new Map<string, Handler[]>();
   const tools = new Map<string, { handler: (args: Record<string, unknown>) => Promise<unknown> }>();
   const cdpSends: Array<{ method: string; params?: Record<string, unknown> }> = [];
@@ -35,7 +35,7 @@ test('network plugin fetches response bodies only on explicit request', async ()
       getTarget: () => null,
       send: async (method: string, params?: Record<string, unknown>) => {
         cdpSends.push({ method, params });
-        return { body: '{"ok":true}', base64Encoded: false };
+        return { body: responseBody, base64Encoded: false };
       },
     },
     events: {
@@ -74,6 +74,10 @@ test('network plugin fetches response bodies only on explicit request', async ()
 
   await networkPlugin.setup(ctx);
 
+  return { cdpSends, emit, tools };
+}
+
+function recordFinishedRequest(emit: (event: string, params: Record<string, unknown>) => void): void {
   emit('Network.requestWillBeSent', {
     requestId: 'request-1',
     request: { url: 'https://example.test/api', method: 'GET', headers: {} },
@@ -87,6 +91,12 @@ test('network plugin fetches response bodies only on explicit request', async ()
     requestId: 'request-1',
     encodedDataLength: 12,
   });
+}
+
+test('network plugin fetches response bodies only on explicit request', async () => {
+  const { cdpSends, emit, tools } = await createNetworkHarness('{"ok":true}');
+
+  recordFinishedRequest(emit);
 
   expect(cdpSends).toEqual([]);
 
@@ -102,4 +112,28 @@ test('network plugin fetches response bodies only on explicit request', async ()
     status: 200,
     body: { ok: true },
   });
+});
+
+test('network plugin does not cache response bodies over the byte limit', async () => {
+  const largeMultibyteBody = String.fromCodePoint(0x1f600).repeat(300_000);
+  expect(largeMultibyteBody.length).toBeLessThan(1024 * 1024);
+  expect(Buffer.byteLength(largeMultibyteBody, 'utf8')).toBeGreaterThan(1024 * 1024);
+
+  const { emit, tools } = await createNetworkHarness(largeMultibyteBody);
+  recordFinishedRequest(emit);
+
+  const getResponseBody = tools.get('get_response_body');
+  expect(getResponseBody).toBeDefined();
+
+  const result = await getResponseBody!.handler({ url: 'example.test', index: -1 });
+  expect(result).toEqual({
+    url: 'https://example.test/api',
+    status: 200,
+    body: largeMultibyteBody,
+  });
+
+  emit('reconnected', {});
+
+  const unavailable = await getResponseBody!.handler({ url: 'example.test', index: -1 });
+  expect(unavailable).toContain('Response body unavailable');
 });

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -265,7 +265,7 @@ export const networkPlugin = definePlugin({
         try {
           const result = await ctx.cdp.send('Network.getResponseBody', { requestId: req.id }) as { body: string; base64Encoded: boolean };
           const body = decodeResponseBody(result);
-          if (body.length <= MAX_BODY_CACHE_SIZE) {
+          if (byteLength(body) <= MAX_BODY_CACHE_SIZE) {
             req.responseBody = body;
             buffers.recalculateByteSize(device && device !== 'all' ? device : undefined);
           }

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { DeviceBufferManager } from '../utils/buffer.js';
 import { formatTime, formatBytes } from '../utils/format.js';
+import { byteLength, truncateRecordValues, truncateString } from '../utils/payload.js';
 import { createLogger } from '../utils/logger.js';
 import { buildNetworkDashboardHtml } from '../apps/network.js';
 
@@ -9,8 +10,9 @@ const logger = createLogger('network');
 
 /** Maximum *decoded* body size (bytes) to keep cached. */
 const MAX_BODY_CACHE_SIZE = 1024 * 1024; // 1 MB
-/** Maximum concurrent getResponseBody CDP calls to avoid flooding the pipeline. */
-const MAX_CONCURRENT_BODY_FETCHES = 4;
+const MAX_NETWORK_BUFFER_BYTES = 2 * 1024 * 1024;
+const MAX_URL_CHARS = 4096;
+const MAX_HEADER_VALUE_CHARS = 4096;
 
 function decodeResponseBody(raw: { body: string; base64Encoded: boolean }): string {
   return raw.base64Encoded ? Buffer.from(raw.body, 'base64').toString('utf8') : raw.body;
@@ -37,43 +39,60 @@ interface NetworkRequest {
   session: number;
 }
 
+function estimateRecordBytes(record: Record<string, string> | undefined, maxBytes: number): number {
+  if (!record) return 0;
+  let total = 0;
+  for (const [key, value] of Object.entries(record)) {
+    total += byteLength(key) + byteLength(value) + 4;
+    if (total >= maxBytes) return maxBytes;
+  }
+  return total;
+}
+
+function estimateNetworkRequestBytes(req: NetworkRequest): number {
+  return (
+    byteLength(req.url) +
+    byteLength(req.method) +
+    byteLength(req.type) +
+    byteLength(req.statusText) +
+    byteLength(req.error) +
+    byteLength(req.responseBody) +
+    estimateRecordBytes(req.requestHeaders, 64 * 1024) +
+    estimateRecordBytes(req.responseHeaders, 64 * 1024) +
+    128
+  );
+}
+
+function formatNetworkRequestLine(
+  r: NetworkRequest,
+  options: { includeTimestamp?: boolean; includeSize?: boolean } = {},
+): string {
+  const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
+  const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
+  const size = options.includeSize && r.size ? `, ${formatBytes(r.size)}` : '';
+  const line = `${r.method} ${r.url} → ${status} (${duration}${size})`;
+  return options.includeTimestamp ? `${formatTime(r.startTime)} ${line}` : line;
+}
+
 export const networkPlugin = definePlugin({
   name: 'network',
 
   description: 'Network request tracking via CDP Network domain',
 
   async setup(ctx) {
-    const buffers = new DeviceBufferManager<NetworkRequest>(200);
+    const buffers = new DeviceBufferManager<NetworkRequest>(200, {
+      maxBytesPerDevice: MAX_NETWORK_BUFFER_BYTES,
+      sizeOf: estimateNetworkRequestBytes,
+    });
     const pendingRequests = new Map<string, NetworkRequest>();
 
     /** Monotonically increasing session counter – bumped on every reconnect so we
      *  can tell which requests belong to the current CDP session vs a stale one. */
     let currentSession = 0;
 
-    /** Simple concurrency limiter for eager body fetches to avoid flooding CDP. */
-    let activeFetches = 0;
-
     function getDeviceBuffer(): ReturnType<DeviceBufferManager<NetworkRequest>['getOrCreate']> | null {
       const key = ctx.getActiveDeviceKey();
       return key ? buffers.getOrCreate(key) : null;
-    }
-
-    function fetchAndCacheBody(req: NetworkRequest): void {
-      if (activeFetches >= MAX_CONCURRENT_BODY_FETCHES) return;
-      activeFetches++;
-      ctx.cdp.send('Network.getResponseBody', { requestId: req.id })
-        .then((result) => {
-          const body = decodeResponseBody(result as { body: string; base64Encoded: boolean });
-          if (body.length <= MAX_BODY_CACHE_SIZE) {
-            req.responseBody = body;
-          }
-        })
-        .catch((err) => {
-          logger.debug(`Could not cache body for ${req.method} ${req.url}: ${err}`);
-        })
-        .finally(() => {
-          activeFetches--;
-        });
     }
 
     // ── CDP Network domain ─────────────────────────────────────────────────────
@@ -87,7 +106,7 @@ export const networkPlugin = definePlugin({
       if ((params.initiator as Record<string, unknown> | undefined)?.stack) return;
 
       const req = params.request as Record<string, unknown>;
-      const url = req?.url as string;
+      const url = truncateString(req?.url as string, MAX_URL_CHARS);
       const method = req?.method as string || 'GET';
       const type = params.type as string | undefined;
       const now = Date.now();
@@ -97,7 +116,7 @@ export const networkPlugin = definePlugin({
         url,
         method,
         type,
-        requestHeaders: req?.headers as Record<string, string>,
+        requestHeaders: truncateRecordValues(req?.headers, MAX_HEADER_VALUE_CHARS),
         startTime: now,
         get timestamp() { return this.startTime; },
         session: currentSession,
@@ -111,7 +130,7 @@ export const networkPlugin = definePlugin({
         const response = params.response as Record<string, unknown>;
         req.status = response.status as number;
         req.statusText = response.statusText as string;
-        req.responseHeaders = response.headers as Record<string, string>;
+        req.responseHeaders = truncateRecordValues(response.headers, MAX_HEADER_VALUE_CHARS);
       }
     });
 
@@ -123,7 +142,6 @@ export const networkPlugin = definePlugin({
         pendingRequests.delete(req.id);
         getDeviceBuffer()?.push(req);
         ctx.notifyResourceUpdated('metro://network');
-        fetchAndCacheBody(req);
       }
     });
 
@@ -159,6 +177,13 @@ export const networkPlugin = definePlugin({
       return buffers.resolve(device, ctx.getActiveDeviceKey());
     }
 
+    function resolveRequest(url: string, index: number, device?: string): NetworkRequest | string {
+      const matches = getRequests(device).filter((r) => r.url.includes(url));
+      if (matches.length === 0) return `No requests found matching "${url}"`;
+      const req = index === -1 ? matches[matches.length - 1] : matches[index];
+      return req ?? `Request index ${index} out of range (${matches.length} matches)`;
+    }
+
     ctx.registerAppResource('ui://metro/network', {
       name: 'Network Dashboard',
       description: 'Interactive network request dashboard with filtering, detail view, and live updates',
@@ -192,12 +217,7 @@ export const networkPlugin = definePlugin({
         const slice = requests.slice(-limit);
         if (format === 'json') return slice;
         return slice
-          .map((r) => {
-            const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
-            const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
-            const size = r.size ? `, ${formatBytes(r.size)}` : '';
-            return `${formatTime(r.startTime)} ${r.method} ${r.url} → ${status} (${duration}${size})`;
-          })
+          .map((r) => formatNetworkRequestLine(r, { includeTimestamp: true, includeSize: true }))
           .join('\n');
       },
     });
@@ -211,11 +231,7 @@ export const networkPlugin = definePlugin({
         device: z.string().optional().describe('Device key or "all". Defaults to current device.'),
       }),
       handler: async ({ url, index, device }) => {
-        const matches = getRequests(device).filter((r) => r.url.includes(url));
-        if (matches.length === 0) return `No requests found matching "${url}"`;
-        const req = index === -1 ? matches[matches.length - 1] : matches[index];
-        if (!req) return `Request index ${index} out of range (${matches.length} matches)`;
-        return req;
+        return resolveRequest(url, index, device);
       },
     });
 
@@ -228,10 +244,8 @@ export const networkPlugin = definePlugin({
         device: z.string().optional().describe('Device key or "all". Defaults to current device.'),
       }),
       handler: async ({ url, index, device }) => {
-        const matches = getRequests(device).filter((r) => r.url.includes(url));
-        if (matches.length === 0) return `No requests found matching "${url}"`;
-        const req = index === -1 ? matches[matches.length - 1] : matches[index];
-        if (!req) return `Request index ${index} out of range (${matches.length} matches)`;
+        const req = resolveRequest(url, index, device);
+        if (typeof req === 'string') return req;
 
         // Use cached body if available (survives reconnections)
         if (req.responseBody !== undefined) {
@@ -251,7 +265,10 @@ export const networkPlugin = definePlugin({
         try {
           const result = await ctx.cdp.send('Network.getResponseBody', { requestId: req.id }) as { body: string; base64Encoded: boolean };
           const body = decodeResponseBody(result);
-          req.responseBody = body;
+          if (body.length <= MAX_BODY_CACHE_SIZE) {
+            req.responseBody = body;
+            buffers.recalculateByteSize(device && device !== 'all' ? device : undefined);
+          }
           try {
             return { url: req.url, status: req.status, body: JSON.parse(body) };
           } catch {
@@ -285,11 +302,7 @@ export const networkPlugin = definePlugin({
         if (errorsOnly) results = results.filter((r) => r.error || (r.status && r.status >= 400));
         return results
           .slice(-limit)
-          .map((r) => {
-            const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
-            const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
-            return `${r.method} ${r.url} → ${status} (${duration})`;
-          })
+          .map((r) => formatNetworkRequestLine(r))
           .join('\n');
       },
     });
@@ -302,11 +315,7 @@ export const networkPlugin = definePlugin({
       }),
       handler: async ({ device }) => {
         const count = buffers.size;
-        if (device === 'all') {
-          buffers.clear();
-        } else {
-          buffers.clear(device || ctx.getActiveDeviceKey() || undefined);
-        }
+        buffers.clearResolved(device, ctx.getActiveDeviceKey());
         pendingRequests.clear();
         return `Cleared ${count} network requests.`;
       },
@@ -447,11 +456,7 @@ export const networkPlugin = definePlugin({
         const requests = getRequests().slice(-20);
         if (requests.length === 0) return '(no requests)';
         return requests
-          .map((r) => {
-            const duration = r.endTime ? `${r.endTime - r.startTime}ms` : 'pending';
-            const status = r.error ? `ERR: ${r.error}` : `${r.status || '???'}`;
-            return `${formatTime(r.startTime)} ${r.method} ${r.url} → ${status} (${duration})`;
-          })
+          .map((r) => formatNetworkRequestLine(r, { includeTimestamp: true }))
           .join('\n');
       },
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -847,6 +847,7 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     const previousClose = transport.onclose;
     transport.onclose = () => {
       previousClose?.();
+      resourceSubscriptions.unsubscribeAll(session);
       resourceUpdates.removeTarget(session.id);
       clearSessionRegistrations(session);
       sessions.delete(session);
@@ -877,6 +878,7 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     process.off('SIGTERM', handleSigterm);
     process.off('exit', handleExit);
     for (const session of sessions) {
+      resourceSubscriptions.unsubscribeAll(session);
       resourceUpdates.removeTarget(session.id);
       clearSessionRegistrations(session);
       session.server.close().catch(() => {});

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,8 @@ import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
 import { extractCDPExceptionMessage } from './utils/cdp.js';
 import { createPreferredFrameSizeMeta, withAppSizing } from './utils/apps.js';
+import { ResourceSubscriptionManager } from './utils/resource-subscriptions.js';
+import { createResourceUpdateScheduler } from './utils/resource-updates.js';
 import { version } from './version.js';
 
 // Built-in plugins
@@ -67,6 +69,7 @@ import { environmentPlugin } from './plugins/environment.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('server');
+const RESOURCE_UPDATE_COALESCE_MS = 250;
 
 const BUILT_IN_PLUGINS: PluginDefinition[] = [
   consolePlugin,
@@ -149,17 +152,23 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   const formatUtils = createFormatUtils();
   const sessions = new Set<McpSession>();
   const runtimeRegistrations: RuntimeRegistration[] = [];
+  const resourceSubscriptions = new ResourceSubscriptionManager();
   let projectRoot: string | null = null;
   let reloadInProgress = false;
   let isInitializingPlugins = false;
   let runtimeClosed = false;
 
+  const resourceUpdates = createResourceUpdateScheduler({
+    delayMs: RESOURCE_UPDATE_COALESCE_MS,
+    getTargets: () => [...sessions].map((session) => ({
+      id: session.id,
+      isSubscribed: (uri) => session.subscribedResources.has(uri),
+      sendResourceUpdated: (uri) => session.server.server.sendResourceUpdated({ uri }),
+    })),
+  });
+
   function notifyResourceUpdated(uri: string): void {
-    for (const session of sessions) {
-      if (session.subscribedResources.has(uri)) {
-        session.server.server.sendResourceUpdated({ uri }).catch(() => {});
-      }
-    }
+    resourceUpdates.notify(uri);
   }
 
   // Active device tracking — used by plugins to key per-device buffers.
@@ -356,14 +365,19 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
       },
       registerResource: (uri: string, resourceConfig: ResourceConfig) => {
         try {
+          const mimeType = resourceConfig.mimeType || 'application/json';
+          resourceSubscriptions.register(uri, {
+            onSubscribe: resourceConfig.onSubscribe,
+            onUnsubscribe: resourceConfig.onUnsubscribe,
+          });
           addRuntimeRegistration(
             (session) => session.server.resource(
               resourceConfig.name,
               uri,
-              { description: resourceConfig.description, mimeType: resourceConfig.mimeType || 'application/json' },
+              { description: resourceConfig.description, mimeType },
               async () => {
                 const content = await resourceConfig.handler();
-                return { contents: [{ uri, text: content, mimeType: resourceConfig.mimeType || 'application/json' }] };
+                return { contents: [{ uri, text: content, mimeType }] };
               }
             ),
             pluginLogger,
@@ -503,6 +517,7 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   // can be called again when the active project root changes.
   async function initPlugins(cfg: Required<MetroMCPConfig>, rootPath?: string): Promise<void> {
     runtimeRegistrations.length = 0;
+    resourceSubscriptions.clearHooks();
     for (const session of sessions) {
       clearSessionRegistrations(session);
     }
@@ -781,13 +796,13 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     };
 
     session.server.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
-      session.subscribedResources.add(req.params.uri);
+      resourceSubscriptions.subscribe(session, req.params.uri);
       logger.debug(`Client subscribed to resource: ${req.params.uri}`);
       return {};
     });
 
     session.server.server.setRequestHandler(UnsubscribeRequestSchema, async (req) => {
-      session.subscribedResources.delete(req.params.uri);
+      resourceSubscriptions.unsubscribe(session, req.params.uri);
       logger.debug(`Client unsubscribed from resource: ${req.params.uri}`);
       return {};
     });
@@ -798,6 +813,7 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     const previousClose = transport.onclose;
     transport.onclose = () => {
       previousClose?.();
+      resourceUpdates.removeTarget(session.id);
       clearSessionRegistrations(session);
       sessions.delete(session);
       logger.debug(`MCP session closed: ${session.id}`);
@@ -822,10 +838,12 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     process.off('SIGTERM', handleSigterm);
     process.off('exit', handleExit);
     for (const session of sessions) {
+      resourceUpdates.removeTarget(session.id);
       clearSessionRegistrations(session);
       session.server.close().catch(() => {});
     }
     sessions.clear();
+    resourceUpdates.close();
     eventsClient.disconnect();
     cleanProxyLock();
     cdpMultiplexer?.stop();

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'bun:test';
+import { CircularBuffer } from './buffer.js';
+
+test('circular buffer evicts old entries when byte budget is exceeded', () => {
+  const buffer = new CircularBuffer<{ timestamp: number; text: string }>(10, {
+    maxBytes: 10,
+    sizeOf: (item) => item.text.length,
+  });
+
+  buffer.push({ timestamp: 1, text: '12345' });
+  buffer.push({ timestamp: 2, text: '67890' });
+  buffer.push({ timestamp: 3, text: 'abcde' });
+
+  expect(buffer.getAll()).toEqual([
+    { timestamp: 2, text: '67890' },
+    { timestamp: 3, text: 'abcde' },
+  ]);
+  expect(buffer.byteSize).toBe(10);
+});

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,24 +1,72 @@
+export interface CircularBufferOptions<T> {
+  maxBytes?: number;
+  sizeOf?: (item: T) => number;
+}
+
+export interface DeviceBufferManagerOptions<T> {
+  maxBytesPerDevice?: number;
+  sizeOf?: (item: T) => number;
+}
+
 /**
  * Fixed-size circular buffer for storing log entries, network requests, etc.
- * When full, oldest entries are overwritten.
+ * When full, oldest entries are overwritten. When a byte budget is provided,
+ * old entries are also evicted until the budget is met, keeping at least one item.
  */
 export class CircularBuffer<T> {
   private items: T[];
+  private itemSizes: number[];
   private head = 0;
   private count = 0;
+  private totalBytes = 0;
 
-  constructor(private readonly capacity: number) {
+  constructor(
+    private readonly capacity: number,
+    private readonly options: CircularBufferOptions<T> = {},
+  ) {
     this.items = new Array(capacity);
+    this.itemSizes = new Array(capacity).fill(0);
   }
 
   push(item: T): void {
     const index = (this.head + this.count) % this.capacity;
+    const itemSize = this.options.sizeOf?.(item) ?? 0;
     if (this.count < this.capacity) {
       this.count++;
     } else {
+      this.totalBytes -= this.itemSizes[this.head] ?? 0;
       this.head = (this.head + 1) % this.capacity;
     }
     this.items[index] = item;
+    this.itemSizes[index] = itemSize;
+    this.totalBytes += itemSize;
+
+    this.evictOverBudget();
+  }
+
+  recalculateByteSize(): void {
+    this.totalBytes = 0;
+    for (let i = 0; i < this.count; i++) {
+      const index = (this.head + i) % this.capacity;
+      const size = this.options.sizeOf?.(this.items[index]!) ?? 0;
+      this.itemSizes[index] = size;
+      this.totalBytes += size;
+    }
+    this.evictOverBudget();
+  }
+
+  private evictOverBudget(): void {
+    while (
+      this.options.maxBytes !== undefined &&
+      this.count > 1 &&
+      this.totalBytes > this.options.maxBytes
+    ) {
+      this.totalBytes -= this.itemSizes[this.head] ?? 0;
+      this.itemSizes[this.head] = 0;
+      this.items[this.head] = undefined as T;
+      this.head = (this.head + 1) % this.capacity;
+      this.count--;
+    }
   }
 
   getAll(): T[] {
@@ -42,6 +90,8 @@ export class CircularBuffer<T> {
     this.head = 0;
     this.count = 0;
     this.items = new Array(this.capacity);
+    this.itemSizes = new Array(this.capacity).fill(0);
+    this.totalBytes = 0;
   }
 
   get size(): number {
@@ -50,6 +100,10 @@ export class CircularBuffer<T> {
 
   get maxSize(): number {
     return this.capacity;
+  }
+
+  get byteSize(): number {
+    return this.totalBytes;
   }
 }
 
@@ -63,7 +117,10 @@ export class DeviceBufferManager<T extends { timestamp: number }> {
   private insertionOrder: string[] = [];
   private readonly maxDevices = 10;
 
-  constructor(private readonly capacityPerDevice: number) {}
+  constructor(
+    private readonly capacityPerDevice: number,
+    private readonly options: DeviceBufferManagerOptions<T> = {},
+  ) {}
 
   /** Get or lazily create a buffer for the given device key. */
   getOrCreate(deviceKey: string): CircularBuffer<T> {
@@ -77,7 +134,10 @@ export class DeviceBufferManager<T extends { timestamp: number }> {
           break;
         }
       }
-      buffer = new CircularBuffer<T>(this.capacityPerDevice);
+      buffer = new CircularBuffer<T>(this.capacityPerDevice, {
+        maxBytes: this.options.maxBytesPerDevice,
+        sizeOf: this.options.sizeOf,
+      });
       this.buffers.set(deviceKey, buffer);
       this.insertionOrder.push(deviceKey);
     }
@@ -119,6 +179,26 @@ export class DeviceBufferManager<T extends { timestamp: number }> {
     } else {
       for (const buffer of this.buffers.values()) {
         buffer.clear();
+      }
+    }
+  }
+
+  /** Clear the same device selection syntax used by resolve(). */
+  clearResolved(device: string | undefined, activeKey: string | null): void {
+    if (device === 'all') {
+      this.clear();
+    } else {
+      this.clear(device || activeKey || undefined);
+    }
+  }
+
+  /** Recalculate byte accounting after a retained entry is mutated in place. */
+  recalculateByteSize(deviceKey?: string): void {
+    if (deviceKey) {
+      this.buffers.get(deviceKey)?.recalculateByteSize();
+    } else {
+      for (const buffer of this.buffers.values()) {
+        buffer.recalculateByteSize();
       }
     }
   }

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -1,0 +1,33 @@
+export const TRUNCATED_MARKER = '[truncated';
+
+export function byteLength(value: string | undefined): number {
+  return value ? Buffer.byteLength(value, 'utf8') : 0;
+}
+
+export function truncateString(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  const omitted = value.length - maxChars;
+  const suffix = `\n[truncated ${omitted} chars]`;
+  if (suffix.length >= maxChars) return value.slice(0, maxChars);
+  return value.slice(0, maxChars - suffix.length) + suffix;
+}
+
+export function stringifyBounded(value: unknown, maxChars: number): string {
+  try {
+    return truncateString(JSON.stringify(value), maxChars);
+  } catch {
+    return '[unserializable]';
+  }
+}
+
+export function truncateRecordValues(
+  record: unknown,
+  maxValueChars: number,
+): Record<string, string> | undefined {
+  if (!record || typeof record !== 'object') return undefined;
+  const bounded: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    bounded[key] = truncateString(String(value), maxValueChars);
+  }
+  return bounded;
+}

--- a/src/utils/resource-subscriptions.test.ts
+++ b/src/utils/resource-subscriptions.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { ResourceSubscriptionManager } from './resource-subscriptions.js';
+
+test('subscription hooks fire once per session subscription state change', () => {
+  const manager = new ResourceSubscriptionManager();
+  const session = { subscribedResources: new Set<string>() };
+  const subscribed: string[] = [];
+  const unsubscribed: string[] = [];
+
+  manager.register('metro://logs', {
+    onSubscribe: (uri) => subscribed.push(uri),
+    onUnsubscribe: (uri) => unsubscribed.push(uri),
+  });
+
+  manager.subscribe(session, 'metro://logs');
+  manager.subscribe(session, 'metro://logs');
+  manager.unsubscribe(session, 'metro://logs');
+  manager.unsubscribe(session, 'metro://logs');
+
+  expect(subscribed).toEqual(['metro://logs']);
+  expect(unsubscribed).toEqual(['metro://logs']);
+});

--- a/src/utils/resource-subscriptions.test.ts
+++ b/src/utils/resource-subscriptions.test.ts
@@ -20,3 +20,25 @@ test('subscription hooks fire once per session subscription state change', () =>
   expect(subscribed).toEqual(['metro://logs']);
   expect(unsubscribed).toEqual(['metro://logs']);
 });
+
+test('unsubscribeAll clears subscribed resources and fires hooks once per uri', () => {
+  const manager = new ResourceSubscriptionManager();
+  const session = { subscribedResources: new Set<string>() };
+  const unsubscribed: string[] = [];
+
+  manager.register('metro://logs', {
+    onUnsubscribe: (uri) => unsubscribed.push(uri),
+  });
+  manager.register('metro://network', {
+    onUnsubscribe: (uri) => unsubscribed.push(uri),
+  });
+
+  manager.subscribe(session, 'metro://logs');
+  manager.subscribe(session, 'metro://network');
+
+  manager.unsubscribeAll(session);
+  manager.unsubscribeAll(session);
+
+  expect(session.subscribedResources.size).toBe(0);
+  expect(unsubscribed).toEqual(['metro://logs', 'metro://network']);
+});

--- a/src/utils/resource-subscriptions.ts
+++ b/src/utils/resource-subscriptions.ts
@@ -31,4 +31,10 @@ export class ResourceSubscriptionManager {
       this.hooks.get(uri)?.onUnsubscribe?.(uri);
     }
   }
+
+  unsubscribeAll(session: ResourceSubscriptionSession): void {
+    for (const uri of [...session.subscribedResources]) {
+      this.unsubscribe(session, uri);
+    }
+  }
 }

--- a/src/utils/resource-subscriptions.ts
+++ b/src/utils/resource-subscriptions.ts
@@ -1,0 +1,34 @@
+import type { ResourceConfig } from '../plugin.js';
+
+export interface ResourceSubscriptionSession {
+  subscribedResources: Set<string>;
+}
+
+type ResourceHooks = Pick<ResourceConfig, 'onSubscribe' | 'onUnsubscribe'>;
+
+export class ResourceSubscriptionManager {
+  private hooks = new Map<string, ResourceHooks>();
+
+  register(uri: string, hooks: ResourceHooks): void {
+    this.hooks.set(uri, hooks);
+  }
+
+  clearHooks(): void {
+    this.hooks.clear();
+  }
+
+  subscribe(session: ResourceSubscriptionSession, uri: string): void {
+    const wasSubscribed = session.subscribedResources.has(uri);
+    session.subscribedResources.add(uri);
+    if (!wasSubscribed) {
+      this.hooks.get(uri)?.onSubscribe?.(uri);
+    }
+  }
+
+  unsubscribe(session: ResourceSubscriptionSession, uri: string): void {
+    const wasSubscribed = session.subscribedResources.delete(uri);
+    if (wasSubscribed) {
+      this.hooks.get(uri)?.onUnsubscribe?.(uri);
+    }
+  }
+}

--- a/src/utils/resource-updates.test.ts
+++ b/src/utils/resource-updates.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'bun:test';
+import { createResourceUpdateScheduler } from './resource-updates.js';
+
+test('coalesces resource updates per uri and subscribed target', () => {
+  const sent: string[] = [];
+  const subscribed = new Set(['metro://logs']);
+  const scheduler = createResourceUpdateScheduler({
+    delayMs: 10_000,
+    getTargets: () => [
+      {
+        id: 'session-1',
+        isSubscribed: (uri) => subscribed.has(uri),
+        sendResourceUpdated: async (uri) => {
+          sent.push(uri);
+        },
+      },
+    ],
+  });
+
+  scheduler.notify('metro://logs');
+  scheduler.notify('metro://logs');
+  scheduler.notify('metro://logs');
+
+  expect(sent).toEqual([]);
+  scheduler.flush('metro://logs');
+  expect(sent).toEqual(['metro://logs']);
+  scheduler.close();
+});
+
+test('skips updates when no target is subscribed', () => {
+  const sent: string[] = [];
+  const scheduler = createResourceUpdateScheduler({
+    delayMs: 10_000,
+    getTargets: () => [
+      {
+        id: 'session-1',
+        isSubscribed: () => false,
+        sendResourceUpdated: async (uri) => {
+          sent.push(uri);
+        },
+      },
+    ],
+  });
+
+  scheduler.notify('metro://logs');
+  scheduler.flush('metro://logs');
+
+  expect(sent).toEqual([]);
+  scheduler.close();
+});

--- a/src/utils/resource-updates.ts
+++ b/src/utils/resource-updates.ts
@@ -1,0 +1,82 @@
+interface ResourceUpdateTarget {
+  id: string;
+  isSubscribed(uri: string): boolean;
+  sendResourceUpdated(uri: string): Promise<void>;
+}
+
+interface PendingUpdate {
+  targetIds: Set<string>;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface ResourceUpdateSchedulerOptions {
+  delayMs: number;
+  getTargets(): ResourceUpdateTarget[];
+}
+
+export interface ResourceUpdateScheduler {
+  notify(uri: string): void;
+  removeTarget(targetId: string): void;
+  close(): void;
+  flush(uri: string): void;
+}
+
+export function createResourceUpdateScheduler({
+  delayMs,
+  getTargets,
+}: ResourceUpdateSchedulerOptions): ResourceUpdateScheduler {
+  const pendingByUri = new Map<string, PendingUpdate>();
+
+  function flush(uri: string): void {
+    const pending = pendingByUri.get(uri);
+    if (!pending) return;
+    pendingByUri.delete(uri);
+
+    const targets = new Map(getTargets().map((target) => [target.id, target]));
+    for (const targetId of pending.targetIds) {
+      const target = targets.get(targetId);
+      if (target?.isSubscribed(uri)) {
+        target.sendResourceUpdated(uri).catch(() => {});
+      }
+    }
+  }
+
+  return {
+    notify(uri: string): void {
+      const subscribed = getTargets().filter((target) => target.isSubscribed(uri));
+      if (subscribed.length === 0) return;
+
+      let pending = pendingByUri.get(uri);
+      if (!pending) {
+        pending = {
+          targetIds: new Set<string>(),
+          timer: setTimeout(() => flush(uri), delayMs),
+        };
+        pendingByUri.set(uri, pending);
+      }
+
+      for (const target of subscribed) {
+        pending.targetIds.add(target.id);
+      }
+    },
+
+    removeTarget(targetId: string): void {
+      for (const [uri, pending] of pendingByUri) {
+        pending.targetIds.delete(targetId);
+        if (pending.targetIds.size === 0) {
+          clearTimeout(pending.timer);
+          pendingByUri.delete(uri);
+        }
+      }
+    },
+
+    close(): void {
+      for (const pending of pendingByUri.values()) {
+        clearTimeout(pending.timer);
+      }
+      pendingByUri.clear();
+    },
+
+    flush,
+  };
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Coalesce resource update notifications so subscribed clients do not receive a flood of per-event JSON-RPC updates.
- Cap retained payload sizes in console, error, and network buffers with byte-aware eviction and safer string truncation.
- Make resource subscription hooks functional and add focused unit coverage for notification batching, payload limits, and explicit network body fetching.

## Testing
- Added unit tests for resource update coalescing, resource subscription hooks, byte-budget buffer eviction, console truncation, and network response body behavior.
- `bun run test`
- `bun run typecheck`
- `bun run build`