### PR TITLE
Stabilize Metro MCP daemon reuse and CDP proxying

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "^0.2.7",
+        "metro-bridge": "^0.2.8",
         "ws": "^8.20.0",
         "zod": "^4.0.0",
       },
@@ -436,7 +436,7 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
-    "metro-bridge": ["metro-bridge@0.2.7", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-wS5D1WLAC3SRvz4v4GMK7C2TgqagjM4wGB+vbmh7QwLuehq0ODk2szs22mDooOZm47UA95GXLLeTxgk6Pu21CQ=="],
+    "metro-bridge": ["metro-bridge@0.2.8", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-yZZQ63Bid+FJwg9cE1Y/AflpFc8TeU9s7HO88wjiayuq8cGfc4LnZpsrwA759vLFR2R7zjcvaMc01k7RC25L5w=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.2.7",
+    "metro-bridge": "^0.2.8",
     "ws": "^8.20.0",
     "zod": "^4.0.0"
   },

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,11 +7,13 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { createLogger } from './utils/logger.js';
+import { version } from './version.js';
 
 const logger = createLogger('daemon');
 
-const CONFIG_DIR = path.join(os.homedir(), '.config', 'metro-mcp');
+const DEFAULT_CONFIG_DIR = path.join(os.homedir(), '.config', 'metro-mcp');
 const DAEMON_KEY_ENV = 'METRO_MCP_DAEMON_KEY';
+const DAEMON_CONFIG_DIR_ENV = 'METRO_MCP_DAEMON_CONFIG_DIR';
 const STARTUP_LOCK_TIMEOUT_MS = 10_000;
 const STARTUP_LOCK_STALE_MS = 30_000;
 const DAEMON_ENV_KEYS = [
@@ -23,7 +25,16 @@ const DAEMON_ENV_KEYS = [
   'METRO_MCP_PROXY_ENABLED',
 ] as const;
 
-interface DaemonRecord {
+export interface DaemonIdentity {
+  version: string;
+  cwd: string;
+  args: string[];
+  env: Record<string, string | undefined>;
+  entrypoint: string;
+  runtime: string;
+}
+
+export interface DaemonRecord {
   pid: number;
   host: string;
   port: number;
@@ -31,7 +42,18 @@ interface DaemonRecord {
   key: string;
   cwd: string;
   args: string[];
+  identity?: DaemonIdentity;
   startedAt: string;
+}
+
+export interface DaemonHealth {
+  ok: boolean;
+  name: string;
+  version: string;
+  daemon?: {
+    key: string;
+    identity: DaemonIdentity;
+  };
 }
 
 function sleep(ms: number): Promise<void> {
@@ -46,9 +68,33 @@ function selectedEnv(): Record<string, string | undefined> {
   return env;
 }
 
-export function getDaemonKey(args: string[]): string {
+function resolvePath(value: string | undefined): string {
+  if (!value) return '';
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+function getConfigDir(): string {
+  return process.env[DAEMON_CONFIG_DIR_ENV] || DEFAULT_CONFIG_DIR;
+}
+
+export function createDaemonIdentity(args: string[], overrides: Partial<DaemonIdentity> = {}): DaemonIdentity {
+  return {
+    version: overrides.version ?? version,
+    cwd: overrides.cwd ?? getDaemonCwd(),
+    args: overrides.args ?? [...args],
+    env: overrides.env ?? selectedEnv(),
+    entrypoint: overrides.entrypoint ?? resolvePath(process.argv[1]),
+    runtime: overrides.runtime ?? resolvePath(process.execPath),
+  };
+}
+
+export function getDaemonKey(args: string[], identity = createDaemonIdentity(args)): string {
   const hash = createHash('sha256');
-  hash.update(JSON.stringify({ args, cwd: getDaemonCwd(), env: selectedEnv() }));
+  hash.update(JSON.stringify(identity));
   return hash.digest('hex').slice(0, 16);
 }
 
@@ -61,15 +107,15 @@ export function getDaemonCwd(): string {
 }
 
 export function getDaemonRecordPath(key: string): string {
-  return path.join(CONFIG_DIR, `daemon-${key}.json`);
+  return path.join(getConfigDir(), `daemon-${key}.json`);
 }
 
 function getDaemonLockPath(key: string): string {
-  return path.join(CONFIG_DIR, `daemon-${key}.lock`);
+  return path.join(getConfigDir(), `daemon-${key}.lock`);
 }
 
 export function writeDaemonRecord(record: DaemonRecord): void {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.mkdirSync(getConfigDir(), { recursive: true });
   fs.writeFileSync(getDaemonRecordPath(record.key), JSON.stringify(record, null, 2));
 }
 
@@ -81,7 +127,29 @@ function removeDaemonRecord(key: string): void {
   }
 }
 
-async function isRecordLive(record: DaemonRecord): Promise<boolean> {
+export function removeDaemonRecordForProcess(key: string, pid: number): void {
+  try {
+    const record = JSON.parse(fs.readFileSync(getDaemonRecordPath(key), 'utf8')) as DaemonRecord;
+    if (record.pid !== pid) return;
+    removeDaemonRecord(key);
+  } catch {
+    // Missing or corrupt records will be cleaned opportunistically on next startup.
+  }
+}
+
+function identityMatches(actual: DaemonIdentity | undefined, expected: DaemonIdentity): boolean {
+  if (!actual) return false;
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+async function readHealth(record: DaemonRecord): Promise<DaemonHealth | null> {
+  const healthUrl = new URL('/health', record.url);
+  const response = await fetch(healthUrl, { signal: AbortSignal.timeout(1000) });
+  if (!response.ok) return null;
+  return await response.json() as DaemonHealth;
+}
+
+async function isRecordLive(record: DaemonRecord, expectedIdentity?: DaemonIdentity): Promise<boolean> {
   try {
     process.kill(record.pid, 0);
   } catch {
@@ -89,18 +157,32 @@ async function isRecordLive(record: DaemonRecord): Promise<boolean> {
   }
 
   try {
-    const healthUrl = new URL('/health', record.url);
-    const response = await fetch(healthUrl, { signal: AbortSignal.timeout(1000) });
-    return response.ok;
+    const health = await readHealth(record);
+    if (!health || health.name !== 'metro-mcp') return false;
+    if (!expectedIdentity) return true;
+
+    if (health.version !== expectedIdentity.version) {
+      logger.warn(
+        `Ignoring metro-mcp daemon ${record.url}: version ${health.version} does not match ${expectedIdentity.version}`
+      );
+      return false;
+    }
+
+    if (health.daemon?.key !== record.key || !identityMatches(health.daemon.identity, expectedIdentity)) {
+      logger.warn(`Ignoring metro-mcp daemon ${record.url}: daemon identity does not match current launch context`);
+      return false;
+    }
+
+    return true;
   } catch {
     return false;
   }
 }
 
-async function readLiveRecord(key: string): Promise<DaemonRecord | null> {
+export async function readLiveRecord(key: string, expectedIdentity?: DaemonIdentity): Promise<DaemonRecord | null> {
   try {
     const record = JSON.parse(fs.readFileSync(getDaemonRecordPath(key), 'utf8')) as DaemonRecord;
-    if (await isRecordLive(record)) return record;
+    if (await isRecordLive(record, expectedIdentity)) return record;
   } catch {
     // Missing or corrupt record.
   }
@@ -108,10 +190,10 @@ async function readLiveRecord(key: string): Promise<DaemonRecord | null> {
   return null;
 }
 
-async function waitForRecord(key: string): Promise<DaemonRecord> {
+async function waitForRecord(key: string, expectedIdentity: DaemonIdentity): Promise<DaemonRecord> {
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
-    const record = await readLiveRecord(key);
+    const record = await readLiveRecord(key, expectedIdentity);
     if (record) return record;
     await sleep(100);
   }
@@ -119,7 +201,7 @@ async function waitForRecord(key: string): Promise<DaemonRecord> {
 }
 
 async function withStartupLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.mkdirSync(getConfigDir(), { recursive: true });
   const lockPath = getDaemonLockPath(key);
   const deadline = Date.now() + STARTUP_LOCK_TIMEOUT_MS;
 
@@ -152,13 +234,39 @@ async function withStartupLock<T>(key: string, fn: () => Promise<T>): Promise<T>
   throw new Error('Timed out waiting for metro-mcp daemon startup lock');
 }
 
+export async function cleanupStaleDaemonRecords(): Promise<void> {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(getConfigDir());
+  } catch {
+    return;
+  }
+
+  await Promise.all(entries.map(async (entry) => {
+    const match = /^daemon-([a-f0-9]+)\.json$/.exec(entry);
+    if (!match) return;
+
+    const key = match[1];
+    try {
+      const record = JSON.parse(fs.readFileSync(getDaemonRecordPath(key), 'utf8')) as DaemonRecord;
+      if (await isRecordLive(record)) return;
+    } catch {
+      // Corrupt records are stale.
+    }
+    removeDaemonRecord(key);
+  }));
+}
+
 async function ensureDaemon(args: string[]): Promise<DaemonRecord> {
-  const key = getDaemonKey(args);
-  const existing = await readLiveRecord(key);
+  const identity = createDaemonIdentity(args);
+  const key = getDaemonKey(args, identity);
+  await cleanupStaleDaemonRecords();
+
+  const existing = await readLiveRecord(key, identity);
   if (existing) return existing;
 
   return withStartupLock(key, async () => {
-    const lockedExisting = await readLiveRecord(key);
+    const lockedExisting = await readLiveRecord(key, identity);
     if (lockedExisting) return lockedExisting;
 
     const entry = process.argv[1];
@@ -175,12 +283,12 @@ async function ensureDaemon(args: string[]): Promise<DaemonRecord> {
     child.unref();
 
     logger.info('Started metro-mcp daemon');
-    return waitForRecord(key);
+    return waitForRecord(key, identity);
   });
 }
 
-export function getDaemonKeyFromEnv(args: string[]): string {
-  return process.env[DAEMON_KEY_ENV] || getDaemonKey(args);
+export function getDaemonKeyFromEnv(args: string[], identity = createDaemonIdentity(args)): string {
+  return process.env[DAEMON_KEY_ENV] || getDaemonKey(args, identity);
 }
 
 export async function startStdioProxy(args: string[]): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 import { loadConfig } from './config.js';
 import { startHttpServer, startServer } from './server.js';
-import { getDaemonCwd, getDaemonKeyFromEnv, startStdioProxy, writeDaemonRecord } from './daemon.js';
+import {
+  createDaemonIdentity,
+  getDaemonCwd,
+  getDaemonKeyFromEnv,
+  removeDaemonRecordForProcess,
+  startStdioProxy,
+  writeDaemonRecord,
+} from './daemon.js';
 import { createLogger } from './utils/logger.js';
 
 const logger = createLogger('main');
@@ -91,9 +98,12 @@ Examples:
 
     if (subcommand === 'serve') {
       const mcpPort = resolveMcpPort(serverArgs);
-      const key = getDaemonKeyFromEnv(serverArgs);
+      const identity = createDaemonIdentity(serverArgs);
+      const key = getDaemonKeyFromEnv(serverArgs, identity);
+      const cleanupDaemonRecord = () => removeDaemonRecordForProcess(key, process.pid);
       await startHttpServer(config, serverArgs, {
         port: mcpPort,
+        daemon: { key, identity },
         onListening: ({ host, port, url }) => {
           writeDaemonRecord({
             pid: process.pid,
@@ -103,8 +113,10 @@ Examples:
             key,
             cwd: getDaemonCwd(),
             args: serverArgs,
+            identity,
             startedAt: new Date().toISOString(),
           });
+          process.once('exit', cleanupDaemonRecord);
         },
       });
       return;

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
+import { supportsMultipleDebuggers, openDevTools } from 'metro-bridge';
 import { definePlugin } from '../plugin.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -91,7 +92,8 @@ export const devtoolsPlugin = definePlugin({
         open: z.boolean().default(true).describe('Attempt to open the browser automatically'),
       }),
       handler: async ({ open }) => {
-        if (!ctx.cdp.getTarget()) {
+        const target = ctx.cdp.getTarget();
+        if (!target) {
           return 'Not connected to Metro. Start your React Native app and try again.';
         }
 
@@ -100,6 +102,36 @@ export const devtoolsPlugin = definePlugin({
         const proxyPort = proxyConfig?.port;
 
         if (!proxyPort) {
+          if (supportsMultipleDebuggers(target)) {
+            let frontendUrl: string;
+            if (target.devtoolsFrontendUrl) {
+              frontendUrl = `http://${ctx.metro.host}:${ctx.metro.port}${target.devtoolsFrontendUrl}`;
+            } else {
+              let wsHost: string;
+              try {
+                wsHost = new URL(target.webSocketDebuggerUrl).host;
+              } catch {
+                return 'Could not parse Metro WebSocket URL. Try reconnecting.';
+              }
+              frontendUrl = buildFrontendUrl(ctx.metro.host, ctx.metro.port, wsHost);
+            }
+
+            if (open) {
+              try {
+                const result = await openDevTools(frontendUrl);
+                return { opened: result.opened, url: frontendUrl };
+              } catch (err) {
+                logger.debug('Failed to open DevTools:', err);
+              }
+            }
+
+            return {
+              opened: false,
+              url: frontendUrl,
+              instructions: 'Open this URL in Chrome or Edge: ' + frontendUrl,
+            };
+          }
+
           return 'CDP proxy is not running. Set proxy.enabled to true in your metro-mcp config.';
         }
 

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
-import { supportsMultipleDebuggers, openDevTools } from 'metro-bridge';
 import { definePlugin } from '../plugin.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('devtools');
-const DEVTOOLS_STATE_FILE = '/tmp/metro-mcp-devtools.json';
+const DEVTOOLS_STATE_FILE = join(tmpdir(), 'metro-mcp-devtools.json');
 
 function buildFrontendUrl(metroHost: string, metroPort: number, wsEndpoint: string): string {
   return `http://${metroHost}:${metroPort}/debugger-frontend/rn_fusebox.html?ws=${wsEndpoint}&sources.hide_add_folder=true`;
@@ -83,55 +84,17 @@ export const devtoolsPlugin = definePlugin({
     ctx.registerTool('open_devtools', {
       description:
         'Open the React Native DevTools debugger panel in Chrome. ' +
-        'On RN 0.85+ connects directly to Metro (no proxy needed). ' +
-        'On older RN versions connects through the CDP proxy so both ' +
-        'DevTools and the MCP can share the single Hermes connection.',
+        'Connects through the CDP proxy so DevTools and the MCP can share ' +
+        'the same Hermes connection.',
       annotations: { openWorldHint: true },
       parameters: z.object({
         open: z.boolean().default(true).describe('Attempt to open the browser automatically'),
       }),
       handler: async ({ open }) => {
-        const target = ctx.cdp.getTarget();
-        if (!target) {
+        if (!ctx.cdp.getTarget()) {
           return 'Not connected to Metro. Start your React Native app and try again.';
         }
 
-        if (supportsMultipleDebuggers(target)) {
-          // Prefer the devtoolsFrontendUrl Metro provides — it encodes the exact
-          // device+page path in the `ws` query param, which is what DevTools needs
-          // to connect to the right session. Falling back to just the host (as we
-          // used to do) opens a generic target-picker that doesn't auto-connect.
-          let frontendUrl: string;
-          if (target.devtoolsFrontendUrl) {
-            frontendUrl = `http://${ctx.metro.host}:${ctx.metro.port}${target.devtoolsFrontendUrl}`;
-          } else {
-            let wsHost: string;
-            try {
-              wsHost = new URL(target.webSocketDebuggerUrl).host;
-            } catch {
-              return 'Could not parse Metro WebSocket URL. Try reconnecting.';
-            }
-            frontendUrl = buildFrontendUrl(ctx.metro.host, ctx.metro.port, wsHost);
-          }
-
-          if (open) {
-            try {
-              const result = await openDevTools(frontendUrl);
-              return { opened: result.opened, url: frontendUrl };
-            } catch (err) {
-              logger.debug('Failed to open DevTools:', err);
-            }
-          }
-
-          return {
-            opened: false,
-            url: frontendUrl,
-            instructions: 'Open this URL in Chrome or Edge: ' + frontendUrl,
-          };
-        }
-
-        // RN <0.85: only one debugger can hold the connection at a time, so the
-        // CDPMultiplexer proxy shares it between DevTools and the MCP.
         const config = ctx.config as Record<string, unknown>;
         const proxyConfig = config.proxy as { port?: number } | undefined;
         const proxyPort = proxyConfig?.port;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,8 @@ import { randomUUID } from 'node:crypto';
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import http from 'node:http';
-import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -27,7 +28,7 @@ import type {
   PromptConfig,
   EvalOptions,
 } from './plugin.js';
-import { CDPSession, CDPMultiplexer, scanMetroPorts, selectBestTarget, fetchTargets, supportsMultipleDebuggers } from 'metro-bridge';
+import { CDPSession, CDPMultiplexer, scanMetroPorts, selectBestTarget, fetchTargets } from 'metro-bridge';
 import type { MetroTarget } from 'metro-bridge';
 import { loadConfig } from './config.js';
 import { MetroEventsClient } from './metro/events.js';
@@ -549,10 +550,10 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
 
   // Singleton proxy lock — prevents multiple metro-mcp instances from competing
   // for Metro's single CDP WebSocket, which causes a connect/disconnect spam loop.
-  // The first instance connects directly to Metro and writes its CDP proxy port to
+  // The first instance owns the upstream Metro connection and writes its CDP proxy port to
   // a lock file. Subsequent instances detect the lock and connect through the
   // existing proxy instead.
-  const PROXY_LOCK_FILE = '/tmp/metro-mcp-proxy.json';
+  const PROXY_LOCK_FILE = join(tmpdir(), 'metro-mcp-proxy.json');
   let isPrimaryInstance = false;
 
   async function tryConnectViaProxy(): Promise<boolean> {
@@ -659,12 +660,10 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
       activeDeviceKey = `${server.port}-${target.id}`;
       activeDeviceName = target.title || target.deviceName || target.id;
 
-      if (supportsMultipleDebuggers(target)) {
-        // RN 0.85+: Metro handles multiple concurrent debugger sessions natively.
-        // No CDPMultiplexer needed — connect directly and skip the proxy.
-        logger.info('Target supports multiple debuggers (RN 0.85+) — skipping CDP proxy');
-      } else if (!cdpMultiplexer && config.proxy?.enabled !== false) {
-        // RN <0.85: start the CDPMultiplexer BEFORE connecting so that the
+      const proxyEnabled = config.proxy?.enabled !== false;
+
+      if (!cdpMultiplexer && proxyEnabled) {
+        // Start the CDPMultiplexer BEFORE connecting so that the
         // messageInterceptor is already in place when 'reconnected' fires and
         // events begin flowing from Metro. Starting it after connectToTarget()
         // caused a window where events were lost on initial connection.
@@ -683,16 +682,15 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
         } catch (err) {
           logger.warn('Could not start CDP proxy:', err);
         }
+      } else if (!proxyEnabled) {
+        logger.warn('CDP proxy is disabled; connecting directly without Metro MCP shared-debugger multiplexing.');
       }
 
       await cdpSession.connectToTarget(target);
       eventsClient.connect(server.host, server.port);
 
-      if (!supportsMultipleDebuggers(target)) {
-        const proxyConfig = (config as Record<string, unknown>).proxy as { port?: number } | undefined;
-        if (proxyConfig?.port) {
-          writeProxyLock(proxyConfig.port, server.port);
-        }
+      if (cdpMultiplexer?.port) {
+        writeProxyLock(cdpMultiplexer.port, server.port);
       }
 
       return true;
@@ -729,8 +727,9 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     }, delay);
   }
 
-  // CDP proxy for Chrome DevTools coexistence — started lazily on first connect
-  // only when the target does not support multiple debuggers natively (RN <0.85).
+  // CDP proxy for Chrome DevTools coexistence — started lazily on first connect.
+  // Metro MCP always prefers this shared path so MCP tools and DevTools do not
+  // compete for the same upstream Metro inspector connection.
   let cdpMultiplexer: CDPMultiplexer | null = null;
 
   // Read preferred proxy port once at startup (stale lock reuse / explicit config).

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,8 @@ import { createFormatUtils } from './utils/format.js';
 import { extractCDPExceptionMessage } from './utils/cdp.js';
 import { createPreferredFrameSizeMeta, withAppSizing } from './utils/apps.js';
 import { version } from './version.js';
+import { createDaemonIdentity, getDaemonKey } from './daemon.js';
+import type { DaemonIdentity } from './daemon.js';
 
 // Built-in plugins
 import { consolePlugin } from './plugins/console.js';
@@ -110,6 +112,10 @@ interface McpSession {
 interface HttpServerOptions {
   host?: string;
   port?: number;
+  daemon?: {
+    key: string;
+    identity: DaemonIdentity;
+  };
   onListening?: (info: { host: string; port: number; url: string }) => void;
 }
 
@@ -171,10 +177,19 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   // Start with a very short delay (500ms) to recover quickly from brief disconnects
   // like hot reloads, then ramp up for longer outages.
   const RECONNECT_DELAYS = [500, 1000, 2000, 4000, 8000, 16000];
+  const RECONNECT_STABLE_MS = 5000;
   const MAX_BURST_ATTEMPTS = 15; // fast retries; after this, switch to slow background probe
   let reconnectAttempts = 0;
   let isReconnecting = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectStabilityTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearReconnectStabilityTimer(): void {
+    if (reconnectStabilityTimer) {
+      clearTimeout(reconnectStabilityTimer);
+      reconnectStabilityTimer = null;
+    }
+  }
 
   function waitForReconnect(): Promise<void> {
     return new Promise<void>((resolve) => {
@@ -226,14 +241,23 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
 
   // Enable required CDP domains on every connection (initial and reconnect).
   cdpSession.on('reconnected', async () => {
-    reconnectAttempts = 0;
     isReconnecting = false;
     if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
     await enableCDPDomains();
+    clearReconnectStabilityTimer();
+    reconnectStabilityTimer = setTimeout(() => {
+      reconnectStabilityTimer = null;
+      if (!runtimeClosed && cdpSession.isConnected) {
+        reconnectAttempts = 0;
+        logger.debug('CDP connection stable; reset reconnect backoff');
+      }
+    }, RECONNECT_STABLE_MS);
   });
 
   // Drive all reconnection through connectToMetro() so we always get a fresh target URL.
   cdpSession.on('disconnected', () => {
+    clearReconnectStabilityTimer();
+    cleanProxyLock();
     scheduleReconnect();
   });
 
@@ -560,8 +584,18 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     try {
       const lockData = JSON.parse(fs.readFileSync(PROXY_LOCK_FILE, 'utf8'));
       if (lockData.pid && lockData.port) {
+        if (lockData.pid === process.pid) {
+          return false;
+        }
+
         // Check if the owning process is still alive
-        try { process.kill(lockData.pid, 0); } catch { return false; }
+        try {
+          process.kill(lockData.pid, 0);
+        } catch {
+          try { fs.unlinkSync(PROXY_LOCK_FILE); } catch {}
+          return false;
+        }
+
         const resp = await fetch(`http://127.0.0.1:${lockData.port}/json`, {
           signal: AbortSignal.timeout(2000),
         });
@@ -628,8 +662,10 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     }
     isReconnecting = true;
     try {
+      const proxyEnabled = config.proxy?.enabled !== false;
+
       // If another metro-mcp instance is already connected, piggyback on its proxy
-      if (await tryConnectViaProxy()) {
+      if (proxyEnabled && await tryConnectViaProxy()) {
         return true;
       }
 
@@ -659,8 +695,6 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
       // that fire on the 'reconnected' event can store events immediately.
       activeDeviceKey = `${server.port}-${target.id}`;
       activeDeviceName = target.title || target.deviceName || target.id;
-
-      const proxyEnabled = config.proxy?.enabled !== false;
 
       if (!cdpMultiplexer && proxyEnabled) {
         // Start the CDPMultiplexer BEFORE connecting so that the
@@ -705,6 +739,7 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   // Schedule a reconnect with exponential backoff, driven from server.ts so we always
   // re-fetch a fresh target URL from Metro's /json endpoint.
   function scheduleReconnect(): void {
+    if (runtimeClosed) return;
     if (reconnectTimer !== null || isReconnecting) return; // already scheduled or in progress
 
     // Use exponential backoff for the initial burst, then fall back to a slow
@@ -817,6 +852,11 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   function closeRuntime(): void {
     if (runtimeClosed) return;
     runtimeClosed = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    clearReconnectStabilityTimer();
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
     process.off('exit', handleExit);
@@ -867,6 +907,8 @@ export async function startHttpServer(
   const runtime = await createMetroRuntime(config, args);
   const host = options.host ?? '127.0.0.1';
   const requestedPort = options.port ?? 0;
+  const daemonIdentity = options.daemon?.identity ?? createDaemonIdentity(args);
+  const daemonKey = options.daemon?.key ?? getDaemonKey(args, daemonIdentity);
   const streamableTransports = new Map<string, StreamableHTTPServerTransport>();
   const sseTransports = new Map<string, SSEServerTransport>();
 
@@ -920,7 +962,15 @@ export async function startHttpServer(
 
     try {
       if (url.pathname === '/health') {
-        sendJson(res, 200, { ok: true, name: 'metro-mcp', version });
+        sendJson(res, 200, {
+          ok: true,
+          name: 'metro-mcp',
+          version,
+          daemon: {
+            key: daemonKey,
+            identity: daemonIdentity,
+          },
+        });
         return;
       }
 

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  cleanupStaleDaemonRecords,
+  createDaemonIdentity,
+  getDaemonKey,
+  getDaemonRecordPath,
+  readLiveRecord,
+  removeDaemonRecordForProcess,
+  writeDaemonRecord,
+} from '../src/daemon.js';
+import { loadConfig } from '../src/config.js';
+import { startHttpServer } from '../src/server.js';
+import { version } from '../src/version.js';
+import type { DaemonHealth, DaemonIdentity, DaemonRecord } from '../src/daemon.js';
+
+const CONFIG_DIR_ENV = 'METRO_MCP_DAEMON_CONFIG_DIR';
+
+let tempDir: string;
+let previousConfigDir: string | undefined;
+let nextPort = 46000 + Math.floor(Math.random() * 1000);
+
+beforeEach(() => {
+  previousConfigDir = process.env[CONFIG_DIR_ENV];
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metro-mcp-daemon-test-'));
+  process.env[CONFIG_DIR_ENV] = tempDir;
+});
+
+afterEach(() => {
+  if (previousConfigDir === undefined) {
+    delete process.env[CONFIG_DIR_ENV];
+  } else {
+    process.env[CONFIG_DIR_ENV] = previousConfigDir;
+  }
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function identity(overrides: Partial<DaemonIdentity> = {}): DaemonIdentity {
+  return createDaemonIdentity(['--port', '8081'], {
+    version: '1.0.0',
+    cwd: '/tmp/react-native-app',
+    args: ['--port', '8081'],
+    env: {
+      METRO_HOST: undefined,
+      METRO_PORT: '8081',
+      METRO_MCP_CONFIG: undefined,
+      METRO_MCP_PLUGINS: undefined,
+      METRO_MCP_PROXY_PORT: undefined,
+      METRO_MCP_PROXY_ENABLED: undefined,
+    },
+    entrypoint: '/tmp/metro-mcp/src/index.ts',
+    runtime: '/usr/local/bin/bun',
+    ...overrides,
+  });
+}
+
+function record(key: string, url: string, recordIdentity: DaemonIdentity): DaemonRecord {
+  const recordUrl = new URL(url);
+  return {
+    pid: process.pid,
+    host: '127.0.0.1',
+    port: recordUrl.port ? Number(recordUrl.port) : 0,
+    url,
+    key,
+    cwd: recordIdentity.cwd,
+    args: recordIdentity.args,
+    identity: recordIdentity,
+    startedAt: new Date().toISOString(),
+  };
+}
+
+async function withHealthServer<T>(
+  health: DaemonHealth,
+  fn: (url: string) => Promise<T>,
+): Promise<T> {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(health));
+      return;
+    }
+    res.writeHead(404).end('Not found');
+  });
+
+  const port = await listen(server);
+
+  try {
+    return await fn(`http://127.0.0.1:${port}/mcp`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve());
+    });
+  }
+}
+
+async function listen(server: http.Server): Promise<number> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const port = nextPort++;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: Error) => {
+          server.off('listening', onListening);
+          reject(err);
+        };
+        const onListening = () => {
+          server.off('error', onError);
+          resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(port, '127.0.0.1');
+      });
+      return port;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw err;
+    }
+  }
+
+  throw new Error('Could not find an available test port');
+}
+
+describe('daemon identity', () => {
+  test('changes the daemon key when the server version changes', () => {
+    const current = identity({ version: '1.0.0' });
+    const next = identity({ version: '1.0.1' });
+
+    expect(getDaemonKey(current.args, current)).not.toBe(getDaemonKey(next.args, next));
+  });
+
+  test('changes the daemon key when launcher context changes', () => {
+    const installed = identity({ entrypoint: '/tmp/bunx/metro-mcp/dist/bin/metro-mcp.js' });
+    const local = identity({ entrypoint: '/Users/stephenradford/Sites/metro-mcp/src/index.ts' });
+    const node = identity({ runtime: '/usr/local/bin/node' });
+
+    expect(getDaemonKey(installed.args, installed)).not.toBe(getDaemonKey(local.args, local));
+    expect(getDaemonKey(installed.args, installed)).not.toBe(getDaemonKey(node.args, node));
+  });
+});
+
+describe('daemon records', () => {
+  test('reuses a matching live daemon record', async () => {
+    const expected = identity();
+    const key = getDaemonKey(expected.args, expected);
+
+    await withHealthServer(
+      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key, identity: expected } },
+      async (url) => {
+        writeDaemonRecord(record(key, url, expected));
+
+        const live = await readLiveRecord(key, expected);
+
+        expect(live?.url).toBe(url);
+        expect(fs.existsSync(getDaemonRecordPath(key))).toBe(true);
+      },
+    );
+  });
+
+  test('removes a live record when the health version does not match', async () => {
+    const expected = identity();
+    const key = getDaemonKey(expected.args, expected);
+
+    await withHealthServer(
+      { ok: true, name: 'metro-mcp', version: '0.9.0', daemon: { key, identity: expected } },
+      async (url) => {
+        writeDaemonRecord(record(key, url, expected));
+
+        await expect(readLiveRecord(key, expected)).resolves.toBeNull();
+        expect(fs.existsSync(getDaemonRecordPath(key))).toBe(false);
+      },
+    );
+  });
+
+  test('removes a live record when daemon identity does not match', async () => {
+    const expected = identity();
+    const actual = identity({ entrypoint: '/tmp/old-metro-mcp/src/index.ts' });
+    const key = getDaemonKey(expected.args, expected);
+
+    await withHealthServer(
+      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key, identity: actual } },
+      async (url) => {
+        writeDaemonRecord(record(key, url, expected));
+
+        await expect(readLiveRecord(key, expected)).resolves.toBeNull();
+        expect(fs.existsSync(getDaemonRecordPath(key))).toBe(false);
+      },
+    );
+  });
+
+  test('cleans corrupt and unreachable daemon records without removing other live metro-mcp records', async () => {
+    const expected = identity();
+    const liveKey = getDaemonKey(expected.args, expected);
+    const corruptKey = 'deadbeefdeadbeef';
+    const unreachableKey = 'ffffffffffffffff';
+    fs.mkdirSync(tempDir, { recursive: true });
+    fs.writeFileSync(getDaemonRecordPath(corruptKey), '{nope');
+    writeDaemonRecord({
+      ...record(unreachableKey, 'http://127.0.0.1:1/mcp', expected),
+      key: unreachableKey,
+    });
+
+    await withHealthServer(
+      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key: liveKey, identity: expected } },
+      async (url) => {
+        writeDaemonRecord(record(liveKey, url, expected));
+
+        await cleanupStaleDaemonRecords();
+
+        expect(fs.existsSync(getDaemonRecordPath(corruptKey))).toBe(false);
+        expect(fs.existsSync(getDaemonRecordPath(unreachableKey))).toBe(false);
+        expect(fs.existsSync(getDaemonRecordPath(liveKey))).toBe(true);
+      },
+    );
+  });
+
+  test('cleans records whose health endpoint is not metro-mcp', async () => {
+    const expected = identity();
+    const key = getDaemonKey(expected.args, expected);
+
+    await withHealthServer(
+      { ok: true, name: 'other-server', version: expected.version },
+      async (url) => {
+        writeDaemonRecord(record(key, url, expected));
+
+        await cleanupStaleDaemonRecords();
+
+        expect(fs.existsSync(getDaemonRecordPath(key))).toBe(false);
+      },
+    );
+  });
+
+  test('removes only the daemon record owned by the exiting process', () => {
+    const expected = identity();
+    const ownedKey = getDaemonKey(expected.args, expected);
+    const otherKey = 'aaaaaaaaaaaaaaaa';
+    writeDaemonRecord(record(ownedKey, 'http://127.0.0.1:4567/mcp', expected));
+    writeDaemonRecord({
+      ...record(otherKey, 'http://127.0.0.1:4568/mcp', expected),
+      key: otherKey,
+      pid: process.pid + 1,
+    });
+
+    removeDaemonRecordForProcess(ownedKey, process.pid);
+    removeDaemonRecordForProcess(otherKey, process.pid);
+
+    expect(fs.existsSync(getDaemonRecordPath(ownedKey))).toBe(false);
+    expect(fs.existsSync(getDaemonRecordPath(otherKey))).toBe(true);
+  });
+});
+
+describe('HTTP health', () => {
+  test('exposes daemon identity while keeping name and version', async () => {
+    const args = ['--port', '65535'];
+    const daemonIdentity = identity({ version, args });
+    const key = getDaemonKey(args, daemonIdentity);
+    const config = await loadConfig(args);
+    config.metro.host = '127.0.0.1';
+    config.metro.port = 65535;
+    config.metro.autoDiscover = false;
+    config.proxy.enabled = false;
+
+    const server = await startHttpServer(config, args, {
+      port: nextPort++,
+      daemon: { key, identity: daemonIdentity },
+    });
+
+    try {
+      const response = await fetch(new URL('/health', server.url));
+      const body = await response.json() as DaemonHealth;
+
+      expect(body.name).toBe('metro-mcp');
+      expect(body.version).toBe(version);
+      expect(body.daemon?.key).toBe(key);
+      expect(body.daemon?.identity).toEqual(daemonIdentity);
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Always route Metro MCP CDP traffic through the CDP multiplexer instead of selecting direct mode from `supportsMultipleDebuggers`.
- Fix daemon reuse by keying records on server version plus launch identity: entrypoint, runtime, cwd, args, and selected Metro MCP env.
- Expose daemon identity from `/health`, ignore mismatched live daemons, and clean stale/corrupt/unreachable daemon records opportunistically.
- Tighten proxy/reconnect handling so stale proxy locks are removed, proxy-disabled mode stays explicit, and reconnect backoff resets only after a stable CDP connection.
- Use `os.tmpdir()` for Metro MCP temp lock/state files and bump Metro MCP to `0.13.0` with `metro-bridge` `^0.2.8`.

## Validation

- `bun test tests/daemon.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- Manual RN 0.85 check: direct CDP clients and Metro MCP eval/log flow work with the fixed bridge origin handling.
- Manual older RN/Fusebox check: fresh Metro MCP daemon connects, `evaluate_js` returns, and matching console logs are readable.
