### PR TITLE
fix(network): capture requests on RN fusebox where the only requestWillBeSent carries a stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/plugins/network.test.ts
+++ b/src/plugins/network.test.ts
@@ -93,6 +93,60 @@ function recordFinishedRequest(emit: (event: string, params: Record<string, unkn
   });
 }
 
+test('network plugin captures stack-bearing requests when no native twin is emitted', async () => {
+  // Modern fusebox inspector (RN 0.76+) emits a single requestWillBeSent that
+  // carries a JS call stack; its requestId is referenced by the later events.
+  const { emit, tools } = await createNetworkHarness('{"ok":true}');
+
+  emit('Network.requestWillBeSent', {
+    requestId: 'uuid-1',
+    request: { url: 'https://example.test/graphql', method: 'POST', headers: {} },
+    type: 'Fetch',
+    initiator: { type: 'script', stack: { callFrames: [] } },
+  });
+  emit('Network.responseReceived', {
+    requestId: 'uuid-1',
+    response: { status: 200, statusText: 'OK', headers: {} },
+  });
+  emit('Network.loadingFinished', { requestId: 'uuid-1', encodedDataLength: 12 });
+
+  const getResponseBody = tools.get('get_response_body');
+  const result = await getResponseBody!.handler({ url: 'example.test/graphql', index: -1 });
+  expect(result).toEqual({
+    url: 'https://example.test/graphql',
+    status: 200,
+    body: { ok: true },
+  });
+});
+
+test('network plugin drops the JS-layer duplicate when a native twin is also emitted', async () => {
+  // Legacy double-emit: native (stackless) event first, then the JS-layer duplicate.
+  const { emit, tools } = await createNetworkHarness('{"ok":true}');
+
+  emit('Network.requestWillBeSent', {
+    requestId: 'native-1',
+    request: { url: 'https://example.test/api', method: 'GET', headers: {} },
+    type: 'Fetch',
+  });
+  emit('Network.requestWillBeSent', {
+    requestId: 'uuid-1',
+    request: { url: 'https://example.test/api', method: 'GET', headers: {} },
+    type: 'Fetch',
+    initiator: { type: 'script', stack: { callFrames: [] } },
+  });
+  emit('Network.responseReceived', {
+    requestId: 'native-1',
+    response: { status: 200, statusText: 'OK', headers: {} },
+  });
+  emit('Network.loadingFinished', { requestId: 'native-1', encodedDataLength: 12 });
+  // The JS-layer duplicate must never have been tracked, so its id resolves to nothing.
+  emit('Network.loadingFinished', { requestId: 'uuid-1', encodedDataLength: 12 });
+
+  const getResponseBody = tools.get('get_response_body');
+  const result = await getResponseBody!.handler({ url: 'example.test/api', index: -1 });
+  expect(result).toMatchObject({ url: 'https://example.test/api', status: 200 });
+});
+
 test('network plugin fetches response bodies only on explicit request', async () => {
   const { cdpSends, emit, tools } = await createNetworkHarness('{"ok":true}');
 

--- a/src/plugins/network.test.ts
+++ b/src/plugins/network.test.ts
@@ -119,21 +119,56 @@ test('network plugin captures stack-bearing requests when no native twin is emit
   });
 });
 
-test('network plugin drops the JS-layer duplicate when a native twin is also emitted', async () => {
-  // Legacy double-emit: native (stackless) event first, then the JS-layer duplicate.
+test('network plugin keeps an unrelated stack-bearing request after a stackless request', async () => {
   const { emit, tools } = await createNetworkHarness('{"ok":true}');
 
+  recordFinishedRequest(emit);
   emit('Network.requestWillBeSent', {
+    requestId: 'uuid-2',
+    request: { url: 'https://example.test/graphql', method: 'POST', headers: {} },
+    type: 'Fetch',
+    initiator: { type: 'script', stack: { callFrames: [] } },
+  });
+  emit('Network.responseReceived', {
+    requestId: 'uuid-2',
+    response: { status: 201, statusText: 'Created', headers: {} },
+  });
+  emit('Network.loadingFinished', { requestId: 'uuid-2', encodedDataLength: 12 });
+
+  const getNetworkRequests = tools.get('get_network_requests');
+  const result = await getNetworkRequests!.handler({
+    limit: 50,
+    summary: false,
+    format: 'json',
+  });
+  expect(result).toEqual([
+    expect.objectContaining({ id: 'request-1', status: 200 }),
+    expect.objectContaining({ id: 'uuid-2', status: 201 }),
+  ]);
+});
+
+async function expectLegacyDuplicateToBeCollapsed(stackBearingFirst: boolean): Promise<void> {
+  const { emit, tools } = await createNetworkHarness('{"ok":true}');
+
+  const nativeEvent = {
     requestId: 'native-1',
     request: { url: 'https://example.test/api', method: 'GET', headers: {} },
     type: 'Fetch',
-  });
-  emit('Network.requestWillBeSent', {
+  };
+  const stackBearingEvent = {
     requestId: 'uuid-1',
     request: { url: 'https://example.test/api', method: 'GET', headers: {} },
     type: 'Fetch',
     initiator: { type: 'script', stack: { callFrames: [] } },
-  });
+  };
+
+  const requestEvents = stackBearingFirst
+    ? [stackBearingEvent, nativeEvent]
+    : [nativeEvent, stackBearingEvent];
+  for (const event of requestEvents) {
+    emit('Network.requestWillBeSent', event);
+  }
+
   emit('Network.responseReceived', {
     requestId: 'native-1',
     response: { status: 200, statusText: 'OK', headers: {} },
@@ -142,9 +177,27 @@ test('network plugin drops the JS-layer duplicate when a native twin is also emi
   // The JS-layer duplicate must never have been tracked, so its id resolves to nothing.
   emit('Network.loadingFinished', { requestId: 'uuid-1', encodedDataLength: 12 });
 
-  const getResponseBody = tools.get('get_response_body');
-  const result = await getResponseBody!.handler({ url: 'example.test/api', index: -1 });
-  expect(result).toMatchObject({ url: 'https://example.test/api', status: 200 });
+  const getNetworkRequests = tools.get('get_network_requests');
+  const result = await getNetworkRequests!.handler({
+    limit: 50,
+    summary: false,
+    format: 'json',
+  });
+  expect(result).toEqual([
+    expect.objectContaining({
+      id: 'native-1',
+      url: 'https://example.test/api',
+      status: 200,
+    }),
+  ]);
+}
+
+test('network plugin drops a stack-bearing duplicate emitted after its native twin', async () => {
+  await expectLegacyDuplicateToBeCollapsed(false);
+});
+
+test('network plugin drops a stack-bearing duplicate emitted before its native twin', async () => {
+  await expectLegacyDuplicateToBeCollapsed(true);
 });
 
 test('network plugin fetches response bodies only on explicit request', async () => {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -97,13 +97,26 @@ export const networkPlugin = definePlugin({
 
     // ── CDP Network domain ─────────────────────────────────────────────────────
 
+    // Some React Native setups' JS networking polyfill fires two requestWillBeSent
+    // events per fetch call:
+    //   1. JS XHR polyfill layer — UUID request ID, full JS call stack in initiator.stack
+    //   2. Native networking layer — numeric request ID, initiator has no call stack
+    // On those, we drop the JS-layer (stack-bearing) event so each request appears once.
+    //
+    // But the modern fusebox inspector (RN 0.76+) emits only a *single*, stack-bearing
+    // event per request, and its requestId is what the subsequent responseReceived /
+    // loadingFinished events reference. Unconditionally dropping stack-bearing events
+    // therefore discards 100% of traffic there. So only treat a stack-bearing event as a
+    // droppable duplicate once we've actually observed a native (stackless) event — i.e.
+    // we know this runtime double-emits. Otherwise keep it; it's the only event we'll get.
+    let sawNativeRequest = false;
     ctx.cdp.on('Network.requestWillBeSent', (params) => {
-      // Hermes fires two requestWillBeSent events per fetch call:
-      //   1. JS XHR polyfill layer — UUID request ID, full JS call stack in initiator.stack
-      //   2. Native networking layer — numeric request ID, initiator has no call stack
-      // Drop the JS-layer event (identified by having a call stack) so each request
-      // appears exactly once, sourced from the native layer.
-      if ((params.initiator as Record<string, unknown> | undefined)?.stack) return;
+      const hasStack = !!(params.initiator as Record<string, unknown> | undefined)?.stack;
+      if (!hasStack) {
+        sawNativeRequest = true;
+      } else if (sawNativeRequest) {
+        return;
+      }
 
       const req = params.request as Record<string, unknown>;
       const url = truncateString(req?.url as string, MAX_URL_CHARS);

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -13,6 +13,7 @@ const MAX_BODY_CACHE_SIZE = 1024 * 1024; // 1 MB
 const MAX_NETWORK_BUFFER_BYTES = 2 * 1024 * 1024;
 const MAX_URL_CHARS = 4096;
 const MAX_HEADER_VALUE_CHARS = 4096;
+const REQUEST_TWIN_WINDOW_MS = 1000;
 
 function decodeResponseBody(raw: { body: string; base64Encoded: boolean }): string {
   return raw.base64Encoded ? Buffer.from(raw.body, 'base64').toString('utf8') : raw.body;
@@ -85,6 +86,8 @@ export const networkPlugin = definePlugin({
       sizeOf: estimateNetworkRequestBytes,
     });
     const pendingRequests = new Map<string, NetworkRequest>();
+    const stackBearingRequestIds = new Set<string>();
+    const pairedRequestIds = new Set<string>();
 
     /** Monotonically increasing session counter – bumped on every reconnect so we
      *  can tell which requests belong to the current CDP session vs a stale one. */
@@ -95,34 +98,61 @@ export const networkPlugin = definePlugin({
       return key ? buffers.getOrCreate(key) : null;
     }
 
+    function findPendingInitiatorTwin(
+      url: string,
+      method: string,
+      type: string | undefined,
+      hasInitiatorStack: boolean,
+      now: number,
+    ): string | undefined {
+      for (const [id, request] of pendingRequests) {
+        if (pairedRequestIds.has(id)) continue;
+        const hasOppositeInitiatorShape = stackBearingRequestIds.has(id) !== hasInitiatorStack;
+        if (
+          hasOppositeInitiatorShape &&
+          request.url === url &&
+          request.method === method &&
+          request.type === type &&
+          now - request.startTime <= REQUEST_TWIN_WINDOW_MS
+        ) {
+          return id;
+        }
+      }
+      return undefined;
+    }
+
+    function takePendingRequest(id: string): NetworkRequest | undefined {
+      const request = pendingRequests.get(id);
+      if (request) {
+        pendingRequests.delete(id);
+        stackBearingRequestIds.delete(id);
+        pairedRequestIds.delete(id);
+      }
+      return request;
+    }
+
     // ── CDP Network domain ─────────────────────────────────────────────────────
 
-    // Some React Native setups' JS networking polyfill fires two requestWillBeSent
-    // events per fetch call:
-    //   1. JS XHR polyfill layer — UUID request ID, full JS call stack in initiator.stack
-    //   2. Native networking layer — numeric request ID, initiator has no call stack
-    // On those, we drop the JS-layer (stack-bearing) event so each request appears once.
-    //
-    // But the modern fusebox inspector (RN 0.76+) emits only a *single*, stack-bearing
-    // event per request, and its requestId is what the subsequent responseReceived /
-    // loadingFinished events reference. Unconditionally dropping stack-bearing events
-    // therefore discards 100% of traffic there. So only treat a stack-bearing event as a
-    // droppable duplicate once we've actually observed a native (stackless) event — i.e.
-    // we know this runtime double-emits. Otherwise keep it; it's the only event we'll get.
-    let sawNativeRequest = false;
+    // Legacy Hermes can emit a stack-bearing JS event and a stackless native event
+    // for the same request, in either order. Modern Fusebox emits only the
+    // stack-bearing event, so dedupe only when an opposite-shape twin is pending.
     ctx.cdp.on('Network.requestWillBeSent', (params) => {
-      const hasStack = !!(params.initiator as Record<string, unknown> | undefined)?.stack;
-      if (!hasStack) {
-        sawNativeRequest = true;
-      } else if (sawNativeRequest) {
-        return;
-      }
-
       const req = params.request as Record<string, unknown>;
       const url = truncateString(req?.url as string, MAX_URL_CHARS);
       const method = req?.method as string || 'GET';
       const type = params.type as string | undefined;
       const now = Date.now();
+      const hasInitiatorStack = Boolean(
+        (params.initiator as Record<string, unknown> | undefined)?.stack,
+      );
+      const twinId = findPendingInitiatorTwin(url, method, type, hasInitiatorStack, now);
+      if (twinId) {
+        if (hasInitiatorStack) {
+          pairedRequestIds.add(twinId);
+          return;
+        }
+        takePendingRequest(twinId);
+      }
 
       const request: NetworkRequest = {
         id: params.requestId as string,
@@ -135,6 +165,8 @@ export const networkPlugin = definePlugin({
         session: currentSession,
       };
       pendingRequests.set(request.id, request);
+      if (hasInitiatorStack) stackBearingRequestIds.add(request.id);
+      if (twinId) pairedRequestIds.add(request.id);
     });
 
     ctx.cdp.on('Network.responseReceived', (params) => {
@@ -148,22 +180,20 @@ export const networkPlugin = definePlugin({
     });
 
     ctx.cdp.on('Network.loadingFinished', (params) => {
-      const req = pendingRequests.get(params.requestId as string);
+      const req = takePendingRequest(params.requestId as string);
       if (req) {
         req.endTime = Date.now();
         req.size = params.encodedDataLength as number;
-        pendingRequests.delete(req.id);
         getDeviceBuffer()?.push(req);
         ctx.notifyResourceUpdated('metro://network');
       }
     });
 
     ctx.cdp.on('Network.loadingFailed', (params) => {
-      const req = pendingRequests.get(params.requestId as string);
+      const req = takePendingRequest(params.requestId as string);
       if (req) {
         req.endTime = Date.now();
         req.error = params.errorText as string;
-        pendingRequests.delete(req.id);
         getDeviceBuffer()?.push(req);
         ctx.notifyResourceUpdated('metro://network');
       }
@@ -178,6 +208,8 @@ export const networkPlugin = definePlugin({
         buf?.push(req);
       }
       pendingRequests.clear();
+      stackBearingRequestIds.clear();
+      pairedRequestIds.clear();
     });
 
     ctx.cdp.on('reconnected', () => {
@@ -330,6 +362,8 @@ export const networkPlugin = definePlugin({
         const count = buffers.size;
         buffers.clearResolved(device, ctx.getActiveDeviceKey());
         pendingRequests.clear();
+        stackBearingRequestIds.clear();
+        pairedRequestIds.clear();
         return `Cleared ${count} network requests.`;
       },
     });


### PR DESCRIPTION
Fixes #64.

## Problem

`Network.requestWillBeSent` drops any event with `initiator.stack` set, to dedupe a legacy double-emit (JS polyfill event + native event):

```ts
if ((params.initiator as Record<string, unknown> | undefined)?.stack) return;
```

On the modern fusebox inspector (RN 0.76+) there is only **one** `requestWillBeSent` per request and it **carries a JS stack** (UUID `requestId`); the `responseReceived` / `loadingFinished` events reference that same id. So the guard discards every request and `get_network_requests` is always empty. See #64 for raw CDP event counts (52 requestWillBeSent / 52 responseReceived / 52 loadingFinished, all stack-bearing, all dropped).

## Fix

Only treat a stack-bearing event as a droppable duplicate once we've actually observed a native (stackless) event — i.e. we know this runtime double-emits. Otherwise keep it, since it's the only event we'll get:

```ts
let sawNativeRequest = false;
ctx.cdp.on('Network.requestWillBeSent', (params) => {
  const hasStack = !!(params.initiator as Record<string, unknown> | undefined)?.stack;
  if (!hasStack) {
    sawNativeRequest = true;
  } else if (sawNativeRequest) {
    return;
  }
  // ... capture
});
```

This preserves the legacy dedup where a native twin exists, while capturing traffic on runtimes that emit only the stack-bearing event.

## Tests

Added two regression tests in `network.test.ts`:
- captures a stack-bearing request when no native twin is emitted (modern fusebox)
- still drops the JS-layer duplicate when a native twin is also emitted (legacy)

`bun test` — 20 pass / 0 fail. `tsc --noEmit` clean.

## Verified

Built the patched server and ran it against a live RN 0.86 app: `get_network_requests` went from `0 requests` to 36+ real requests (GraphQL POSTs, SSE, images, analytics) with full headers, status, and timing.

## Note

The legacy double-emit path is inferred from the existing code comment (I don't have an older-RN runtime to reproduce it). Worst case on a legacy runtime is a single duplicate for the very first request if the JS-layer event arrives before the first native event; happy to gate on RN version instead if you'd prefer.