### PR TITLE
Keep CDP reconnects pinned to a safe app target

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "github:steve228uk/metro-bridge#53fae7c",
+        "metro-bridge": "github:steve228uk/metro-bridge#065571a",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },
@@ -349,7 +349,7 @@
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#53fae7c", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-53fae7c", "sha512-6fwiZl1rBNZTeYKAlyw/9gR6G9y1BFociiv9v8Z/qsUad1OpfQaFMdeZKeddrHSv33NQl5HbIAtG5c5ERYD0sg=="],
+    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#065571a", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-065571a", "sha512-bT1HkyraCSJNbVpQLP8+9w3ZHYQSDLHlL33/ebOoartuWaCLl8OhUM6yAn50UzllIvj6sFTE4bZd3+nIEALy0g=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "github:steve228uk/metro-bridge#689fb456a2c57f6f698cc6810481329cbd5612fa",
+        "metro-bridge": "^0.2.9",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },
@@ -349,7 +349,7 @@
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#689fb45", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-689fb45", "sha512-RVQkoXUEyP3Y2FZv6UBhpX+J9dyYKxSPftKULD12pg9RmQnQss3XHWR74g023cQUKPNBgnD+VsyMPeWm6/9XLg=="],
+    "metro-bridge": ["metro-bridge@0.2.9", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-YRxcbpXr95BZJljRvw9IFWoSybpipYag5922Js1AlnPn0LygK0ciCiNmth1wzyu3pAKDA5YH8NtMWc7DfOeFWw=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "github:steve228uk/metro-bridge#065571a",
+        "metro-bridge": "github:steve228uk/metro-bridge#689fb456a2c57f6f698cc6810481329cbd5612fa",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },
@@ -349,7 +349,7 @@
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#065571a", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-065571a", "sha512-bT1HkyraCSJNbVpQLP8+9w3ZHYQSDLHlL33/ebOoartuWaCLl8OhUM6yAn50UzllIvj6sFTE4bZd3+nIEALy0g=="],
+    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#689fb45", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-689fb45", "sha512-RVQkoXUEyP3Y2FZv6UBhpX+J9dyYKxSPftKULD12pg9RmQnQss3XHWR74g023cQUKPNBgnD+VsyMPeWm6/9XLg=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "^0.2.8",
+        "metro-bridge": "github:steve228uk/metro-bridge#878f50b",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },
@@ -349,7 +349,7 @@
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "metro-bridge": ["metro-bridge@0.2.8", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-yZZQ63Bid+FJwg9cE1Y/AflpFc8TeU9s7HO88wjiayuq8cGfc4LnZpsrwA759vLFR2R7zjcvaMc01k7RC25L5w=="],
+    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#878f50b", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-878f50b", "sha512-hQ9y+VIxII2sc0Yt3CAcZqCPu+hJsGUkbT69TxJYgz+b8AtSvQRETClZ+jEGP92yWP7NYJUI4e38lmRFO5uxPA=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "github:steve228uk/metro-bridge#878f50b",
+        "metro-bridge": "github:steve228uk/metro-bridge#53fae7c",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },
@@ -349,7 +349,7 @@
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#878f50b", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-878f50b", "sha512-hQ9y+VIxII2sc0Yt3CAcZqCPu+hJsGUkbT69TxJYgz+b8AtSvQRETClZ+jEGP92yWP7NYJUI4e38lmRFO5uxPA=="],
+    "metro-bridge": ["metro-bridge@github:steve228uk/metro-bridge#53fae7c", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "steve228uk-metro-bridge-53fae7c", "sha512-6fwiZl1rBNZTeYKAlyw/9gR6G9y1BFociiv9v8Z/qsUad1OpfQaFMdeZKeddrHSv33NQl5HbIAtG5c5ERYD0sg=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "github:steve228uk/metro-bridge#53fae7c",
+    "metro-bridge": "github:steve228uk/metro-bridge#065571a",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "github:steve228uk/metro-bridge#065571a",
+    "metro-bridge": "github:steve228uk/metro-bridge#689fb456a2c57f6f698cc6810481329cbd5612fa",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "github:steve228uk/metro-bridge#689fb456a2c57f6f698cc6810481329cbd5612fa",
+    "metro-bridge": "^0.2.9",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "github:steve228uk/metro-bridge#878f50b",
+    "metro-bridge": "github:steve228uk/metro-bridge#53fae7c",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.2.8",
+    "metro-bridge": "github:steve228uk/metro-bridge#878f50b",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },

--- a/src/plugins/device.test.ts
+++ b/src/plugins/device.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { describeMetroTarget } from './device.js';
+
+describe('describeMetroTarget', () => {
+  test('exposes app identity and attachability', () => {
+    expect(
+      describeMetroTarget({
+        id: 'page-1',
+        appId: 'com.example.app',
+        title: 'My App',
+        description: '',
+        type: 'node',
+        deviceName: 'iPhone 17',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/debug?page=1',
+        reactNative: {
+          logicalDeviceId: 'device-1',
+          capabilities: { nativePageReloads: true },
+        },
+      }),
+    ).toMatchObject({
+      id: 'page-1',
+      appId: 'com.example.app',
+      logicalDeviceId: 'device-1',
+      attachable: true,
+    });
+  });
+
+  test('exposes rejection reasons', () => {
+    expect(
+      describeMetroTarget({
+        id: 'worklet',
+        title: 'anonymous',
+        description: 'Worklet Runtime',
+        type: 'node',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/debug?page=2',
+      }),
+    ).toMatchObject({
+      attachable: false,
+      reason: 'auxiliary-runtime',
+    });
+  });
+});

--- a/src/plugins/device.test.ts
+++ b/src/plugins/device.test.ts
@@ -7,8 +7,8 @@ describe('describeMetroTarget', () => {
       describeMetroTarget({
         id: 'page-1',
         appId: 'com.example.app',
-        title: 'My App',
-        description: '',
+        title: 'Hermes React Native',
+        description: 'React Native instance',
         type: 'node',
         deviceName: 'iPhone 17',
         webSocketDebuggerUrl: 'ws://127.0.0.1:8081/debug?page=1',

--- a/src/plugins/device.ts
+++ b/src/plugins/device.ts
@@ -1,6 +1,25 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { scanMetroPorts, fetchTargets, checkMetroStatus } from 'metro-bridge';
+import {
+  scanMetroPorts,
+  fetchTargets,
+  checkMetroStatus,
+  classifyMetroTarget,
+  type MetroTarget,
+} from 'metro-bridge';
+
+export function describeMetroTarget(target: MetroTarget) {
+  return {
+    id: target.id,
+    appId: target.appId,
+    title: target.title,
+    type: target.type,
+    deviceName: target.deviceName,
+    logicalDeviceId: target.reactNative?.logicalDeviceId,
+    vm: target.vm,
+    ...classifyMetroTarget(target),
+  };
+}
 
 export const devicePlugin = definePlugin({
   name: 'device',
@@ -23,25 +42,13 @@ export const devicePlugin = definePlugin({
           const servers = await scanMetroPorts(host);
           return servers.map((s) => ({
             port: s.port,
-            targets: s.targets.map((t) => ({
-              id: t.id,
-              title: t.title,
-              type: t.type,
-              deviceName: t.deviceName,
-              vm: t.vm,
-            })),
+            targets: s.targets.map(describeMetroTarget),
           }));
         }
 
         const port = metroConfig?.port || 8081;
         const targets = await fetchTargets(host, port);
-        return targets.map((t) => ({
-          id: t.id,
-          title: t.title,
-          type: t.type,
-          deviceName: t.deviceName,
-          vm: t.vm,
-        }));
+        return targets.map(describeMetroTarget);
       },
     });
 

--- a/src/plugins/devtools.ts
+++ b/src/plugins/devtools.ts
@@ -107,6 +107,9 @@ export const devtoolsPlugin = definePlugin({
             if (target.devtoolsFrontendUrl) {
               frontendUrl = `http://${ctx.metro.host}:${ctx.metro.port}${target.devtoolsFrontendUrl}`;
             } else {
+              if (!target.webSocketDebuggerUrl) {
+                return 'Metro target has no debugger WebSocket URL. Try reconnecting.';
+              }
               let wsHost: string;
               try {
                 wsHost = new URL(target.webSocketDebuggerUrl).host;

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,12 @@ import { extractCDPExceptionMessage } from './utils/cdp.js';
 import { createPreferredFrameSizeMeta, withAppSizing } from './utils/apps.js';
 import { ResourceSubscriptionManager } from './utils/resource-subscriptions.js';
 import { createResourceUpdateScheduler } from './utils/resource-updates.js';
+import {
+  createMetroTargetPin,
+  selectMetroTarget,
+  selectPinnedTarget,
+  type MetroTargetPin,
+} from './utils/target-selection.js';
 import { version } from './version.js';
 import { createDaemonIdentity, getDaemonKey } from './daemon.js';
 import type { DaemonIdentity } from './daemon.js';
@@ -215,6 +221,7 @@ export async function createMetroRuntime(
   // Active device tracking — used by plugins to key per-device buffers.
   let activeDeviceKey: string | null = null;
   let activeDeviceName: string | null = null;
+  let targetPin: MetroTargetPin | null = null;
 
   // Server-side reconnect state — single source of truth for all reconnect logic.
   // Start with a very short delay (500ms) to recover quickly from brief disconnects
@@ -673,33 +680,34 @@ export async function createMetroRuntime(
           signal: AbortSignal.timeout(2000),
         });
         if (!resp.ok) return false;
-        const targets = (await resp.json()) as Array<{
-          id?: string;
-          title?: string;
-          webSocketDebuggerUrl?: string;
-        }>;
-        if (targets.length > 0 && targets[0].webSocketDebuggerUrl) {
+        const targets = (await resp.json()) as MetroTarget[];
+        const metroHost = lockData.metroHost ?? config.metro.host!;
+        const metroPort = lockData.metroPort ?? config.metro.port!;
+        const target = targetPin
+          ? targetPin.host === metroHost && targetPin.port === metroPort
+            ? selectPinnedTarget(targets, targetPin)
+            : null
+          : selectBestTarget(targets);
+        if (target) {
           logger.info(
             `Found existing metro-mcp proxy (PID ${lockData.pid}, port ${lockData.port}) — connecting as secondary`,
           );
           // Set active device key BEFORE connecting so plugin event handlers
           // that fire on the 'reconnected' event can store events immediately.
-          activeDeviceKey = targets[0].id
-            ? `${lockData.port}-${targets[0].id}`
-            : null;
-          activeDeviceName = targets[0].title || targets[0].id || 'secondary';
+          activeDeviceKey = `${metroPort}-${target.id}`;
+          activeDeviceName = target.title || target.deviceName || target.id;
           // Point devtools plugin at the primary's proxy so open_devtools uses the right port
           (config as Record<string, unknown>).proxy = {
             ...config.proxy,
             port: lockData.port,
           };
-          await cdpSession.connectToTarget(
-            targets[0] as unknown as MetroTarget,
+          await cdpSession.connectToTarget(target);
+          eventsClient.connect(metroHost, metroPort);
+          config.metro.port = metroPort;
+          targetPin ??= createMetroTargetPin(
+            { host: metroHost, port: metroPort },
+            target,
           );
-          if (lockData.metroPort) {
-            eventsClient.connect(config.metro.host!, lockData.metroPort);
-            config.metro.port = lockData.metroPort;
-          }
           return true;
         }
       }
@@ -709,11 +717,20 @@ export async function createMetroRuntime(
     return false;
   }
 
-  function writeProxyLock(proxyPort: number, metroPort: number): void {
+  function writeProxyLock(
+    proxyPort: number,
+    metroHost: string,
+    metroPort: number,
+  ): void {
     try {
       fs.writeFileSync(
         PROXY_LOCK_FILE,
-        JSON.stringify({ pid: process.pid, port: proxyPort, metroPort }),
+        JSON.stringify({
+          pid: process.pid,
+          port: proxyPort,
+          metroHost,
+          metroPort,
+        }),
       );
       isPrimaryInstance = true;
       logger.info(`Wrote proxy lock (port ${proxyPort})`);
@@ -771,14 +788,17 @@ export async function createMetroRuntime(
         return false;
       }
 
-      const server = servers[0];
-      config.metro.port = server.port;
-      const target = selectBestTarget(server.targets);
-
-      if (!target) {
-        logger.warn('No suitable CDP target found.');
+      const selected = selectMetroTarget(servers, targetPin);
+      if (!selected) {
+        logger.warn(
+          targetPin
+            ? 'Pinned Metro app is unavailable; remaining disconnected.'
+            : 'No suitable CDP target found.',
+        );
         return false;
       }
+      const { server, target } = selected;
+      config.metro.port = server.port;
 
       // Set active device key BEFORE connecting so plugin event handlers
       // that fire on the 'reconnected' event can store events immediately.
@@ -815,9 +835,10 @@ export async function createMetroRuntime(
 
       await cdpSession.connectToTarget(target);
       eventsClient.connect(server.host, server.port);
+      targetPin ??= createMetroTargetPin(server, target);
 
       if (cdpMultiplexer?.port) {
-        writeProxyLock(cdpMultiplexer.port, server.port);
+        writeProxyLock(cdpMultiplexer.port, server.host, server.port);
       }
 
       return true;

--- a/src/utils/target-selection.test.ts
+++ b/src/utils/target-selection.test.ts
@@ -43,10 +43,20 @@ describe('pinned Metro target selection', () => {
     const originalServer = server([target('page-1')]);
     const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);
     const reloaded = target('page-2', {
-      reactNative: { logicalDeviceId: 'replacement-device-id' },
+      reactNative: undefined,
     });
 
     expect(selectPinnedTarget([reloaded], pin)).toBe(reloaded);
+  });
+
+  test('rejects the device-name fallback when its logical id conflicts', () => {
+    const originalServer = server([target('page-1')]);
+    const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);
+    const otherDevice = target('page-2', {
+      reactNative: { logicalDeviceId: 'device-2' },
+    });
+
+    expect(selectPinnedTarget([otherDevice], pin)).toBeNull();
   });
 
   test('refuses auxiliary runtimes and another device', () => {

--- a/src/utils/target-selection.test.ts
+++ b/src/utils/target-selection.test.ts
@@ -64,6 +64,18 @@ describe('pinned Metro target selection', () => {
     expect(selectPinnedTarget([worklet, otherDevice], pin)).toBeNull();
   });
 
+  test('rejects a recycled target id with conflicting app identity', () => {
+    const originalServer = server([target('page-1')]);
+    const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);
+    const replacement = target('page-1', {
+      appId: 'com.example.other',
+      deviceName: 'iPhone 18',
+      reactNative: { logicalDeviceId: 'device-2' },
+    });
+
+    expect(selectPinnedTarget([replacement], pin)).toBeNull();
+  });
+
   test('stays on the same Metro server', () => {
     const originalServer = server([target('page-1')]);
     const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);

--- a/src/utils/target-selection.test.ts
+++ b/src/utils/target-selection.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import type { MetroServerInfo, MetroTarget } from 'metro-bridge';
+import {
+  createMetroTargetPin,
+  selectMetroTarget,
+  selectPinnedTarget,
+} from './target-selection.js';
+
+function target(
+  id: string,
+  overrides: Partial<MetroTarget> = {},
+): MetroTarget {
+  return {
+    id,
+    appId: 'com.example.app',
+    title: 'Hermes React Native',
+    description: 'React Native instance',
+    type: 'node',
+    deviceName: 'iPhone 17',
+    webSocketDebuggerUrl: `ws://127.0.0.1:8081/debug?page=${id}`,
+    reactNative: { logicalDeviceId: 'device-1' },
+    ...overrides,
+  };
+}
+
+function server(
+  targets: MetroTarget[],
+  overrides: Partial<MetroServerInfo> = {},
+): MetroServerInfo {
+  return { host: '127.0.0.1', port: 8081, targets, ...overrides };
+}
+
+describe('pinned Metro target selection', () => {
+  test('reconnects to the same app after its page id changes', () => {
+    const originalServer = server([target('page-1')]);
+    const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);
+    const reloaded = target('page-2');
+
+    expect(selectPinnedTarget([reloaded], pin)).toBe(reloaded);
+  });
+
+  test('falls back from logical device id to app id and device name', () => {
+    const originalServer = server([target('page-1')]);
+    const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);
+    const reloaded = target('page-2', {
+      reactNative: { logicalDeviceId: 'replacement-device-id' },
+    });
+
+    expect(selectPinnedTarget([reloaded], pin)).toBe(reloaded);
+  });
+
+  test('refuses auxiliary runtimes and another device', () => {
+    const originalServer = server([target('page-1')]);
+    const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);
+    const worklet = target('worklet', {
+      title: 'React Native animations',
+      description: 'Worklet Runtime',
+    });
+    const otherDevice = target('page-2', {
+      deviceName: 'iPhone 18',
+      reactNative: { logicalDeviceId: 'device-2' },
+    });
+
+    expect(selectPinnedTarget([worklet, otherDevice], pin)).toBeNull();
+  });
+
+  test('stays on the same Metro server', () => {
+    const originalServer = server([target('page-1')]);
+    const pin = createMetroTargetPin(originalServer, originalServer.targets[0]);
+    const differentServer = server([target('page-2')], { port: 19000 });
+
+    expect(selectMetroTarget([differentServer], pin)).toBeNull();
+  });
+});

--- a/src/utils/target-selection.ts
+++ b/src/utils/target-selection.ts
@@ -52,8 +52,16 @@ export function selectPinnedTarget(
 
   if (pin.appId && pin.deviceName) {
     const deviceMatch = attachable.find(
-      (target) =>
-        target.appId === pin.appId && target.deviceName === pin.deviceName,
+      (target) => {
+        const logicalDeviceId = target.reactNative?.logicalDeviceId;
+        return (
+          target.appId === pin.appId &&
+          target.deviceName === pin.deviceName &&
+          (!pin.logicalDeviceId ||
+            !logicalDeviceId ||
+            logicalDeviceId === pin.logicalDeviceId)
+        );
+      },
     );
     if (deviceMatch) return deviceMatch;
   }

--- a/src/utils/target-selection.ts
+++ b/src/utils/target-selection.ts
@@ -1,0 +1,83 @@
+import {
+  classifyMetroTarget,
+  selectBestTarget,
+  type MetroServerInfo,
+  type MetroTarget,
+} from 'metro-bridge';
+
+export interface MetroTargetPin {
+  host: string;
+  port: number;
+  appId?: string;
+  logicalDeviceId?: string;
+  deviceName?: string;
+  targetId: string;
+}
+
+export interface SelectedMetroTarget {
+  server: MetroServerInfo;
+  target: MetroTarget;
+}
+
+export function createMetroTargetPin(
+  server: Pick<MetroServerInfo, 'host' | 'port'>,
+  target: MetroTarget,
+): MetroTargetPin {
+  return {
+    host: server.host,
+    port: server.port,
+    appId: target.appId,
+    logicalDeviceId: target.reactNative?.logicalDeviceId,
+    deviceName: target.deviceName,
+    targetId: target.id,
+  };
+}
+
+export function selectPinnedTarget(
+  targets: MetroTarget[],
+  pin: MetroTargetPin,
+): MetroTarget | null {
+  const attachable = targets.filter(
+    (target) => classifyMetroTarget(target).attachable,
+  );
+
+  if (pin.appId && pin.logicalDeviceId) {
+    const logicalMatch = attachable.find(
+      (target) =>
+        target.appId === pin.appId &&
+        target.reactNative?.logicalDeviceId === pin.logicalDeviceId,
+    );
+    if (logicalMatch) return logicalMatch;
+  }
+
+  if (pin.appId && pin.deviceName) {
+    const deviceMatch = attachable.find(
+      (target) =>
+        target.appId === pin.appId && target.deviceName === pin.deviceName,
+    );
+    if (deviceMatch) return deviceMatch;
+  }
+
+  return attachable.find((target) => target.id === pin.targetId) ?? null;
+}
+
+export function selectMetroTarget(
+  servers: MetroServerInfo[],
+  pin: MetroTargetPin | null,
+): SelectedMetroTarget | null {
+  if (pin) {
+    const server = servers.find(
+      (candidate) =>
+        candidate.host === pin.host && candidate.port === pin.port,
+    );
+    if (!server) return null;
+    const target = selectPinnedTarget(server.targets, pin);
+    return target ? { server, target } : null;
+  }
+
+  for (const server of servers) {
+    const target = selectBestTarget(server.targets);
+    if (target) return { server, target };
+  }
+  return null;
+}

--- a/src/utils/target-selection.ts
+++ b/src/utils/target-selection.ts
@@ -58,7 +58,17 @@ export function selectPinnedTarget(
     if (deviceMatch) return deviceMatch;
   }
 
-  return attachable.find((target) => target.id === pin.targetId) ?? null;
+  const idMatch = attachable.find((target) => target.id === pin.targetId);
+  if (!idMatch) return null;
+  if (pin.appId && idMatch.appId !== pin.appId) return null;
+  if (
+    pin.logicalDeviceId &&
+    idMatch.reactNative?.logicalDeviceId !== pin.logicalDeviceId
+  ) {
+    return null;
+  }
+  if (pin.deviceName && idMatch.deviceName !== pin.deviceName) return null;
+  return idMatch;
 }
 
 export function selectMetroTarget(


### PR DESCRIPTION
## Summary

- classify every list_devices target with attachability and a stable rejection reason
- pin reconnects to the original Metro server and app identity across page-id changes
- refuse auxiliary runtimes, another device, or another Metro server while the pinned app is absent
- preserve Metro host and app identity through the shared CDP proxy

## Dependency

Metro Bridge PR steve228uk/metro-bridge#12 is merged and version 0.2.9 is published. This PR now consumes `metro-bridge ^0.2.9` from npm with the refreshed lockfile.

## Testing

- bun run typecheck
- bun test (41 passing)
- bun run build
- bun run docs:build

Closes #72.