### PR TITLE
Implement protocol v2 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If you want to expose one long-lived MCP endpoint yourself, start the shared ser
 npx -y metro-mcp serve --mcp-port 8765
 ```
 
-This serves Streamable HTTP at `http://127.0.0.1:8765/mcp` and legacy SSE at `http://127.0.0.1:8765/sse`. Tools such as [`supergateway`](https://github.com/supercorp-ai/supergateway) can point at the Streamable HTTP endpoint instead of launching a fresh stdio process per request.
+This serves Streamable HTTP at `http://127.0.0.1:8765/mcp`. The endpoint supports both the 2025-era MCP handshake and the 2026-07-28 negotiation; `/sse` and `/messages` are intentionally unavailable. Tools such as [`supergateway`](https://github.com/supercorp-ai/supergateway) can point at the Streamable HTTP endpoint instead of launching a fresh stdio process per request.
 
 ### With custom Metro port
 
@@ -160,7 +160,7 @@ For OpenCode, add the port to the command array:
 - **Node.js** 18+ or **Bun** 1.0+
 - **iOS**: Xcode 14+ with Simulator (`xcrun simctl` is used for most operations)
 - **Android**: Android SDK with `adb` on your PATH
-- **IDB** *(optional)*: Some iOS operations fall back to [IDB (idb-companion)](https://github.com/facebook/idb) — install with `brew install idb-companion`. Tools will tell you when IDB is needed.
+- **IDB** _(optional)_: Some iOS operations fall back to [IDB (idb-companion)](https://github.com/facebook/idb) — install with `brew install idb-companion`. Tools will tell you when IDB is needed.
 
 ---
 
@@ -179,33 +179,33 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 
 ## Features
 
-| Plugin | Tools | Description |
-|--------|-------|-------------|
-| **console** | 2 | Console log collection with filtering |
-| **network** | 6 | Network request tracking, response body inspection, and stats |
-| **errors** | 3 | Runtime exception collection + Metro bundle error detection |
-| **evaluate** | 1 | Execute JavaScript in the app runtime |
-| **device** | 4 | Device management, connection status, and app reload |
-| **environment** | 4 | Build flags, platform constants, env vars, and Expo config inspection |
-| **source** | 1 | Stack trace symbolication |
-| **redux** | 3 | Redux state inspection and action dispatch |
-| **components** | 5 | React component tree inspection |
-| **storage** | 3 | AsyncStorage reading |
-| **simulator** | 6 | iOS simulator / Android device control |
-| **deeplink** | 2 | Cross-platform deep link testing |
-| **permissions** | 5 | Inspect and manage app permissions on iOS Simulator and Android Emulator |
-| **ui-interact** | 6 | UI automation (tap, swipe, type) |
-| **navigation** | 4 | React Navigation / Expo Router state |
-| **accessibility** | 3 | Accessibility auditing |
-| **commands** | 2 | Custom app commands |
-| **automation** | 3 | Wait/polling helpers for async state changes |
-| **profiler** | 9 | CPU profiling (React DevTools hook) + heap sampling + render tracking |
-| **test-recorder** | 7 | Record interactions and generate Appium, Maestro, or Detox tests |
-| **filesystem** | 5 | Browse and read files in app sandbox directories (Documents, caches, SQLite DBs) |
-| **devtools** | 1 | Open Chrome DevTools alongside the MCP via CDP proxy |
-| **debug-globals** | 1 | Auto-discover Redux stores, Apollo Client, and other debug globals |
-| **inspect-point** | 1 | Coordinate-based React component inspection (experimental) |
-| **statusline** | 1 | Claude Code status bar integration |
+| Plugin            | Tools | Description                                                                      |
+| ----------------- | ----- | -------------------------------------------------------------------------------- |
+| **console**       | 2     | Console log collection with filtering                                            |
+| **network**       | 6     | Network request tracking, response body inspection, and stats                    |
+| **errors**        | 3     | Runtime exception collection + Metro bundle error detection                      |
+| **evaluate**      | 1     | Execute JavaScript in the app runtime                                            |
+| **device**        | 4     | Device management, connection status, and app reload                             |
+| **environment**   | 4     | Build flags, platform constants, env vars, and Expo config inspection            |
+| **source**        | 1     | Stack trace symbolication                                                        |
+| **redux**         | 3     | Redux state inspection and action dispatch                                       |
+| **components**    | 5     | React component tree inspection                                                  |
+| **storage**       | 3     | AsyncStorage reading                                                             |
+| **simulator**     | 6     | iOS simulator / Android device control                                           |
+| **deeplink**      | 2     | Cross-platform deep link testing                                                 |
+| **permissions**   | 5     | Inspect and manage app permissions on iOS Simulator and Android Emulator         |
+| **ui-interact**   | 6     | UI automation (tap, swipe, type)                                                 |
+| **navigation**    | 4     | React Navigation / Expo Router state                                             |
+| **accessibility** | 3     | Accessibility auditing                                                           |
+| **commands**      | 2     | Custom app commands                                                              |
+| **automation**    | 3     | Wait/polling helpers for async state changes                                     |
+| **profiler**      | 9     | CPU profiling (React DevTools hook) + heap sampling + render tracking            |
+| **test-recorder** | 7     | Record interactions and generate Appium, Maestro, or Detox tests                 |
+| **filesystem**    | 5     | Browse and read files in app sandbox directories (Documents, caches, SQLite DBs) |
+| **devtools**      | 1     | Open Chrome DevTools alongside the MCP via CDP proxy                             |
+| **debug-globals** | 1     | Auto-discover Redux stores, Apollo Client, and other debug globals               |
+| **inspect-point** | 1     | Coordinate-based React component inspection (experimental)                       |
+| **statusline**    | 1     | Claude Code status bar integration                                               |
 
 → See the [full tools reference](docs/tools.md).
 
@@ -225,11 +225,11 @@ The tool automatically finds Chrome or Edge using the same detection as Metro an
 
 ### What to avoid
 
-| Method | What happens |
-|--------|-------------|
-| Pressing **"j"** in Metro terminal | Disconnects the MCP |
-| **"Open Debugger"** in the dev menu | Disconnects the MCP |
-| `open_devtools` MCP tool | Works alongside the MCP |
+| Method                              | What happens            |
+| ----------------------------------- | ----------------------- |
+| Pressing **"j"** in Metro terminal  | Disconnects the MCP     |
+| **"Open Debugger"** in the dev menu | Disconnects the MCP     |
+| `open_devtools` MCP tool            | Works alongside the MCP |
 
 ### Configuration
 
@@ -257,11 +257,11 @@ Run `setup_statusline` in Claude Code — it writes a script to `~/.claude/metro
 
 The status bar segment shows three states:
 
-| State | Display |
-|-------|---------|
-| Not running | `Metro ○` (dimmed) |
-| Running, not connected | `Metro ●` (red) |
-| Connected | `Metro ● localhost:8081` (green) |
+| State                  | Display                          |
+| ---------------------- | -------------------------------- |
+| Not running            | `Metro ○` (dimmed)               |
+| Running, not connected | `Metro ●` (red)                  |
+| Connected              | `Metro ● localhost:8081` (green) |
 
 ---
 
@@ -273,7 +273,7 @@ Record real user interactions (taps, text entry, scrolls) and generate productio
 
 Describe a flow and the AI navigates the app, then generates the test:
 
-> *"Write an Appium test for the guest checkout flow — start by tapping 'Start Shopping' on the welcome screen and end when the cart screen is visible."*
+> _"Write an Appium test for the guest checkout flow — start by tapping 'Start Shopping' on the welcome screen and end when the cart screen is visible."_
 
 The AI calls `start_test_recording`, navigates using `tap_element`/`type_text`/`swipe`, then generates a complete test with real selectors observed from the fiber tree.
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,13 +6,14 @@
       "name": "metro-mcp",
       "dependencies": {
         "@clack/prompts": "^1.2.0",
-        "@modelcontextprotocol/ext-apps": "^1.7.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/client": "^2.0.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
         "metro-bridge": "^0.2.8",
         "ws": "^8.20.0",
-        "zod": "^4.0.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.2.10",
@@ -132,9 +133,13 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.7.1", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-J3WdG1A4JSSKnSWKyU+895dBVYBV2Utgtf7fUsUK45mlkETm53a/1DR6Pm3hUGKqLLQthZLmpxOg8VPzJi/lyg=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/node": ["@modelcontextprotocol/node@2.0.0", "", { "dependencies": { "@hono/node-server": "^1.19.9" }, "peerDependencies": { "@modelcontextprotocol/server": "^2.0.0", "hono": "^4.11.4" }, "optionalPeers": ["hono"] }, "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
 
@@ -202,8 +207,6 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -262,25 +265,11 @@
 
     "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
     "algoliasearch": ["algoliasearch@5.50.0", "", { "dependencies": { "@algolia/abtesting": "1.16.0", "@algolia/client-abtesting": "5.50.0", "@algolia/client-analytics": "5.50.0", "@algolia/client-common": "5.50.0", "@algolia/client-insights": "5.50.0", "@algolia/client-personalization": "5.50.0", "@algolia/client-query-suggestions": "5.50.0", "@algolia/client-search": "5.50.0", "@algolia/ingestion": "1.50.0", "@algolia/monitoring": "1.50.0", "@algolia/recommend": "5.50.0", "@algolia/requester-browser-xhr": "5.50.0", "@algolia/requester-fetch": "5.50.0", "@algolia/requester-node-http": "5.50.0" } }, "sha512-yE5I83Q2s8euVou8Y3feXK08wyZInJWLYXgWO6Xti9jBUEZAGUahyeQ7wSZWkifLWVnQVKEz5RAmBlXG5nqxog=="],
 
     "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
-
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -294,17 +283,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -312,77 +291,33 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
     "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
-
-    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
-
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
-
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
-
-    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@1.2.1", "", {}, "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow=="],
 
     "fast-string-width": ["fast-string-width@1.1.0", "", { "dependencies": { "fast-string-truncated-width": "^1.2.0" } }, "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
-
     "fast-wrap-ansi": ["fast-wrap-ansi@0.1.6", "", { "dependencies": { "fast-string-width": "^1.1.0" } }, "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w=="],
-
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
 
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
-
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
@@ -394,19 +329,7 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
-
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 
@@ -416,10 +339,6 @@
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
-
     "lighthouse-logger": ["lighthouse-logger@2.0.2", "", { "dependencies": { "debug": "^4.4.1", "marky": "^1.2.2" } }, "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -428,13 +347,7 @@
 
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
-
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "metro-bridge": ["metro-bridge@0.2.8", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-yZZQ63Bid+FJwg9cE1Y/AflpFc8TeU9s7HO88wjiayuq8cGfc4LnZpsrwA759vLFR2R7zjcvaMc01k7RC25L5w=="],
 
@@ -448,10 +361,6 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
@@ -462,23 +371,9 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
     "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
 
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-to-regexp": ["path-to-regexp@8.4.0", "", {}, "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="],
 
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
@@ -492,51 +387,23 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
-
-    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
-
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
-
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
-
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
-
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -546,19 +413,13 @@
 
     "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
 
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
-
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -574,10 +435,6 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
-
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -590,13 +447,9 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,6 +13,7 @@ bunx metro-mcp create-plugin
 ```
 
 Prompts for:
+
 - **Plugin name suffix** — becomes the directory and package name (`metro-mcp-plugin-<name>`)
 - **Description** — optional
 - **Author** — defaults to `git config user.name`
@@ -48,12 +49,12 @@ bunx metro-mcp doctor
 
 Runs the following checks and reports pass/fail for each:
 
-| Check | Details |
-|---|---|
-| Node.js version | Must be >=18 |
-| Config file | Looks for `metro-mcp.config.ts` or `.js` in the current directory |
+| Check              | Details                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| Node.js version    | Must be >=18                                                                                                         |
+| Config file        | Looks for `metro-mcp.config.ts` or `.js` in the current directory                                                    |
 | Metro connectivity | Uses `metro-bridge` status discovery for the configured host:port, including the `localhost` to `127.0.0.1` fallback |
-| Plugin paths | Verifies local plugin file paths from your config exist on disk |
+| Plugin paths       | Verifies local plugin file paths from your config exist on disk                                                      |
 
 Exit code is `0` if all checks pass, `1` if any fail.
 
@@ -75,6 +76,7 @@ bunx metro-mcp validate-plugin ./node_modules/metro-mcp-plugin-mmkv/dist/index.j
 ```
 
 Checks that the file:
+
 1. Exists and can be imported
 2. Exports an object (as default or named export) with a `name` string and a `setup` function
 
@@ -96,15 +98,16 @@ To run the shared HTTP server in the foreground:
 bunx metro-mcp serve --mcp-port 8765
 ```
 
-| Flag | Description |
-|---|---|
-| `--host`, `-H <host>` | Metro bundler host (default: `localhost`) |
-| `--port`, `-p <port>` | Metro bundler port (default: `8081`) |
-| `--config`, `-c <path>` | Path to a config file (absolute or relative to CWD) |
-| `--plugin <path>` | Load a plugin by path — repeatable |
-| `--mcp-port <port>` | Port for `serve` mode (default: random, env: `METRO_MCP_MCP_PORT`) |
-| `--stdio-direct` | Disable multiplexing and run the legacy single-process stdio server |
-| `--help` | Print usage |
+| Flag                    | Description                                                         |
+| ----------------------- | ------------------------------------------------------------------- |
+| `--host`, `-H <host>`   | Metro bundler host (default: `localhost`)                           |
+| `--port`, `-p <port>`   | Metro bundler port (default: `8081`)                                |
+| `--config`, `-c <path>` | Path to a config file (absolute or relative to CWD)                 |
+| `--plugin <path>`       | Load a plugin by path — repeatable                                  |
+| `--project-root <path>` | Project root for config discovery, plugins, and daemon identity     |
+| `--mcp-port <port>`     | Port for `serve` mode (default: random, env: `METRO_MCP_MCP_PORT`)  |
+| `--stdio-direct`        | Disable multiplexing and run the legacy single-process stdio server |
+| `--help`                | Print usage                                                         |
 
 **Examples:**
 
@@ -134,12 +137,13 @@ See [Configuration](/configuration#environment-variables) for the full list of e
 
 Key ones at a glance:
 
-| Variable | Description |
-|---|---|
-| `METRO_HOST` | Metro bundler host |
-| `METRO_PORT` | Metro bundler port |
-| `METRO_MCP_CONFIG` | Path to config file |
-| `METRO_MCP_PLUGINS` | Colon-separated plugin paths |
-| `METRO_MCP_MCP_PORT` | Port for `serve` mode |
-| `METRO_MCP_MULTIPLEX` | Set to `false` to disable the stdio daemon/proxy |
-| `DEBUG` | Enable debug logging |
+| Variable                 | Description                                      |
+| ------------------------ | ------------------------------------------------ |
+| `METRO_HOST`             | Metro bundler host                               |
+| `METRO_PORT`             | Metro bundler port                               |
+| `METRO_MCP_CONFIG`       | Path to config file                              |
+| `METRO_MCP_PLUGINS`      | Colon-separated plugin paths                     |
+| `METRO_MCP_PROJECT_ROOT` | Project root                                     |
+| `METRO_MCP_MCP_PORT`     | Port for `serve` mode                            |
+| `METRO_MCP_MULTIPLEX`    | Set to `false` to disable the stdio daemon/proxy |
+| `DEBUG`                  | Enable debug logging                             |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,17 +2,18 @@
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `METRO_HOST` | `localhost` | Metro bundler host |
-| `METRO_PORT` | `8081` | Metro bundler port |
-| `METRO_MCP_CONFIG` | — | Path to config file (absolute or relative to CWD) |
-| `METRO_MCP_PLUGINS` | — | Colon-separated plugin paths to load (e.g. `./my-plugin.ts:metro-mcp-plugin-foo`) |
-| `METRO_MCP_PROXY_ENABLED` | `true` | Enable the CDP proxy for Chrome DevTools coexistence |
-| `METRO_MCP_PROXY_PORT` | `0` (random) | Fixed port for the CDP proxy. Use `0` for a random available port |
-| `METRO_MCP_MCP_PORT` | `0` (random) | Fixed port for `metro-mcp serve` Streamable HTTP/SSE endpoint |
-| `METRO_MCP_MULTIPLEX` | `true` | Set to `false` to run the legacy single-process stdio server |
-| `DEBUG` | — | Enable debug logging |
+| Variable                  | Default           | Description                                                                         |
+| ------------------------- | ----------------- | ----------------------------------------------------------------------------------- |
+| `METRO_HOST`              | `localhost`       | Metro bundler host                                                                  |
+| `METRO_PORT`              | `8081`            | Metro bundler port                                                                  |
+| `METRO_MCP_PROJECT_ROOT`  | canonicalized CWD | Project directory used for config discovery, relative paths, and daemon identity    |
+| `METRO_MCP_CONFIG`        | —                 | Path to config file (absolute or relative to the project root)                      |
+| `METRO_MCP_PLUGINS`       | —                 | Colon-separated plugin paths to load (relative paths resolve from the project root) |
+| `METRO_MCP_PROXY_ENABLED` | `true`            | Enable the CDP proxy for Chrome DevTools coexistence                                |
+| `METRO_MCP_PROXY_PORT`    | `0` (random)      | Fixed port for the CDP proxy. Use `0` for a random available port                   |
+| `METRO_MCP_MCP_PORT`      | `0` (random)      | Fixed port for `metro-mcp serve` Streamable HTTP endpoint                           |
+| `METRO_MCP_MULTIPLEX`     | `true`            | Set to `false` to run the legacy single-process stdio server                        |
+| `DEBUG`                   | —                 | Enable debug logging                                                                |
 
 ## CLI Arguments
 
@@ -22,14 +23,15 @@ npx -y metro-mcp --host 192.168.1.100 --port 19000
 bunx metro-mcp --host 192.168.1.100 --port 19000
 ```
 
-| Argument | Description |
-|----------|-------------|
-| `--host`, `-H` | Metro bundler host |
-| `--port`, `-p` | Metro bundler port |
-| `--config`, `-c` | Path to config file (overrides `METRO_MCP_CONFIG`) |
-| `--plugin` | Load a plugin by path (repeatable) |
-| `--mcp-port` | Port for `metro-mcp serve` |
-| `--stdio-direct` | Disable stdio multiplexing for this process |
+| Argument         | Description                                            |
+| ---------------- | ------------------------------------------------------ |
+| `--host`, `-H`   | Metro bundler host                                     |
+| `--port`, `-p`   | Metro bundler port                                     |
+| `--config`, `-c` | Path to config file (overrides `METRO_MCP_CONFIG`)     |
+| `--plugin`       | Load a plugin by path (repeatable)                     |
+| `--project-root` | Project directory (overrides `METRO_MCP_PROJECT_ROOT`) |
+| `--mcp-port`     | Port for `metro-mcp serve`                             |
+| `--stdio-direct` | Disable stdio multiplexing for this process            |
 
 ## Multi-client and HTTP mode
 
@@ -52,25 +54,25 @@ Each stdio process connects to a shared local daemon when the project directory 
 npx -y metro-mcp serve --mcp-port 8765
 ```
 
-Streamable HTTP is available at `http://127.0.0.1:8765/mcp`; legacy SSE is available at `http://127.0.0.1:8765/sse`.
+Streamable HTTP is available at `http://127.0.0.1:8765/mcp` for both supported client eras. `/sse` and `/messages` return `404`.
 
 ## Config File
 
-metro-mcp looks for `metro-mcp.config.ts` (or `.js`) in your project root. In **Claude Code, Cursor, and VS Code**, the project root is discovered automatically via MCP roots — no path configuration needed.
+metro-mcp looks for `metro-mcp.config.ts` (or `.js`) in the effective project root. The root is selected in this order: `--project-root`, `METRO_MCP_PROJECT_ROOT`, then the canonicalized launch CWD. A daemon is always bound to one project root; changing projects requires a new launch/reconnection.
 
 ::: tip TypeScript vs JavaScript
 `metro-mcp.config.ts` only works when running via `bunx` (Bun runtime). Use `metro-mcp.config.js` if running via `npx` / Node.js.
 :::
 
-If your client doesn't support MCP roots, or you want to point at a config in a non-standard location, pass the path explicitly:
+To use a project from another working directory, set the project root explicitly:
 
 ```json
 {
   "mcpServers": {
     "metro-mcp": {
       "command": "bunx",
-      "args": ["metro-mcp"],
-      "env": { "METRO_MCP_CONFIG": "/Users/you/my-project/metro-mcp.config.ts" }
+      "args": ["metro-mcp", "--project-root", "/Users/you/my-project"],
+      "env": {}
     }
   }
 }
@@ -79,14 +81,14 @@ If your client doesn't support MCP roots, or you want to point at a config in a 
 Or via CLI:
 
 ```bash
-claude mcp add metro-mcp -- bunx metro-mcp --config /Users/you/my-project/metro-mcp.config.ts
+claude mcp add metro-mcp -- bunx metro-mcp --project-root /Users/you/my-project
 ```
 
 Run with `DEBUG=1` to see exactly where the server is looking for config:
 
 ```bash
 DEBUG=1 bunx metro-mcp
-# logs: Config search CWD: /some/path
+# logs: Project root: /some/path
 # logs: Loaded config from /full/path/metro-mcp.config.ts
 ```
 
@@ -99,7 +101,7 @@ export default defineConfig({
   metro: {
     host: 'localhost',
     port: 8081,
-    autoDiscover: true,  // Scan common ports automatically
+    autoDiscover: true, // Scan common ports automatically
   },
   plugins: [],
   bufferSizes: {
@@ -108,14 +110,14 @@ export default defineConfig({
     errors: 100,
   },
   network: {
-    interceptFetch: false,  // Opt-in: inject JS to wrap fetch()
+    interceptFetch: false, // Opt-in: inject JS to wrap fetch()
   },
   proxy: {
-    enabled: true,   // CDP proxy for Chrome DevTools coexistence
-    port: 0,         // 0 = random available port
+    enabled: true, // CDP proxy for Chrome DevTools coexistence
+    port: 0, // 0 = random available port
   },
   profiler: {
-    newArchitecture: true,  // Set to false for legacy bridge apps
+    newArchitecture: true, // Set to false for legacy bridge apps
   },
 });
 ```
@@ -124,18 +126,18 @@ export default defineConfig({
 
 The CDP proxy allows Chrome DevTools to connect alongside the MCP, working around Hermes's single-connection limitation. See the [Chrome DevTools](/guide/getting-started#chrome-devtools) section for details.
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `proxy.enabled` | `true` | Enable the CDP proxy server. When enabled, external debuggers (Chrome DevTools, etc.) can connect to the proxy port and share the Hermes connection with the MCP. |
-| `proxy.port` | `0` | Port for the proxy's WebSocket + HTTP server. `0` picks a random available port. Set a fixed port if you need a stable URL. |
+| Option          | Default | Description                                                                                                                                                       |
+| --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy.enabled` | `true`  | Enable the CDP proxy server. When enabled, external debuggers (Chrome DevTools, etc.) can connect to the proxy port and share the Hermes connection with the MCP. |
+| `proxy.port`    | `0`     | Port for the proxy's WebSocket + HTTP server. `0` picks a random available port. Set a fixed port if you need a stable URL.                                       |
 
 The proxy also serves a `/json` endpoint for Chrome's target auto-discovery and a `/json/version` endpoint.
 
 ## Profiler Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `profiler.newArchitecture` | `true` | Controls which profiling path is used. When `true` (default), `__REACT_DEVTOOLS_GLOBAL_HOOK__` is used as the primary path — works on all architectures including Bridgeless/Fusebox. When `false`, CDP `Profiler.*` domain calls are attempted first (suitable for legacy bridge apps). |
+| Option                     | Default | Description                                                                                                                                                                                                                                                                              |
+| -------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `profiler.newArchitecture` | `true`  | Controls which profiling path is used. When `true` (default), `__REACT_DEVTOOLS_GLOBAL_HOOK__` is used as the primary path — works on all architectures including Bridgeless/Fusebox. When `false`, CDP `Profiler.*` domain calls are attempted first (suitable for legacy bridge apps). |
 
 ### Which value should I use?
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ Works with **Expo**, **bare React Native**, and any project using **Metro + Herm
 - **Node.js** 18+ or **Bun** 1.0+
 - **iOS**: Xcode 14+ with Simulator (`xcrun simctl` is used for most operations)
 - **Android**: Android SDK with `adb` on your PATH
-- **IDB** *(optional)*: Some iOS operations fall back to [IDB (idb-companion)](https://github.com/facebook/idb) — install with `brew install idb-companion`. Tools will tell you when IDB is needed.
+- **IDB** _(optional)_: Some iOS operations fall back to [IDB (idb-companion)](https://github.com/facebook/idb) — install with `brew install idb-companion`. Tools will tell you when IDB is needed.
 
 ## Installation
 
@@ -105,17 +105,17 @@ npx add-mcp metro-mcp --all -g -y
 
 ### With a config file
 
-In Claude Code, Cursor, VS Code, and OpenCode, metro-mcp automatically discovers `metro-mcp.config.ts` (or `.js`) from your project root — no extra configuration needed. Just add the file and it will be picked up.
+metro-mcp automatically discovers `metro-mcp.config.ts` (or `.js`) from the effective project root. The root is `--project-root`, then `METRO_MCP_PROJECT_ROOT`, then the canonicalized working directory.
 
 ```bash
 # Install metro-mcp as usual
 claude mcp add metro-mcp -- bunx metro-mcp
 ```
 
-If your client doesn't support MCP roots, pass the config path explicitly:
+To point the MCP server at a different project, pass the project root explicitly:
 
 ```bash
-claude mcp add metro-mcp -- bunx metro-mcp --config /Users/you/my-project/metro-mcp.config.ts
+claude mcp add metro-mcp -- bunx metro-mcp --project-root /Users/you/my-project
 ```
 
 See [Configuration](/configuration) for all options.
@@ -146,13 +146,13 @@ metro-mcp connects to your running Metro dev server the same way Chrome DevTools
 
 ## Compatibility
 
-| | Supported |
-|---|---|
-| **React Native** | 0.70+ (Hermes required) |
-| **Expo** | SDK 49+ |
-| **Node.js** | 18+ |
-| **Bun** | 1.0+ |
-| **Platforms** | iOS Simulator, Android Emulator, physical devices via USB |
+|                  | Supported                                                 |
+| ---------------- | --------------------------------------------------------- |
+| **React Native** | 0.70+ (Hermes required)                                   |
+| **Expo**         | SDK 49+                                                   |
+| **Node.js**      | 18+                                                       |
+| **Bun**          | 1.0+                                                      |
+| **Platforms**    | iOS Simulator, Android Emulator, physical devices via USB |
 
 ## Chrome DevTools
 
@@ -180,11 +180,11 @@ Run `setup_statusline` in Claude Code — it writes a script to `~/.claude/metro
 /statusline add the script at ~/.claude/metro-mcp-statusline.sh
 ```
 
-| State | Display |
-|-------|---------|
-| Not running | `Metro ○` (dimmed) |
-| Running, not connected | `Metro ●` (red) |
-| Connected | `Metro ● localhost:8081` (green) |
+| State                  | Display                          |
+| ---------------------- | -------------------------------- |
+| Not running            | `Metro ○` (dimmed)               |
+| Running, not connected | `Metro ●` (red)                  |
+| Connected              | `Metro ● localhost:8081` (green) |
 
 ## Next Steps
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-mcp",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "mcpName": "io.github.steve228uk/metro-mcp",
   "description": "Plugin-based MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
   "homepage": "https://metromcp.dev",
@@ -40,8 +40,8 @@
     "prepare": "bun run build",
     "build": "bun run build:apps && bun run clean && bun run build:js && bun run build:bin && bun run build:types",
     "build:apps": "bun run scripts/build-apps.ts",
-    "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/sdk --external @modelcontextprotocol/ext-apps --external zod --external ws && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/sdk --external @modelcontextprotocol/ext-apps --external zod",
-    "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target node --external @modelcontextprotocol/sdk --external @modelcontextprotocol/ext-apps --external zod --external ws && chmod +x dist/bin/metro-mcp.js",
+    "build:js": "bun build src/index.ts src/plugin.ts --outdir dist --target node --external @modelcontextprotocol/server --external @modelcontextprotocol/client --external @modelcontextprotocol/node --external zod --external ws && bun build src/plugin.ts --outfile dist/plugin.cjs --target node --format cjs --external @modelcontextprotocol/server --external @modelcontextprotocol/client --external @modelcontextprotocol/node --external zod",
+    "build:bin": "bun build bin/metro-mcp.ts --outfile dist/bin/metro-mcp.js --target node --external @modelcontextprotocol/server --external @modelcontextprotocol/client --external @modelcontextprotocol/node --external zod --external ws && chmod +x dist/bin/metro-mcp.js",
     "build:types": "bunx tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "docs:dev": "vitepress dev docs",
@@ -64,13 +64,14 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^1.2.0",
-    "@modelcontextprotocol/ext-apps": "^1.7.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
     "metro-bridge": "^0.2.8",
     "ws": "^8.20.0",
-    "zod": "^4.0.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/bun": "^1.2.10",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.steve228uk/metro-mcp",
   "title": "Metro MCP",
   "description": "MCP server for React Native/Expo runtime debugging, inspection, and automation via Metro/CDP",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "repository": {
     "url": "https://github.com/steve228uk/metro-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "metro-mcp",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,9 +69,12 @@ function resolveConfigPath(value: string, projectRoot: string): string {
 function resolvePluginPath(value: string, projectRoot: string): string {
   if (
     isAbsolute(value) ||
-    value.startsWith('.') ||
-    value.includes('/') ||
-    value.includes('\\')
+    value === '.' ||
+    value === '..' ||
+    value.startsWith('./') ||
+    value.startsWith('../') ||
+    value.startsWith('.\\') ||
+    value.startsWith('..\\')
   ) {
     return resolve(projectRoot, value);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,12 @@
-import { resolve } from 'node:path';
+import fs from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
 import type { MetroMCPConfig } from './plugin.js';
 import { createLogger } from './utils/logger.js';
 
 const logger = createLogger('config');
 
 const DEFAULT_CONFIG: Required<MetroMCPConfig> = {
+  projectRoot: '',
   metro: {
     host: 'localhost',
     port: 8081,
@@ -25,46 +27,95 @@ const DEFAULT_CONFIG: Required<MetroMCPConfig> = {
   },
 };
 
+function valueAfter(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+/** Resolve and validate the one project this metro-mcp process serves. */
+export function resolveProjectRoot(
+  args: string[] = [],
+  baseDir = process.cwd(),
+): string {
+  const configured =
+    valueAfter(args, '--project-root') ?? process.env.METRO_MCP_PROJECT_ROOT;
+  const candidate = resolve(baseDir, configured ?? '.');
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(candidate);
+  } catch {
+    throw new Error(
+      `Invalid Metro MCP project root "${candidate}": the path does not exist. ` +
+        `Pass --project-root <directory> or set METRO_MCP_PROJECT_ROOT to an existing directory.`,
+    );
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(
+      `Invalid Metro MCP project root "${candidate}": the path is not a directory. ` +
+        `Pass --project-root <directory> or set METRO_MCP_PROJECT_ROOT to a directory.`,
+    );
+  }
+
+  return fs.realpathSync(candidate);
+}
+
+function resolveConfigPath(value: string, projectRoot: string): string {
+  return fs.realpathSync(
+    isAbsolute(value) ? value : resolve(projectRoot, value),
+  );
+}
+
+function resolvePluginPath(value: string, projectRoot: string): string {
+  if (
+    isAbsolute(value) ||
+    value.startsWith('.') ||
+    value.includes('/') ||
+    value.includes('\\')
+  ) {
+    return resolve(projectRoot, value);
+  }
+  return value;
+}
+
 /**
  * Load configuration from environment variables, CLI args, and config file.
- * @param rootPath - Directory to search for a config file. Overrides CWD for
- *   auto-discovery but is ignored when an explicit --config / METRO_MCP_CONFIG path
- *   is provided.
+ * Relative config and local plugin paths are always rooted at the effective
+ * project root, never at the launcher's incidental working directory.
  */
-export async function loadConfig(args: string[], rootPath?: string): Promise<Required<MetroMCPConfig>> {
+export async function loadConfig(
+  args: string[],
+  rootPath?: string,
+): Promise<Required<MetroMCPConfig>> {
+  const projectRoot = resolveProjectRoot(args, rootPath ?? process.cwd());
   const config = structuredClone(DEFAULT_CONFIG);
+  config.projectRoot = projectRoot;
 
-  // Environment variables
-  if (process.env.METRO_HOST) {
-    config.metro.host = process.env.METRO_HOST;
-  }
+  if (process.env.METRO_HOST) config.metro.host = process.env.METRO_HOST;
   if (process.env.METRO_PORT) {
     const port = parseInt(process.env.METRO_PORT, 10);
-    if (!isNaN(port)) {
+    if (!Number.isNaN(port)) {
       config.metro.port = port;
       config.metro.autoDiscover = false;
     }
   }
-
   if (process.env.METRO_MCP_PROXY_PORT) {
     const port = parseInt(process.env.METRO_MCP_PROXY_PORT, 10);
-    if (!isNaN(port)) config.proxy.port = port;
+    if (!Number.isNaN(port)) config.proxy.port = port;
   }
-  if (process.env.METRO_MCP_PROXY_ENABLED === 'false') {
+  if (process.env.METRO_MCP_PROXY_ENABLED === 'false')
     config.proxy.enabled = false;
-  }
 
-  // CLI args
   let configFilePath: string | undefined;
   const extraPlugins: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if ((arg === '--host' || arg === '-h') && args[i + 1]) {
+    if ((arg === '--host' || arg === '-H') && args[i + 1]) {
       config.metro.host = args[++i];
     } else if ((arg === '--port' || arg === '-p') && args[i + 1]) {
       const port = parseInt(args[++i], 10);
-      if (!isNaN(port)) {
+      if (!Number.isNaN(port)) {
         config.metro.port = port;
         config.metro.autoDiscover = false;
       }
@@ -75,21 +126,18 @@ export async function loadConfig(args: string[], rootPath?: string): Promise<Req
     }
   }
 
-  // Env var fallbacks (CLI flags take precedence)
-  if (!configFilePath && process.env.METRO_MCP_CONFIG) {
+  if (!configFilePath && process.env.METRO_MCP_CONFIG)
     configFilePath = process.env.METRO_MCP_CONFIG;
-  }
   if (process.env.METRO_MCP_PLUGINS) {
-    extraPlugins.push(...process.env.METRO_MCP_PLUGINS.split(':').filter(Boolean));
+    extraPlugins.push(
+      ...process.env.METRO_MCP_PLUGINS.split(':').filter(Boolean),
+    );
   }
 
-  // Load config file
-  const cwd = rootPath ?? process.cwd();
-  logger.debug(`Config search CWD: ${cwd}`);
+  logger.debug(`Project root: ${projectRoot}`);
 
   if (configFilePath) {
-    // Explicit path — throw on failure (user asserted this file exists)
-    const fullPath = resolve(cwd, configFilePath);
+    const fullPath = resolveConfigPath(configFilePath, projectRoot);
     try {
       const mod = await import(fullPath);
       const fileConfig: MetroMCPConfig = mod.default || mod;
@@ -99,51 +147,60 @@ export async function loadConfig(args: string[], rootPath?: string): Promise<Req
       throw new Error(`Failed to load config from ${fullPath}: ${err}`);
     }
   } else {
-    // Auto-discover from CWD
-    // Note: .ts files only load under Bun runtime; use .js with npx/Node.js
-    const configPaths = ['metro-mcp.config.ts', 'metro-mcp.config.js'];
-    for (const configPath of configPaths) {
+    for (const configPath of ['metro-mcp.config.ts', 'metro-mcp.config.js']) {
+      const fullPath = resolve(projectRoot, configPath);
+      if (!fs.existsSync(fullPath)) continue;
       try {
-        const fullPath = resolve(cwd, configPath);
         const mod = await import(fullPath);
         const fileConfig: MetroMCPConfig = mod.default || mod;
         mergeConfig(config, fileConfig);
         logger.info(`Loaded config from ${fullPath}`);
         break;
-      } catch {
-        // Config file not found or invalid, continue
+      } catch (err) {
+        throw new Error(`Failed to load config from ${fullPath}: ${err}`);
       }
     }
   }
 
-  // Append any plugins from CLI/env (additive — supplements config file plugins)
-  if (extraPlugins.length > 0) {
-    config.plugins = [...config.plugins, ...extraPlugins];
-  }
-
+  config.projectRoot = projectRoot;
+  config.plugins = [...config.plugins, ...extraPlugins].map((plugin) =>
+    resolvePluginPath(plugin, projectRoot),
+  );
   return config;
 }
 
-function mergeConfig(target: Required<MetroMCPConfig>, source: MetroMCPConfig): void {
+function mergeConfig(
+  target: Required<MetroMCPConfig>,
+  source: MetroMCPConfig,
+): void {
+  if (source.projectRoot !== undefined) {
+    throw new Error(
+      'projectRoot is controlled by --project-root or METRO_MCP_PROJECT_ROOT and cannot be set in a config file',
+    );
+  }
   if (source.metro) {
     if (source.metro.host !== undefined) target.metro.host = source.metro.host;
     if (source.metro.port !== undefined) {
       target.metro.port = source.metro.port;
       target.metro.autoDiscover = false;
     }
-    if (source.metro.autoDiscover !== undefined) target.metro.autoDiscover = source.metro.autoDiscover;
+    if (source.metro.autoDiscover !== undefined)
+      target.metro.autoDiscover = source.metro.autoDiscover;
   }
   if (source.plugins) target.plugins = source.plugins;
   if (source.bufferSizes) {
-    if (source.bufferSizes.logs !== undefined) target.bufferSizes.logs = source.bufferSizes.logs;
-    if (source.bufferSizes.network !== undefined) target.bufferSizes.network = source.bufferSizes.network;
-    if (source.bufferSizes.errors !== undefined) target.bufferSizes.errors = source.bufferSizes.errors;
+    if (source.bufferSizes.logs !== undefined)
+      target.bufferSizes.logs = source.bufferSizes.logs;
+    if (source.bufferSizes.network !== undefined)
+      target.bufferSizes.network = source.bufferSizes.network;
+    if (source.bufferSizes.errors !== undefined)
+      target.bufferSizes.errors = source.bufferSizes.errors;
   }
-  if (source.profiler) {
-    if (source.profiler.newArchitecture !== undefined) target.profiler.newArchitecture = source.profiler.newArchitecture;
-  }
+  if (source.profiler?.newArchitecture !== undefined)
+    target.profiler.newArchitecture = source.profiler.newArchitecture;
   if (source.proxy) {
-    if (source.proxy.enabled !== undefined) target.proxy.enabled = source.proxy.enabled;
+    if (source.proxy.enabled !== undefined)
+      target.proxy.enabled = source.proxy.enabled;
     if (source.proxy.port !== undefined) target.proxy.port = source.proxy.port;
   }
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,11 +3,12 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { JSONRPCMessage } from '@modelcontextprotocol/client';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import { createLogger } from './utils/logger.js';
 import { version } from './version.js';
+import { resolveProjectRoot } from './config.js';
 
 const logger = createLogger('daemon');
 
@@ -21,6 +22,7 @@ const DAEMON_ENV_KEYS = [
   'METRO_PORT',
   'METRO_MCP_CONFIG',
   'METRO_MCP_PLUGINS',
+  'METRO_MCP_PROJECT_ROOT',
   'METRO_MCP_PROXY_PORT',
   'METRO_MCP_PROXY_ENABLED',
 ] as const;
@@ -28,6 +30,7 @@ const DAEMON_ENV_KEYS = [
 export interface DaemonIdentity {
   version: string;
   cwd: string;
+  projectRoot: string;
   args: string[];
   env: Record<string, string | undefined>;
   entrypoint: string;
@@ -81,10 +84,14 @@ function getConfigDir(): string {
   return process.env[DAEMON_CONFIG_DIR_ENV] || DEFAULT_CONFIG_DIR;
 }
 
-export function createDaemonIdentity(args: string[], overrides: Partial<DaemonIdentity> = {}): DaemonIdentity {
+export function createDaemonIdentity(
+  args: string[],
+  overrides: Partial<DaemonIdentity> = {},
+): DaemonIdentity {
   return {
     version: overrides.version ?? version,
     cwd: overrides.cwd ?? getDaemonCwd(),
+    projectRoot: overrides.projectRoot ?? getDaemonCwd(),
     args: overrides.args ?? [...args],
     env: overrides.env ?? selectedEnv(),
     entrypoint: overrides.entrypoint ?? resolvePath(process.argv[1]),
@@ -92,7 +99,10 @@ export function createDaemonIdentity(args: string[], overrides: Partial<DaemonId
   };
 }
 
-export function getDaemonKey(args: string[], identity = createDaemonIdentity(args)): string {
+export function getDaemonKey(
+  args: string[],
+  identity = createDaemonIdentity(args),
+): string {
   const hash = createHash('sha256');
   hash.update(JSON.stringify(identity));
   return hash.digest('hex').slice(0, 16);
@@ -116,7 +126,10 @@ function getDaemonLockPath(key: string): string {
 
 export function writeDaemonRecord(record: DaemonRecord): void {
   fs.mkdirSync(getConfigDir(), { recursive: true });
-  fs.writeFileSync(getDaemonRecordPath(record.key), JSON.stringify(record, null, 2));
+  fs.writeFileSync(
+    getDaemonRecordPath(record.key),
+    JSON.stringify(record, null, 2),
+  );
 }
 
 function removeDaemonRecord(key: string): void {
@@ -129,7 +142,9 @@ function removeDaemonRecord(key: string): void {
 
 export function removeDaemonRecordForProcess(key: string, pid: number): void {
   try {
-    const record = JSON.parse(fs.readFileSync(getDaemonRecordPath(key), 'utf8')) as DaemonRecord;
+    const record = JSON.parse(
+      fs.readFileSync(getDaemonRecordPath(key), 'utf8'),
+    ) as DaemonRecord;
     if (record.pid !== pid) return;
     removeDaemonRecord(key);
   } catch {
@@ -137,19 +152,27 @@ export function removeDaemonRecordForProcess(key: string, pid: number): void {
   }
 }
 
-function identityMatches(actual: DaemonIdentity | undefined, expected: DaemonIdentity): boolean {
+function identityMatches(
+  actual: DaemonIdentity | undefined,
+  expected: DaemonIdentity,
+): boolean {
   if (!actual) return false;
   return JSON.stringify(actual) === JSON.stringify(expected);
 }
 
 async function readHealth(record: DaemonRecord): Promise<DaemonHealth | null> {
   const healthUrl = new URL('/health', record.url);
-  const response = await fetch(healthUrl, { signal: AbortSignal.timeout(1000) });
+  const response = await fetch(healthUrl, {
+    signal: AbortSignal.timeout(1000),
+  });
   if (!response.ok) return null;
-  return await response.json() as DaemonHealth;
+  return (await response.json()) as DaemonHealth;
 }
 
-async function isRecordLive(record: DaemonRecord, expectedIdentity?: DaemonIdentity): Promise<boolean> {
+async function isRecordLive(
+  record: DaemonRecord,
+  expectedIdentity?: DaemonIdentity,
+): Promise<boolean> {
   try {
     process.kill(record.pid, 0);
   } catch {
@@ -163,13 +186,18 @@ async function isRecordLive(record: DaemonRecord, expectedIdentity?: DaemonIdent
 
     if (health.version !== expectedIdentity.version) {
       logger.warn(
-        `Ignoring metro-mcp daemon ${record.url}: version ${health.version} does not match ${expectedIdentity.version}`
+        `Ignoring metro-mcp daemon ${record.url}: version ${health.version} does not match ${expectedIdentity.version}`,
       );
       return false;
     }
 
-    if (health.daemon?.key !== record.key || !identityMatches(health.daemon.identity, expectedIdentity)) {
-      logger.warn(`Ignoring metro-mcp daemon ${record.url}: daemon identity does not match current launch context`);
+    if (
+      health.daemon?.key !== record.key ||
+      !identityMatches(health.daemon.identity, expectedIdentity)
+    ) {
+      logger.warn(
+        `Ignoring metro-mcp daemon ${record.url}: daemon identity does not match current launch context`,
+      );
       return false;
     }
 
@@ -179,9 +207,14 @@ async function isRecordLive(record: DaemonRecord, expectedIdentity?: DaemonIdent
   }
 }
 
-export async function readLiveRecord(key: string, expectedIdentity?: DaemonIdentity): Promise<DaemonRecord | null> {
+export async function readLiveRecord(
+  key: string,
+  expectedIdentity?: DaemonIdentity,
+): Promise<DaemonRecord | null> {
   try {
-    const record = JSON.parse(fs.readFileSync(getDaemonRecordPath(key), 'utf8')) as DaemonRecord;
+    const record = JSON.parse(
+      fs.readFileSync(getDaemonRecordPath(key), 'utf8'),
+    ) as DaemonRecord;
     if (await isRecordLive(record, expectedIdentity)) return record;
   } catch {
     // Missing or corrupt record.
@@ -190,7 +223,10 @@ export async function readLiveRecord(key: string, expectedIdentity?: DaemonIdent
   return null;
 }
 
-async function waitForRecord(key: string, expectedIdentity: DaemonIdentity): Promise<DaemonRecord> {
+async function waitForRecord(
+  key: string,
+  expectedIdentity: DaemonIdentity,
+): Promise<DaemonRecord> {
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     const record = await readLiveRecord(key, expectedIdentity);
@@ -200,7 +236,10 @@ async function waitForRecord(key: string, expectedIdentity: DaemonIdentity): Pro
   throw new Error('Timed out waiting for metro-mcp daemon to start');
 }
 
-async function withStartupLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+async function withStartupLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
   fs.mkdirSync(getConfigDir(), { recursive: true });
   const lockPath = getDaemonLockPath(key);
   const deadline = Date.now() + STARTUP_LOCK_TIMEOUT_MS;
@@ -209,7 +248,13 @@ async function withStartupLock<T>(key: string, fn: () => Promise<T>): Promise<T>
     let fd: number | null = null;
     try {
       fd = fs.openSync(lockPath, 'wx');
-      fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+      fs.writeFileSync(
+        fd,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+        }),
+      );
       return await fn();
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
@@ -225,8 +270,16 @@ async function withStartupLock<T>(key: string, fn: () => Promise<T>): Promise<T>
       await sleep(100);
     } finally {
       if (fd !== null) {
-        try { fs.closeSync(fd); } catch { /* ignore */ }
-        try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+        try {
+          fs.closeSync(fd);
+        } catch {
+          /* ignore */
+        }
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {
+          /* ignore */
+        }
       }
     }
   }
@@ -242,23 +295,29 @@ export async function cleanupStaleDaemonRecords(): Promise<void> {
     return;
   }
 
-  await Promise.all(entries.map(async (entry) => {
-    const match = /^daemon-([a-f0-9]+)\.json$/.exec(entry);
-    if (!match) return;
+  await Promise.all(
+    entries.map(async (entry) => {
+      const match = /^daemon-([a-f0-9]+)\.json$/.exec(entry);
+      if (!match) return;
 
-    const key = match[1];
-    try {
-      const record = JSON.parse(fs.readFileSync(getDaemonRecordPath(key), 'utf8')) as DaemonRecord;
-      if (await isRecordLive(record)) return;
-    } catch {
-      // Corrupt records are stale.
-    }
-    removeDaemonRecord(key);
-  }));
+      const key = match[1];
+      try {
+        const record = JSON.parse(
+          fs.readFileSync(getDaemonRecordPath(key), 'utf8'),
+        ) as DaemonRecord;
+        if (await isRecordLive(record)) return;
+      } catch {
+        // Corrupt records are stale.
+      }
+      removeDaemonRecord(key);
+    }),
+  );
 }
 
 async function ensureDaemon(args: string[]): Promise<DaemonRecord> {
-  const identity = createDaemonIdentity(args);
+  const identity = createDaemonIdentity(args, {
+    projectRoot: resolveProjectRoot(args),
+  });
   const key = getDaemonKey(args, identity);
   await cleanupStaleDaemonRecords();
 
@@ -270,7 +329,8 @@ async function ensureDaemon(args: string[]): Promise<DaemonRecord> {
     if (lockedExisting) return lockedExisting;
 
     const entry = process.argv[1];
-    if (!entry) throw new Error('Cannot locate metro-mcp entrypoint for daemon startup');
+    if (!entry)
+      throw new Error('Cannot locate metro-mcp entrypoint for daemon startup');
 
     const child = spawn(process.execPath, [entry, 'serve', ...args], {
       detached: true,
@@ -287,27 +347,31 @@ async function ensureDaemon(args: string[]): Promise<DaemonRecord> {
   });
 }
 
-export function getDaemonKeyFromEnv(args: string[], identity = createDaemonIdentity(args)): string {
+export function getDaemonKeyFromEnv(
+  args: string[],
+  identity = createDaemonIdentity(args),
+): string {
   return process.env[DAEMON_KEY_ENV] || getDaemonKey(args, identity);
 }
 
 export async function startStdioProxy(args: string[]): Promise<void> {
   const record = await ensureDaemon(args);
   const stdio = new StdioServerTransport();
-  const daemonTransport = new StreamableHTTPClientTransport(new URL(record.url));
+  const daemonTransport = new StreamableHTTPClientTransport(
+    new URL(record.url),
+  );
   let closing = false;
 
-  async function closeQuietly(transport: { close(): Promise<void> }): Promise<void> {
+  async function closeQuietly(transport: {
+    close(): Promise<void>;
+  }): Promise<void> {
     await transport.close().catch(() => {});
   }
 
   async function close(): Promise<void> {
     if (closing) return;
     closing = true;
-    await Promise.all([
-      closeQuietly(stdio),
-      closeQuietly(daemonTransport),
-    ]);
+    await Promise.all([closeQuietly(stdio), closeQuietly(daemonTransport)]);
     process.exit(0);
   }
 
@@ -324,7 +388,8 @@ export async function startStdioProxy(args: string[]): Promise<void> {
     });
   };
   stdio.onerror = (err) => logger.error('stdio transport error:', err);
-  daemonTransport.onerror = (err) => logger.error('daemon transport error:', err);
+  daemonTransport.onerror = (err) =>
+    logger.error('daemon transport error:', err);
   stdio.onclose = () => void close();
   daemonTransport.onclose = () => void close();
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -88,10 +88,14 @@ export function createDaemonIdentity(
   args: string[],
   overrides: Partial<DaemonIdentity> = {},
 ): DaemonIdentity {
+  const projectRoot =
+    overrides.projectRoot ?? overrides.cwd ?? getDaemonCwd();
   return {
     version: overrides.version ?? version,
-    cwd: overrides.cwd ?? getDaemonCwd(),
-    projectRoot: overrides.projectRoot ?? getDaemonCwd(),
+    // Daemon ownership is project-scoped. The launcher's incidental working
+    // directory must not split one project across multiple daemon keys.
+    cwd: projectRoot,
+    projectRoot,
     args: overrides.args ?? [...args],
     env: overrides.env ?? selectedEnv(),
     entrypoint: overrides.entrypoint ?? resolvePath(process.argv[1]),

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,9 @@ async function main() {
 
   // Catch unknown subcommands (args that look like commands, not flags)
   if (subcommand && subcommand !== 'serve' && !subcommand.startsWith('-')) {
-    console.error(`Unknown command: ${subcommand}\nRun \`metro-mcp --help\` for usage.`);
+    console.error(
+      `Unknown command: ${subcommand}\nRun \`metro-mcp --help\` for usage.`,
+    );
     process.exit(1);
   }
 
@@ -68,6 +70,7 @@ Options:
   --port, -p <port>       Metro port (default: 8081, env: METRO_PORT)
   --config, -c <path>     Path to config file (env: METRO_MCP_CONFIG)
   --plugin <path>         Load a plugin (repeatable, env: METRO_MCP_PLUGINS)
+  --project-root <path>   Project root (env: METRO_MCP_PROJECT_ROOT)
   --mcp-port <port>       Port for \`serve\` mode (default: random, env: METRO_MCP_MCP_PORT)
   --stdio-direct          Run one legacy stdio server process without multiplexing
   --help                  Show this help message
@@ -77,6 +80,7 @@ Environment Variables:
   METRO_PORT              Metro bundler port
   METRO_MCP_CONFIG        Path to config file (absolute or relative to CWD)
   METRO_MCP_PLUGINS       Colon-separated plugin paths
+  METRO_MCP_PROJECT_ROOT  Project root for config, plugins, and daemon identity
   METRO_MCP_MCP_PORT      Port for the shared MCP HTTP server
   METRO_MCP_MULTIPLEX     Set to "false" to disable the stdio daemon/proxy
   DEBUG                   Enable debug logging
@@ -94,13 +98,18 @@ Examples:
 
   try {
     const config = await loadConfig(serverArgs);
-    logger.info(`Starting metro-mcp (Metro: ${config.metro.host}:${config.metro.port})`);
+    logger.info(
+      `Starting metro-mcp (Metro: ${config.metro.host}:${config.metro.port})`,
+    );
 
     if (subcommand === 'serve') {
       const mcpPort = resolveMcpPort(serverArgs);
-      const identity = createDaemonIdentity(serverArgs);
+      const identity = createDaemonIdentity(serverArgs, {
+        projectRoot: config.projectRoot,
+      });
       const key = getDaemonKeyFromEnv(serverArgs, identity);
-      const cleanupDaemonRecord = () => removeDaemonRecordForProcess(key, process.pid);
+      const cleanupDaemonRecord = () =>
+        removeDaemonRecordForProcess(key, process.pid);
       await startHttpServer(config, serverArgs, {
         port: mcpPort,
         daemon: { key, identity },
@@ -111,7 +120,7 @@ Examples:
             port,
             url,
             key,
-            cwd: getDaemonCwd(),
+            cwd: config.projectRoot ?? getDaemonCwd(),
             args: serverArgs,
             identity,
             startedAt: new Date().toISOString(),
@@ -122,8 +131,14 @@ Examples:
       return;
     }
 
-    if (serverArgs.includes('--stdio-direct') || process.env.METRO_MCP_MULTIPLEX === 'false') {
-      await startServer(config, serverArgs.filter((arg) => arg !== '--stdio-direct'));
+    if (
+      serverArgs.includes('--stdio-direct') ||
+      process.env.METRO_MCP_MULTIPLEX === 'false'
+    ) {
+      await startServer(
+        config,
+        serverArgs.filter((arg) => arg !== '--stdio-direct'),
+      );
       return;
     }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -47,10 +47,16 @@ export interface ToolAnnotations {
 
 export interface ToolHandlerContext {
   /** Send a progress notification to the client (only if client provided a progressToken) */
-  sendProgress?: (progress: number, total: number, message?: string) => Promise<void>;
+  sendProgress?: (
+    progress: number,
+    total: number,
+    message?: string,
+  ) => Promise<void>;
 }
 
-export interface ToolConfig<T extends z.ZodType = z.ZodType> {
+export interface ToolConfig<
+  T extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
+> {
   description: string;
   parameters: T;
   annotations?: ToolAnnotations;
@@ -93,7 +99,9 @@ export interface PromptConfig {
     description: string;
     required?: boolean;
   }>;
-  handler: (args: Record<string, string>) => Promise<Array<{ role: 'user' | 'assistant'; content: string }>>;
+  handler: (
+    args: Record<string, string>,
+  ) => Promise<Array<{ role: 'user' | 'assistant'; content: string }>>;
 }
 
 // ── Eval Options ──
@@ -124,7 +132,10 @@ export interface PluginContext {
   cdp: CDPConnection;
   /** Metro `/events` WebSocket — build progress, bundling errors, etc. */
   events: MetroEventsConnection;
-  registerTool<T extends z.ZodType>(name: string, config: ToolConfig<T>): void;
+  registerTool<T extends z.ZodObject<z.ZodRawShape>>(
+    name: string,
+    config: ToolConfig<T>,
+  ): void;
   registerResource(uri: string, config: ResourceConfig): void;
   registerPrompt(name: string, config: PromptConfig): void;
   config: Record<string, unknown>;
@@ -181,6 +192,8 @@ export function definePlugin(plugin: PluginDefinition): PluginDefinition {
 // ── Config ──
 
 export interface MetroMCPConfig {
+  /** Effective project root; resolved by the CLI and not configurable in a file. */
+  projectRoot?: string;
   metro?: {
     host?: string;
     port?: number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,18 +5,26 @@ import http from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { SubscribeRequestSchema, UnsubscribeRequestSchema, RootsListChangedNotificationSchema, isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import {
-  registerAppResource as registerMcpAppResource,
-  registerAppTool as registerMcpAppTool,
-  RESOURCE_MIME_TYPE,
-} from '@modelcontextprotocol/ext-apps/server';
+  createMcpHandler,
+  isInitializeRequest,
+  isLegacyRequest,
+  McpServer,
+} from '@modelcontextprotocol/server';
+import type {
+  McpHttpHandler,
+  ServerContext,
+  ToolCallback,
+  Transport,
+} from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import {
+  NodeStreamableHTTPServerTransport,
+  hostHeaderValidation,
+  originValidation,
+  toNodeHandler,
+  toWebRequest,
+} from '@modelcontextprotocol/node';
 import { z } from 'zod';
 import type {
   MetroMCPConfig,
@@ -28,9 +36,14 @@ import type {
   PromptConfig,
   EvalOptions,
 } from './plugin.js';
-import { CDPSession, CDPMultiplexer, scanMetroPorts, selectBestTarget, fetchTargets } from 'metro-bridge';
+import {
+  CDPSession,
+  CDPMultiplexer,
+  scanMetroPorts,
+  selectBestTarget,
+  fetchTargets,
+} from 'metro-bridge';
 import type { MetroTarget } from 'metro-bridge';
-import { loadConfig } from './config.js';
 import { MetroEventsClient } from './metro/events.js';
 import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
@@ -103,7 +116,7 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   environmentPlugin,
 ];
 
-type RuntimeRegistration = (session: McpSession) => { remove: () => void };
+type RuntimeRegistration = (server: McpServer) => { remove: () => void };
 
 interface McpSession {
   id: string;
@@ -130,11 +143,15 @@ function createMcpServer(): McpServer {
     },
     {
       instructions: `React Native runtime debugging MCP server. Connects to Metro bundler via Chrome DevTools Protocol to provide console logs, network requests, component tree inspection, state management debugging, device control, and more. Use list_devices to see connected targets, then use other tools to inspect and interact with the running app.`,
-    }
+    },
   );
 }
 
-function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+function sendJson(
+  res: http.ServerResponse,
+  status: number,
+  body: unknown,
+): void {
   res.writeHead(status, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(body));
 }
@@ -148,11 +165,16 @@ async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
   return raw ? JSON.parse(raw) : undefined;
 }
 
-async function closeQuietly(closable: { close(): Promise<void> }): Promise<void> {
+async function closeQuietly(closable: {
+  close(): Promise<void>;
+}): Promise<void> {
   await closable.close().catch(() => {});
 }
 
-export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>, args: string[] = []) {
+export async function createMetroRuntime(
+  initialConfig: Required<MetroMCPConfig>,
+  args: string[] = [],
+) {
   let config = initialConfig;
   const cdpSession = new CDPSession();
   const eventsClient = new MetroEventsClient();
@@ -160,22 +182,26 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   const sessions = new Set<McpSession>();
   const runtimeRegistrations: RuntimeRegistration[] = [];
   const resourceSubscriptions = new ResourceSubscriptionManager();
-  let projectRoot: string | null = null;
-  let reloadInProgress = false;
   let isInitializingPlugins = false;
   let runtimeClosed = false;
+  let modernResourceNotifier: ((uri: string) => void) | null = null;
+  let stdioHandle: { close(): Promise<void> } | null = null;
 
   const resourceUpdates = createResourceUpdateScheduler({
     delayMs: RESOURCE_UPDATE_COALESCE_MS,
-    getTargets: () => [...sessions].map((session) => ({
-      id: session.id,
-      isSubscribed: (uri) => session.subscribedResources.has(uri),
-      sendResourceUpdated: (uri) => session.server.server.sendResourceUpdated({ uri }),
-    })),
+    getTargets: () =>
+      [...sessions].map((session) => ({
+        id: session.id,
+        isSubscribed: (uri) => session.subscribedResources.has(uri),
+        sendResourceUpdated: async (uri) => {
+          await session.server.server.sendResourceUpdated({ uri });
+        },
+      })),
   });
 
   function notifyResourceUpdated(uri: string): void {
     resourceUpdates.notify(uri);
+    modernResourceNotifier?.(uri);
   }
 
   // Active device tracking — used by plugins to key per-device buffers.
@@ -202,9 +228,15 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
 
   function waitForReconnect(): Promise<void> {
     return new Promise<void>((resolve) => {
-      if (!isReconnecting) { resolve(); return; }
+      if (!isReconnecting) {
+        resolve();
+        return;
+      }
       const check = setInterval(() => {
-        if (!isReconnecting) { clearInterval(check); resolve(); }
+        if (!isReconnecting) {
+          clearInterval(check);
+          resolve();
+        }
       }, 100);
     });
   }
@@ -251,7 +283,10 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   // Enable required CDP domains on every connection (initial and reconnect).
   cdpSession.on('reconnected', async () => {
     isReconnecting = false;
-    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
     await enableCDPDomains();
     clearReconnectStabilityTimer();
     reconnectStabilityTimer = setTimeout(() => {
@@ -280,107 +315,97 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     await enableCDPDomains();
   });
 
-  function clearSessionRegistrations(session: McpSession): void {
-    for (const reg of session.registrations) {
-      try { reg.remove(); } catch { /* ignore */ }
-    }
-    session.registrations.length = 0;
-  }
-
-  function materializeSession(session: McpSession): void {
-    clearSessionRegistrations(session);
-    for (const register of runtimeRegistrations) {
-      try {
-        session.registrations.push(register(session));
-      } catch (err) {
-        logger.error(`Failed to materialize MCP registration for session ${session.id}:`, err);
-      }
-    }
-  }
-
-  function materializeAllSessions(): void {
-    for (const session of sessions) {
-      materializeSession(session);
-    }
-  }
-
   function addRuntimeRegistration(
     register: RuntimeRegistration,
     registrationLogger: ReturnType<typeof createLogger>,
     debugMessage: string,
   ): void {
     runtimeRegistrations.push(register);
-    if (!isInitializingPlugins) materializeAllSessions();
     registrationLogger.debug(debugMessage);
   }
 
+  function materializeServer(server: McpServer): Array<{ remove: () => void }> {
+    const registrations: Array<{ remove: () => void }> = [];
+    for (const register of runtimeRegistrations) {
+      try {
+        registrations.push(register(server));
+      } catch (err) {
+        logger.error('Failed to materialize MCP registration:', err);
+      }
+    }
+    return registrations;
+  }
+
   // Create the plugin context factory
-  function createPluginContext(plugin: PluginDefinition, cfg: Required<MetroMCPConfig>): PluginContext {
+  function createPluginContext(
+    plugin: PluginDefinition,
+    cfg: Required<MetroMCPConfig>,
+  ): PluginContext {
     const pluginLogger = createLogger(plugin.name);
     return {
       cdp: cdpSession,
       events: eventsClient,
-      registerTool: <T extends z.ZodType>(name: string, toolConfig: ToolConfig<T>) => {
+      registerTool: <T extends z.ZodObject<z.ZodRawShape>>(
+        name: string,
+        toolConfig: ToolConfig<T>,
+      ) => {
         try {
-          // Use duck typing in addition to instanceof so plugins that bundle a
-          // different copy of zod (e.g. via file: deps or package links) still work.
-          const params = toolConfig.parameters as Record<string, unknown>;
-          const isZodObject =
-            params instanceof z.ZodObject ||
-            (typeof params.shape === 'object' && params.shape !== null);
-          const inputSchema: z.ZodRawShape = isZodObject
-            ? (toolConfig.parameters as unknown as z.ZodObject<z.ZodRawShape>).shape
-            : { input: toolConfig.parameters };
-
-          const toolDefinition = {
-            description: toolConfig.description,
-            inputSchema,
-            annotations: toolConfig.annotations,
-          };
-
-          const handler: ToolCallback<typeof inputSchema> = async (args, extra) => {
-            // Build a sendProgress helper if the client sent a progressToken
-            const progressToken = extra._meta?.progressToken;
-            const sendProgress = progressToken !== undefined
-              ? async (progress: number, total: number, message?: string) => {
-                  await extra.sendNotification({
-                    method: 'notifications/progress',
-                    params: { progressToken, progress, total, ...(message ? { message } : {}) },
-                  } as Parameters<typeof extra.sendNotification>[0]);
-                }
-              : undefined;
+          const handler = async (args: unknown, ctx: ServerContext) => {
+            // V2 carries progress metadata and notification delivery on the
+            // request context rather than the v1 callback `extra` object.
+            const progressToken = ctx.mcpReq._meta?.progressToken;
+            const sendProgress =
+              progressToken !== undefined
+                ? async (progress: number, total: number, message?: string) => {
+                    await ctx.mcpReq.notify({
+                      method: 'notifications/progress',
+                      params: {
+                        progressToken,
+                        progress,
+                        total,
+                        ...(message ? { message } : {}),
+                      },
+                    });
+                  }
+                : undefined;
 
             try {
-              const result = await toolConfig.handler(args as z.infer<T>, { sendProgress });
-              const content = typeof result === 'string' ? result : JSON.stringify(result);
+              const result = await toolConfig.handler(args as z.infer<T>, {
+                sendProgress,
+              });
+              const content =
+                typeof result === 'string' ? result : JSON.stringify(result);
               return {
                 content: [{ type: 'text' as const, text: content }],
               };
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
-              return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+              return {
+                content: [{ type: 'text' as const, text: `Error: ${message}` }],
+                isError: true,
+              };
             }
           };
 
           addRuntimeRegistration(
-            (session) => {
-              if (toolConfig.appUri) {
-                return registerMcpAppTool(
-                  session.server,
-                  name,
-                  {
-                    ...toolDefinition,
-                    _meta: { ui: { resourceUri: toolConfig.appUri } },
-                  },
-                  handler,
-                );
-              }
-              return session.server.registerTool(
+            (server) =>
+              server.registerTool(
                 name,
-                toolDefinition,
-                handler,
-              );
-            },
+                {
+                  description: toolConfig.description,
+                  inputSchema: toolConfig.parameters,
+                  annotations: toolConfig.annotations,
+                  ...(toolConfig.appUri
+                    ? {
+                        _meta: {
+                          ui: { resourceUri: toolConfig.appUri },
+                          'ui/resourceUri': toolConfig.appUri,
+                        },
+                      }
+                    : {}),
+                },
+                handler as ToolCallback<T>,
+              ),
             pluginLogger,
             `Registered tool: ${name}`,
           );
@@ -396,15 +421,20 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
             onUnsubscribe: resourceConfig.onUnsubscribe,
           });
           addRuntimeRegistration(
-            (session) => session.server.resource(
-              resourceConfig.name,
-              uri,
-              { description: resourceConfig.description, mimeType },
-              async () => {
-                const content = await resourceConfig.handler();
-                return { contents: [{ uri, text: content, mimeType }] };
-              }
-            ),
+            (server) =>
+              server.registerResource(
+                resourceConfig.name,
+                uri,
+                { description: resourceConfig.description, mimeType },
+                async (resourceUri) => {
+                  const content = await resourceConfig.handler();
+                  return {
+                    contents: [
+                      { uri: resourceUri.href, text: content, mimeType },
+                    ],
+                  };
+                },
+              ),
             pluginLogger,
             `Registered resource: ${uri}`,
           );
@@ -414,25 +444,33 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
       },
       registerAppResource: (uri: string, appConfig: AppResourceConfig) => {
         try {
-          const preferredFrameSizeMeta = createPreferredFrameSizeMeta(appConfig.minHeight);
+          const preferredFrameSizeMeta = createPreferredFrameSizeMeta(
+            appConfig.minHeight,
+          );
           addRuntimeRegistration(
-            (session) => registerMcpAppResource(
-              session.server,
-              appConfig.name,
-              uri,
-              { description: appConfig.description, _meta: preferredFrameSizeMeta },
-              async () => {
-                const html = await appConfig.handler();
-                return {
-                  contents: [{
-                    uri,
-                    text: withAppSizing(html, appConfig.minHeight),
-                    mimeType: RESOURCE_MIME_TYPE,
-                    _meta: preferredFrameSizeMeta,
-                  }],
-                };
-              }
-            ),
+            (server) =>
+              server.registerResource(
+                appConfig.name,
+                uri,
+                {
+                  description: appConfig.description,
+                  mimeType: 'text/html;profile=mcp-app',
+                  _meta: preferredFrameSizeMeta,
+                },
+                async (resourceUri) => {
+                  const html = await appConfig.handler();
+                  return {
+                    contents: [
+                      {
+                        uri: resourceUri.href,
+                        text: withAppSizing(html, appConfig.minHeight),
+                        mimeType: 'text/html;profile=mcp-app',
+                        _meta: preferredFrameSizeMeta,
+                      },
+                    ],
+                  };
+                },
+              ),
             pluginLogger,
             `Registered app resource: ${uri}`,
           );
@@ -446,24 +484,32 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
           const argsShape: Record<string, z.ZodType> = {};
           if (promptConfig.arguments) {
             for (const arg of promptConfig.arguments) {
-              argsShape[arg.name] = arg.required ? z.string() : z.string().optional();
+              argsShape[arg.name] = arg.required
+                ? z.string()
+                : z.string().optional();
             }
           }
+          const promptDefinition = {
+            description: promptConfig.description,
+            ...(promptConfig.arguments?.length
+              ? { argsSchema: z.object(argsShape) }
+              : {}),
+          };
           addRuntimeRegistration(
-            (session) => session.server.prompt(
-              name,
-              promptConfig.description,
-              argsShape,
-              async (args) => {
-                const messages = await promptConfig.handler(args as Record<string, string>);
-                return {
-                  messages: messages.map((m) => ({
-                    role: m.role as 'user' | 'assistant',
-                    content: { type: 'text' as const, text: m.content },
-                  })),
-                };
-              }
-            ),
+            (server) =>
+              server.registerPrompt(
+                name,
+                promptDefinition as any,
+                async (args: any) => {
+                  const messages = await promptConfig.handler(args ?? {});
+                  return {
+                    messages: messages.map((m) => ({
+                      role: m.role as 'user' | 'assistant',
+                      content: { type: 'text' as const, text: m.content },
+                    })),
+                  };
+                },
+              ),
             pluginLogger,
             `Registered prompt: ${name}`,
           );
@@ -486,7 +532,9 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
             }
           }
           if (!cdpSession.isConnected) {
-            throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+            throw new Error(
+              'Not connected to Metro. Use list_devices to check connection status.',
+            );
           }
           const result = (await cdpSession.send('Runtime.evaluate', {
             expression,
@@ -495,18 +543,24 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
             timeout: options?.timeout,
           })) as Record<string, unknown>;
           if (result.exceptionDetails) {
-            throw new Error(extractCDPExceptionMessage(result.exceptionDetails as Record<string, unknown>));
+            throw new Error(
+              extractCDPExceptionMessage(
+                result.exceptionDetails as Record<string, unknown>,
+              ),
+            );
           }
           return (result.result as Record<string, unknown>).value;
         }
         try {
           return await tryEval();
         } catch (err) {
-          if (err instanceof Error && (
-            err.message === 'WebSocket closed' ||
-            err.message === 'Not connected to CDP target' ||
-            err.message === 'Not connected to Metro. Use list_devices to check connection status.'
-          )) {
+          if (
+            err instanceof Error &&
+            (err.message === 'WebSocket closed' ||
+              err.message === 'Not connected to CDP target' ||
+              err.message ===
+                'Not connected to Metro. Use list_devices to check connection status.')
+          ) {
             if (isReconnecting) {
               await waitForReconnect();
             } else {
@@ -538,25 +592,20 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     };
   }
 
-  // Load and initialize all plugins. Clears existing registrations first so this
-  // can be called again when the active project root changes.
-  async function initPlugins(cfg: Required<MetroMCPConfig>, rootPath?: string): Promise<void> {
+  // Load and initialize plugins once into a long-lived runtime registration set.
+  // Fresh MCP server instances are materialized from this set for each modern
+  // request and each legacy connection.
+  async function initPlugins(cfg: Required<MetroMCPConfig>): Promise<void> {
     runtimeRegistrations.length = 0;
     resourceSubscriptions.clearHooks();
-    for (const session of sessions) {
-      clearSessionRegistrations(session);
-    }
 
-    const baseDir = rootPath ?? process.cwd();
     const allPlugins = [...BUILT_IN_PLUGINS];
 
     for (const pluginPath of cfg.plugins) {
       try {
-        const resolvedPath = pluginPath.startsWith('.')
-          ? resolve(baseDir, pluginPath)
-          : pluginPath.startsWith('/')
-            ? pluginPath
-            : import.meta.resolve(pluginPath);
+        const resolvedPath = pluginPath.startsWith('/')
+          ? pluginPath
+          : import.meta.resolve(pluginPath);
         const mod = await import(resolvedPath);
         const plugin: PluginDefinition = mod.default || mod;
         if (plugin?.name && typeof plugin?.setup === 'function') {
@@ -582,7 +631,6 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     } finally {
       isInitializingPlugins = false;
     }
-    materializeAllSessions();
   }
 
   await initPlugins(config);
@@ -607,7 +655,9 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
         try {
           process.kill(lockData.pid, 0);
         } catch {
-          try { fs.unlinkSync(PROXY_LOCK_FILE); } catch {}
+          try {
+            fs.unlinkSync(PROXY_LOCK_FILE);
+          } catch {}
           return false;
         }
 
@@ -615,21 +665,29 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
           signal: AbortSignal.timeout(2000),
         });
         if (!resp.ok) return false;
-        const targets = await resp.json() as Array<{ id?: string; title?: string; webSocketDebuggerUrl?: string }>;
+        const targets = (await resp.json()) as Array<{
+          id?: string;
+          title?: string;
+          webSocketDebuggerUrl?: string;
+        }>;
         if (targets.length > 0 && targets[0].webSocketDebuggerUrl) {
           logger.info(
-            `Found existing metro-mcp proxy (PID ${lockData.pid}, port ${lockData.port}) — connecting as secondary`
+            `Found existing metro-mcp proxy (PID ${lockData.pid}, port ${lockData.port}) — connecting as secondary`,
           );
           // Set active device key BEFORE connecting so plugin event handlers
           // that fire on the 'reconnected' event can store events immediately.
-          activeDeviceKey = targets[0].id ? `${lockData.port}-${targets[0].id}` : null;
+          activeDeviceKey = targets[0].id
+            ? `${lockData.port}-${targets[0].id}`
+            : null;
           activeDeviceName = targets[0].title || targets[0].id || 'secondary';
           // Point devtools plugin at the primary's proxy so open_devtools uses the right port
           (config as Record<string, unknown>).proxy = {
             ...config.proxy,
             port: lockData.port,
           };
-          await cdpSession.connectToTarget(targets[0] as unknown as MetroTarget);
+          await cdpSession.connectToTarget(
+            targets[0] as unknown as MetroTarget,
+          );
           if (lockData.metroPort) {
             eventsClient.connect(config.metro.host!, lockData.metroPort);
             config.metro.port = lockData.metroPort;
@@ -647,7 +705,7 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     try {
       fs.writeFileSync(
         PROXY_LOCK_FILE,
-        JSON.stringify({ pid: process.pid, port: proxyPort, metroPort })
+        JSON.stringify({ pid: process.pid, port: proxyPort, metroPort }),
       );
       isPrimaryInstance = true;
       logger.info(`Wrote proxy lock (port ${proxyPort})`);
@@ -680,7 +738,7 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
       const proxyEnabled = config.proxy?.enabled !== false;
 
       // If another metro-mcp instance is already connected, piggyback on its proxy
-      if (proxyEnabled && await tryConnectViaProxy()) {
+      if (proxyEnabled && (await tryConnectViaProxy())) {
         return true;
       }
 
@@ -688,12 +746,20 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
       if (config.metro.autoDiscover) {
         servers = await scanMetroPorts(config.metro.host!);
       } else {
-        const targets = await fetchTargets(config.metro.host!, config.metro.port!);
-        servers = targets.length > 0 ? [{ host: config.metro.host!, port: config.metro.port!, targets }] : [];
+        const targets = await fetchTargets(
+          config.metro.host!,
+          config.metro.port!,
+        );
+        servers =
+          targets.length > 0
+            ? [{ host: config.metro.host!, port: config.metro.port!, targets }]
+            : [];
       }
 
       if (servers.length === 0) {
-        logger.warn('No Metro servers found. Tools will report disconnected status.');
+        logger.warn(
+          'No Metro servers found. Tools will report disconnected status.',
+        );
         return false;
       }
 
@@ -716,7 +782,9 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
         // messageInterceptor is already in place when 'reconnected' fires and
         // events begin flowing from Metro. Starting it after connectToTarget()
         // caused a window where events were lost on initial connection.
-        const mux = new CDPMultiplexer(cdpSession, { protectedDomains: ['Runtime', 'Network'] });
+        const mux = new CDPMultiplexer(cdpSession, {
+          protectedDomains: ['Runtime', 'Network'],
+        });
         try {
           const startedPort = await mux.start(preferredProxyPort);
           const devtoolsUrl = mux.getDevToolsUrl();
@@ -732,7 +800,9 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
           logger.warn('Could not start CDP proxy:', err);
         }
       } else if (!proxyEnabled) {
-        logger.warn('CDP proxy is disabled; connecting directly without Metro MCP shared-debugger multiplexing.');
+        logger.warn(
+          'CDP proxy is disabled; connecting directly without Metro MCP shared-debugger multiplexing.',
+        );
       }
 
       await cdpSession.connectToTarget(target);
@@ -760,11 +830,16 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     // Use exponential backoff for the initial burst, then fall back to a slow
     // background probe so the server keeps trying indefinitely (e.g. app started
     // long after the MCP server).
-    const delay = reconnectAttempts < MAX_BURST_ATTEMPTS
-      ? RECONNECT_DELAYS[Math.min(reconnectAttempts, RECONNECT_DELAYS.length - 1)]
-      : 30000;
+    const delay =
+      reconnectAttempts < MAX_BURST_ATTEMPTS
+        ? RECONNECT_DELAYS[
+            Math.min(reconnectAttempts, RECONNECT_DELAYS.length - 1)
+          ]
+        : 30000;
     reconnectAttempts++;
-    logger.info(`Reconnecting to Metro in ${delay}ms (attempt ${reconnectAttempts})`);
+    logger.info(
+      `Reconnecting to Metro in ${delay}ms (attempt ${reconnectAttempts})`,
+    );
 
     isReconnecting = true;
     reconnectTimer = setTimeout(async () => {
@@ -788,73 +863,48 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     try {
       const stale = JSON.parse(fs.readFileSync(PROXY_LOCK_FILE, 'utf8'));
       if (stale.port) preferredProxyPort = stale.port;
-    } catch { /* no stale lock */ }
-  }
-
-  // Reload config + plugins from the first client's active project root. v1 shares
-  // one runtime across sessions, so later clients must target the same app.
-  async function reloadFromRoots(session: McpSession, suppressErrors = false): Promise<void> {
-    if (reloadInProgress) return;
-    reloadInProgress = true;
-    try {
-      const { roots } = await session.server.server.listRoots();
-      const firstRoot = roots[0];
-      if (!firstRoot) return;
-      const rootPath = new URL(firstRoot.uri).pathname;
-      if (projectRoot && projectRoot !== rootPath) {
-        logger.warn(
-          `Ignoring roots change for ${rootPath}; metro-mcp multiplexing is already bound to ${projectRoot}`
-        );
-        return;
-      }
-      if (projectRoot === rootPath) return;
-      projectRoot = rootPath;
-      logger.info(`Reloading plugins from: ${rootPath}`);
-      const newConfig = await loadConfig(args, rootPath);
-      config = newConfig;
-      await initPlugins(newConfig, rootPath);
-      logger.info(`Plugins reloaded for: ${rootPath}`);
-    } catch (err) {
-      if (!suppressErrors) logger.error('Failed to reload plugins on roots change:', err);
-    } finally {
-      reloadInProgress = false;
+    } catch {
+      /* no stale lock */
     }
   }
 
   async function connectSession(transport: Transport): Promise<McpSession> {
+    const server = createMcpServer();
     const session: McpSession = {
       id: randomUUID(),
-      server: createMcpServer(),
+      server,
       subscribedResources: new Set<string>(),
-      registrations: [],
+      registrations: materializeServer(server),
     };
 
-    session.server.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
-      resourceSubscriptions.subscribe(session, req.params.uri);
+    server.server.setRequestHandler('resources/subscribe', async (req) => {
+      resourceSubscriptions.subscribe(
+        session,
+        String((req.params as { uri: string }).uri),
+      );
       logger.debug(`Client subscribed to resource: ${req.params.uri}`);
       return {};
     });
 
-    session.server.server.setRequestHandler(UnsubscribeRequestSchema, async (req) => {
-      resourceSubscriptions.unsubscribe(session, req.params.uri);
+    server.server.setRequestHandler('resources/unsubscribe', async (req) => {
+      resourceSubscriptions.unsubscribe(
+        session,
+        String((req.params as { uri: string }).uri),
+      );
       logger.debug(`Client unsubscribed from resource: ${req.params.uri}`);
       return {};
     });
-
-    session.server.server.setNotificationHandler(RootsListChangedNotificationSchema, () => reloadFromRoots(session));
-    session.server.server.oninitialized = () => reloadFromRoots(session, true);
 
     const previousClose = transport.onclose;
     transport.onclose = () => {
       previousClose?.();
       resourceSubscriptions.unsubscribeAll(session);
       resourceUpdates.removeTarget(session.id);
-      clearSessionRegistrations(session);
+      for (const registration of session.registrations) registration.remove();
       sessions.delete(session);
       logger.debug(`MCP session closed: ${session.id}`);
     };
 
-    materializeSession(session);
     sessions.add(session);
     await session.server.connect(transport);
     logger.info(`MCP session connected: ${session.id}`);
@@ -862,8 +912,19 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   }
 
   async function startStdio(): Promise<void> {
-    await connectSession(new StdioServerTransport());
-    logger.info('MCP stdio session started');
+    const handle = serveStdio(
+      () => {
+        const server = createMcpServer();
+        materializeServer(server);
+        return server;
+      },
+      {
+        legacy: 'serve',
+        onerror: (err) => logger.error('stdio server error:', err),
+      },
+    );
+    stdioHandle = handle;
+    logger.info('MCP stdio server started');
   }
 
   function closeRuntime(): void {
@@ -880,19 +941,29 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
     for (const session of sessions) {
       resourceSubscriptions.unsubscribeAll(session);
       resourceUpdates.removeTarget(session.id);
-      clearSessionRegistrations(session);
+      for (const registration of session.registrations) registration.remove();
       session.server.close().catch(() => {});
     }
     sessions.clear();
+    stdioHandle?.close().catch(() => {});
+    stdioHandle = null;
     resourceUpdates.close();
     eventsClient.disconnect();
     cleanProxyLock();
     cdpMultiplexer?.stop();
   }
 
-  const handleSigint = () => { closeRuntime(); process.exit(0); };
-  const handleSigterm = () => { closeRuntime(); process.exit(0); };
-  const handleExit = () => { closeRuntime(); };
+  const handleSigint = () => {
+    closeRuntime();
+    process.exit(0);
+  };
+  const handleSigterm = () => {
+    closeRuntime();
+    process.exit(0);
+  };
+  const handleExit = () => {
+    closeRuntime();
+  };
 
   // Clean up on shutdown
   process.on('SIGINT', handleSigint);
@@ -910,11 +981,22 @@ export async function createMetroRuntime(initialConfig: Required<MetroMCPConfig>
   return {
     connectSession,
     startStdio,
+    createServer: () => {
+      const server = createMcpServer();
+      materializeServer(server);
+      return server;
+    },
+    setModernResourceNotifier: (notifier: (uri: string) => void) => {
+      modernResourceNotifier = notifier;
+    },
     close: closeRuntime,
   };
 }
 
-export async function startServer(config: Required<MetroMCPConfig>, args: string[] = []): Promise<void> {
+export async function startServer(
+  config: Required<MetroMCPConfig>,
+  args: string[] = [],
+): Promise<void> {
   const runtime = await createMetroRuntime(config, args);
   await runtime.startStdio();
 }
@@ -923,23 +1005,41 @@ export async function startHttpServer(
   config: Required<MetroMCPConfig>,
   args: string[] = [],
   options: HttpServerOptions = {},
-): Promise<{ host: string; port: number; url: string; close: () => Promise<void> }> {
+): Promise<{
+  host: string;
+  port: number;
+  url: string;
+  close: () => Promise<void>;
+}> {
   const runtime = await createMetroRuntime(config, args);
   const host = options.host ?? '127.0.0.1';
   const requestedPort = options.port ?? 0;
   const daemonIdentity = options.daemon?.identity ?? createDaemonIdentity(args);
   const daemonKey = options.daemon?.key ?? getDaemonKey(args, daemonIdentity);
-  const streamableTransports = new Map<string, StreamableHTTPServerTransport>();
-  const sseTransports = new Map<string, SSEServerTransport>();
+  const streamableTransports = new Map<
+    string,
+    NodeStreamableHTTPServerTransport
+  >();
+
+  const modernHandler: McpHttpHandler = createMcpHandler(
+    () => runtime.createServer(),
+    { legacy: 'reject' },
+  );
+  runtime.setModernResourceNotifier((uri) =>
+    modernHandler.notify.resourceUpdated(uri),
+  );
+  const modernNodeHandler = toNodeHandler(modernHandler, {
+    onerror: (err) => logger.error('Modern MCP request failed:', err),
+  });
 
   function getSessionIdHeader(req: http.IncomingMessage): string | undefined {
     const sessionId = req.headers['mcp-session-id'];
     return Array.isArray(sessionId) ? sessionId[0] : sessionId;
   }
 
-  async function createStreamableTransport(): Promise<StreamableHTTPServerTransport> {
-    let transport: StreamableHTTPServerTransport;
-    transport = new StreamableHTTPServerTransport({
+  async function createStreamableTransport(): Promise<NodeStreamableHTTPServerTransport> {
+    let transport: NodeStreamableHTTPServerTransport;
+    transport = new NodeStreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (initializedSessionId) => {
         streamableTransports.set(initializedSessionId, transport);
@@ -953,17 +1053,22 @@ export async function startHttpServer(
     return transport;
   }
 
-  async function handleStreamableMcpRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  async function handleLegacyMcpRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    parsedBody: unknown,
+  ): Promise<void> {
     const sessionKey = getSessionIdHeader(req);
-    let transport = sessionKey ? streamableTransports.get(sessionKey) : undefined;
-    let parsedBody: unknown;
-
-    if (req.method === 'POST') {
-      parsedBody = await readJsonBody(req);
-    }
+    let transport = sessionKey
+      ? streamableTransports.get(sessionKey)
+      : undefined;
 
     if (!transport) {
-      if (req.method !== 'POST' || !parsedBody || !isInitializeRequest(parsedBody)) {
+      if (
+        req.method !== 'POST' ||
+        !parsedBody ||
+        !isInitializeRequest(parsedBody)
+      ) {
         sendJson(res, 400, {
           jsonrpc: '2.0',
           error: { code: -32000, message: 'Bad Request: No valid MCP session' },
@@ -995,28 +1100,21 @@ export async function startHttpServer(
       }
 
       if (url.pathname === '/mcp') {
-        await handleStreamableMcpRequest(req, res);
-        return;
-      }
-
-      if (url.pathname === '/sse' && req.method === 'GET') {
-        const transport = new SSEServerTransport('/messages', res);
-        sseTransports.set(transport.sessionId, transport);
-        transport.onclose = () => {
-          sseTransports.delete(transport.sessionId);
-        };
-        await runtime.connectSession(transport);
-        return;
-      }
-
-      if (url.pathname === '/messages' && req.method === 'POST') {
-        const sessionId = url.searchParams.get('sessionId');
-        const transport = sessionId ? sseTransports.get(sessionId) : undefined;
-        if (!transport) {
-          res.writeHead(404).end('No transport found for sessionId');
+        if (
+          !hostHeaderValidation(['localhost', '127.0.0.1', '[::1]'])(req, res)
+        )
           return;
+        if (!originValidation(['localhost', '127.0.0.1', '[::1]'])(req, res))
+          return;
+
+        const parsedBody =
+          req.method === 'POST' ? await readJsonBody(req) : undefined;
+        const probe = await toWebRequest(req, parsedBody);
+        if (await isLegacyRequest(probe, parsedBody)) {
+          await handleLegacyMcpRequest(req, res, parsedBody);
+        } else {
+          await modernNodeHandler(req, res, parsedBody);
         }
-        await transport.handlePostMessage(req, res);
         return;
       }
 
@@ -1044,7 +1142,8 @@ export async function startHttpServer(
   });
 
   const address = server.address();
-  const port = typeof address === 'object' && address ? address.port : requestedPort;
+  const port =
+    typeof address === 'object' && address ? address.port : requestedPort;
   const url = `http://${host}:${port}/mcp`;
   options.onListening?.({ host, port, url });
   logger.info(`MCP HTTP server listening on ${url}`);
@@ -1057,11 +1156,11 @@ export async function startHttpServer(
       for (const transport of streamableTransports.values()) {
         await closeQuietly(transport);
       }
-      for (const transport of sseTransports.values()) {
-        await closeQuietly(transport);
-      }
+      await modernHandler.close();
       runtime.close();
-      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      await new Promise<void>((resolveClose) =>
+        server.close(() => resolveClose()),
+      );
     },
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,7 +136,7 @@ interface HttpServerOptions {
 }
 
 function createMcpServer(): McpServer {
-  return new McpServer(
+  const server = new McpServer(
     {
       name: 'metro-mcp',
       version,
@@ -145,6 +145,8 @@ function createMcpServer(): McpServer {
       instructions: `React Native runtime debugging MCP server. Connects to Metro bundler via Chrome DevTools Protocol to provide console logs, network requests, component tree inspection, state management debugging, device control, and more. Use list_devices to see connected targets, then use other tools to inspect and interact with the running app.`,
     },
   );
+  server.server.registerCapabilities({ resources: { subscribe: true } });
+  return server;
 }
 
 function sendJson(
@@ -180,6 +182,7 @@ export async function createMetroRuntime(
   const eventsClient = new MetroEventsClient();
   const formatUtils = createFormatUtils();
   const sessions = new Set<McpSession>();
+  const modernStdioServers = new Set<McpServer>();
   const runtimeRegistrations: RuntimeRegistration[] = [];
   const resourceSubscriptions = new ResourceSubscriptionManager();
   let isInitializingPlugins = false;
@@ -202,6 +205,11 @@ export async function createMetroRuntime(
   function notifyResourceUpdated(uri: string): void {
     resourceUpdates.notify(uri);
     modernResourceNotifier?.(uri);
+    for (const server of modernStdioServers) {
+      server.server
+        .sendResourceUpdated({ uri })
+        .catch((err) => logger.warn('Failed to send stdio resource update:', err));
+    }
   }
 
   // Active device tracking — used by plugins to key per-device buffers.
@@ -911,15 +919,63 @@ export async function createMetroRuntime(
     return session;
   }
 
-  async function startStdio(): Promise<void> {
+  async function startStdio(transport?: Transport): Promise<void> {
     const handle = serveStdio(
-      () => {
+      ({ era }) => {
         const server = createMcpServer();
-        materializeServer(server);
+        const registrations = materializeServer(server);
+        const previousClose = server.close.bind(server);
+        let closed = false;
+
+        if (era === 'modern') {
+          modernStdioServers.add(server);
+        } else {
+          const session: McpSession = {
+            id: randomUUID(),
+            server,
+            subscribedResources: new Set<string>(),
+            registrations,
+          };
+          server.server.setRequestHandler('resources/subscribe', async (req) => {
+            resourceSubscriptions.subscribe(
+              session,
+              String((req.params as { uri: string }).uri),
+            );
+            return {};
+          });
+          server.server.setRequestHandler(
+            'resources/unsubscribe',
+            async (req) => {
+              resourceSubscriptions.unsubscribe(
+                session,
+                String((req.params as { uri: string }).uri),
+              );
+              return {};
+            },
+          );
+          sessions.add(session);
+        }
+
+        server.close = async () => {
+          if (!closed) {
+            closed = true;
+            modernStdioServers.delete(server);
+            const session = [...sessions].find(
+              (candidate) => candidate.server === server,
+            );
+            if (session) {
+              resourceSubscriptions.unsubscribeAll(session);
+              resourceUpdates.removeTarget(session.id);
+              sessions.delete(session);
+            }
+          }
+          await previousClose();
+        };
         return server;
       },
       {
         legacy: 'serve',
+        ...(transport ? { transport } : {}),
         onerror: (err) => logger.error('stdio server error:', err),
       },
     );
@@ -945,6 +1001,7 @@ export async function createMetroRuntime(
       session.server.close().catch(() => {});
     }
     sessions.clear();
+    modernStdioServers.clear();
     stdioHandle?.close().catch(() => {});
     stdioHandle = null;
     resourceUpdates.close();
@@ -989,6 +1046,7 @@ export async function createMetroRuntime(
     setModernResourceNotifier: (notifier: (uri: string) => void) => {
       modernResourceNotifier = notifier;
     },
+    notifyResourceUpdated,
     close: closeRuntime,
   };
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -73,9 +73,46 @@ describe('project-root configuration', () => {
     ]);
   });
 
+  test('preserves package plugin specifiers while resolving explicit paths', async () => {
+    const root = tempProject();
+    const config = await loadConfig(
+      [
+        '--plugin',
+        '@scope/plugin',
+        '--plugin',
+        'plugin/subpath',
+        '--plugin',
+        './plugins/local.ts',
+      ],
+      root,
+    );
+
+    expect(config.plugins).toEqual([
+      '@scope/plugin',
+      'plugin/subpath',
+      path.join(fs.realpathSync(root), 'plugins', 'local.ts'),
+    ]);
+  });
+
   test('separates daemon identities by effective project root', () => {
     const first = createDaemonIdentity([], { projectRoot: '/tmp/project-a' });
     const second = createDaemonIdentity([], { projectRoot: '/tmp/project-b' });
     expect(getDaemonKey([], first)).not.toBe(getDaemonKey([], second));
+  });
+
+  test('reuses a daemon identity across incidental launcher directories', () => {
+    const projectRoot = tempProject();
+    const first = createDaemonIdentity([], {
+      cwd: '/tmp/launcher-a',
+      projectRoot,
+    });
+    const second = createDaemonIdentity([], {
+      cwd: '/tmp/launcher-b',
+      projectRoot,
+    });
+
+    expect(first.cwd).toBe(projectRoot);
+    expect(second.cwd).toBe(projectRoot);
+    expect(getDaemonKey([], first)).toBe(getDaemonKey([], second));
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig, resolveProjectRoot } from '../src/config.js';
+import { createDaemonIdentity, getDaemonKey } from '../src/daemon.js';
+
+const PROJECT_ROOT_ENV = 'METRO_MCP_PROJECT_ROOT';
+let previousProjectRoot: string | undefined;
+
+afterEach(() => {
+  if (previousProjectRoot === undefined) delete process.env[PROJECT_ROOT_ENV];
+  else process.env[PROJECT_ROOT_ENV] = previousProjectRoot;
+  previousProjectRoot = undefined;
+});
+
+function tempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'metro-mcp-config-test-'));
+}
+
+describe('project-root configuration', () => {
+  test('canonicalizes the working directory when no root is supplied', async () => {
+    const root = tempProject();
+    const config = await loadConfig([], root);
+    expect(config.projectRoot).toBe(fs.realpathSync(root));
+  });
+
+  test('applies CLI, environment, then CWD project-root precedence', () => {
+    const cwdRoot = tempProject();
+    const envRoot = tempProject();
+    const cliRoot = tempProject();
+
+    previousProjectRoot = process.env[PROJECT_ROOT_ENV];
+    process.env[PROJECT_ROOT_ENV] = envRoot;
+    expect(resolveProjectRoot([], cwdRoot)).toBe(fs.realpathSync(envRoot));
+    expect(resolveProjectRoot(['--project-root', cliRoot], cwdRoot)).toBe(
+      fs.realpathSync(cliRoot),
+    );
+
+    delete process.env[PROJECT_ROOT_ENV];
+    expect(resolveProjectRoot([], cwdRoot)).toBe(fs.realpathSync(cwdRoot));
+  });
+
+  test('rejects missing and non-directory project roots with actionable errors', () => {
+    const root = tempProject();
+    const file = path.join(root, 'not-a-directory');
+    fs.writeFileSync(file, 'x');
+
+    expect(() =>
+      resolveProjectRoot(['--project-root', path.join(root, 'missing')]),
+    ).toThrow(/does not exist/);
+    expect(() => resolveProjectRoot(['--project-root', file])).toThrow(
+      /not a directory/,
+    );
+  });
+
+  test('resolves relative config and plugin paths from the effective project root', async () => {
+    const root = tempProject();
+    fs.mkdirSync(path.join(root, 'plugins'));
+    fs.writeFileSync(
+      path.join(root, 'plugins', 'local.ts'),
+      'export default {}',
+    );
+    fs.writeFileSync(
+      path.join(root, 'metro-mcp.config.ts'),
+      `export default { metro: { port: 19000 }, plugins: ['./plugins/local.ts'] };\n`,
+    );
+
+    const config = await loadConfig([], root);
+    expect(config.metro.port).toBe(19000);
+    expect(config.plugins).toEqual([
+      path.join(fs.realpathSync(root), 'plugins', 'local.ts'),
+    ]);
+  });
+
+  test('separates daemon identities by effective project root', () => {
+    const first = createDaemonIdentity([], { projectRoot: '/tmp/project-a' });
+    const second = createDaemonIdentity([], { projectRoot: '/tmp/project-b' });
+    expect(getDaemonKey([], first)).not.toBe(getDaemonKey([], second));
+  });
+});

--- a/tests/protocol-v2.test.ts
+++ b/tests/protocol-v2.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import { loadConfig } from '../src/config.js';
+import { startHttpServer } from '../src/server.js';
+
+const clients: Client[] = [];
+let server: Awaited<ReturnType<typeof startHttpServer>> | undefined;
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) await client.close().catch(() => {});
+  await server?.close().catch(() => {});
+  server = undefined;
+});
+
+async function startTestServer() {
+  const config = await loadConfig(['--project-root', process.cwd()]);
+  config.metro.host = '127.0.0.1';
+  config.metro.port = 65535;
+  config.metro.autoDiscover = false;
+  config.proxy.enabled = false;
+  server = await startHttpServer(config, ['--project-root', process.cwd()], {
+    port: 0,
+  });
+  return server;
+}
+
+function createClient(url: string, modern: boolean): Client {
+  const client = new Client(
+    {
+      name: modern ? 'metro-mcp-modern-test' : 'metro-mcp-legacy-test',
+      version: '1.0.0',
+    },
+    modern ? { versionNegotiation: { mode: 'auto' } } : undefined,
+  );
+  clients.push(client);
+  void url;
+  return client;
+}
+
+describe('V2 HTTP compatibility', () => {
+  test('serves modern negotiation, tools, resources, prompts, and app metadata', async () => {
+    const running = await startTestServer();
+    const client = createClient(running.url, true);
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(running.url)),
+    );
+
+    expect(client.getProtocolEra()).toBe('modern');
+    const tools = await client.listTools();
+    expect(tools.tools.some((tool) => tool.name === 'list_devices')).toBe(true);
+    const consoleTool = tools.tools.find(
+      (tool) => tool.name === 'get_console_logs',
+    );
+    expect(consoleTool?._meta).toMatchObject({
+      ui: { resourceUri: 'ui://metro/console' },
+      'ui/resourceUri': 'ui://metro/console',
+    });
+
+    const result = await client.callTool({
+      name: 'get_app_info',
+      arguments: {},
+    });
+    expect(result.content?.[0]).toMatchObject({ type: 'text' });
+
+    const resources = await client.listResources();
+    expect(
+      resources.resources.some((resource) => resource.uri === 'metro://logs'),
+    ).toBe(true);
+    const app = await client.readResource({ uri: 'ui://metro/console' });
+    expect(app.contents[0]).toMatchObject({
+      mimeType: 'text/html;profile=mcp-app',
+    });
+
+    const prompts = await client.listPrompts();
+    expect(prompts.prompts.some((prompt) => prompt.name === 'debug-app')).toBe(
+      true,
+    );
+    expect(
+      (await client.getPrompt({ name: 'debug-app' })).messages.length,
+    ).toBeGreaterThan(0);
+  });
+
+  test('keeps the 2025-era initialize path on /mcp and removes legacy SSE endpoints', async () => {
+    const running = await startTestServer();
+    expect((await fetch(new URL('/sse', running.url))).status).toBe(404);
+    expect((await fetch(new URL('/messages', running.url))).status).toBe(404);
+
+    const client = createClient(running.url, false);
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(running.url)),
+    );
+    expect(client.getProtocolEra()).toBe('legacy');
+    expect((await client.listTools()).tools.length).toBeGreaterThan(20);
+    await client.subscribeResource({ uri: 'metro://logs' });
+  });
+});

--- a/tests/protocol-v2.test.ts
+++ b/tests/protocol-v2.test.ts
@@ -3,8 +3,9 @@ import {
   Client,
   StreamableHTTPClientTransport,
 } from '@modelcontextprotocol/client';
+import { InMemoryTransport } from '@modelcontextprotocol/server';
 import { loadConfig } from '../src/config.js';
-import { startHttpServer } from '../src/server.js';
+import { createMetroRuntime, startHttpServer } from '../src/server.js';
 
 const clients: Client[] = [];
 let server: Awaited<ReturnType<typeof startHttpServer>> | undefined;
@@ -38,6 +39,55 @@ function createClient(url: string, modern: boolean): Client {
   clients.push(client);
   void url;
   return client;
+}
+
+async function expectDirectStdioResourceUpdate(modern: boolean) {
+  const config = await loadConfig(['--project-root', process.cwd()]);
+  config.metro.host = '127.0.0.1';
+  config.metro.port = 65535;
+  config.metro.autoDiscover = false;
+  config.proxy.enabled = false;
+  const runtime = await createMetroRuntime(config, [
+    '--project-root',
+    process.cwd(),
+  ]);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = createClient('stdio', modern);
+  let receivedUpdate: ((uri: string) => void) | undefined;
+  const update = new Promise<string>((resolve) => {
+    receivedUpdate = resolve;
+  });
+  client.setNotificationHandler('notifications/resources/updated', (notification) => {
+    receivedUpdate?.(notification.params.uri);
+  });
+
+  try {
+    await runtime.startStdio(serverTransport);
+    await client.connect(clientTransport);
+    if (modern) {
+      const subscription = await client.listen({
+        resourceSubscriptions: ['metro://logs'],
+      });
+      expect(subscription.honoredFilter.resourceSubscriptions).toEqual([
+        'metro://logs',
+      ]);
+    } else {
+      await client.subscribeResource({ uri: 'metro://logs' });
+    }
+
+    runtime.notifyResourceUpdated('metro://logs');
+    expect(
+      await Promise.race([
+        update,
+        new Promise<string>((_, reject) =>
+          setTimeout(() => reject(new Error('resource update timed out')), 1000),
+        ),
+      ]),
+    ).toBe('metro://logs');
+  } finally {
+    await client.close().catch(() => {});
+    runtime.close();
+  }
 }
 
 describe('V2 HTTP compatibility', () => {
@@ -95,5 +145,15 @@ describe('V2 HTTP compatibility', () => {
     expect(client.getProtocolEra()).toBe('legacy');
     expect((await client.listTools()).tools.length).toBeGreaterThan(20);
     await client.subscribeResource({ uri: 'metro://logs' });
+  });
+});
+
+describe('direct stdio compatibility', () => {
+  test('delivers modern resource updates through subscriptions/listen', async () => {
+    await expectDirectStdioResourceUpdate(true);
+  });
+
+  test('delivers legacy resource updates through resources/subscribe', async () => {
+    await expectDirectStdioResourceUpdate(false);
   });
 });


### PR DESCRIPTION
## Summary

- Migrate the MCP server and plugin configuration to protocol v2
- Update CLI, configuration, getting-started, and README documentation
- Add daemon, server, and configuration changes supporting the new integration
- Add protocol v2 and configuration test coverage

## Testing

- Added and ran configuration and protocol v2 tests
- Not run (not requested)