### PR TITLE
Stop orphaned managed daemons with client leases

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -59,8 +59,8 @@ export interface DaemonHealth {
   name: string;
   version: string;
   daemon?: {
-    key: string;
-    identity: DaemonIdentity;
+    keyHash: string;
+    identityHash: string;
     managed?: boolean;
   };
 }
@@ -198,6 +198,22 @@ export function getDaemonKey(
   return hash.digest('hex').slice(0, 16);
 }
 
+export function getDaemonIdentityFingerprint(identity: DaemonIdentity): string {
+  return createHash('sha256').update(JSON.stringify(identity)).digest('hex');
+}
+
+export function getDaemonKeyFingerprint(key: string): string {
+  return createHash('sha256')
+    .update('metro-mcp-daemon-key\0')
+    .update(key)
+    .digest('hex');
+}
+
+function ensureConfigDir(): void {
+  fs.mkdirSync(getConfigDir(), { recursive: true, mode: 0o700 });
+  fs.chmodSync(getConfigDir(), 0o700);
+}
+
 export function getDaemonCwd(): string {
   try {
     return fs.realpathSync(process.cwd());
@@ -215,11 +231,13 @@ export function getDaemonLockPath(key: string): string {
 }
 
 export function writeDaemonRecord(record: DaemonRecord): void {
-  fs.mkdirSync(getConfigDir(), { recursive: true });
+  ensureConfigDir();
   fs.writeFileSync(
     getDaemonRecordPath(record.key),
     JSON.stringify(record, null, 2),
+    { mode: 0o600 },
   );
+  fs.chmodSync(getDaemonRecordPath(record.key), 0o600);
 }
 
 function removeDaemonRecord(key: string): void {
@@ -299,9 +317,12 @@ async function isRecordLive(
       return false;
     }
 
+    const daemon = health.daemon;
     if (
-      health.daemon?.key !== record.key ||
-      !identityMatches(health.daemon.identity, expectedIdentity)
+      !daemon ||
+      daemon.keyHash !== getDaemonKeyFingerprint(record.key) ||
+      daemon.identityHash !== getDaemonIdentityFingerprint(expectedIdentity) ||
+      !identityMatches(record.identity, expectedIdentity)
     ) {
       logger.warn(
         `Ignoring metro-mcp daemon ${record.url}: daemon identity does not match current launch context`,
@@ -309,7 +330,7 @@ async function isRecordLive(
       return false;
     }
 
-    record.managed = health.daemon.managed === true;
+    record.managed = daemon.managed === true;
     return true;
   } catch {
     return false;
@@ -349,7 +370,7 @@ export async function withStartupLock<T>(
   key: string,
   fn: () => Promise<T>,
 ): Promise<T> {
-  fs.mkdirSync(getConfigDir(), { recursive: true });
+  ensureConfigDir();
   const lockPath = getDaemonLockPath(key);
   const deadline = Date.now() + STARTUP_LOCK_TIMEOUT_MS;
 
@@ -358,7 +379,7 @@ export async function withStartupLock<T>(
     let lockToken: string | null = null;
     let heartbeat: ReturnType<typeof setInterval> | null = null;
     try {
-      fd = fs.openSync(lockPath, 'wx');
+      fd = fs.openSync(lockPath, 'wx', 0o600);
       lockToken = randomUUID();
       fs.writeFileSync(
         fd,
@@ -380,24 +401,11 @@ export async function withStartupLock<T>(
       return await fn();
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-      try {
-        const contents = fs.readFileSync(lockPath, 'utf8');
-        const lock = JSON.parse(contents) as { pid?: number };
-        const stat = fs.statSync(lockPath);
-        if (
-          !isProcessAlive(lock.pid) ||
-          Date.now() - stat.mtimeMs > STARTUP_LOCK_STALE_MS
-        ) {
-          removeStartupLockIfUnchanged(lockPath, contents);
-          continue;
-        }
-      } catch {
-        try {
-          const contents = fs.readFileSync(lockPath, 'utf8');
-          removeStartupLockIfUnchanged(lockPath, contents);
-        } catch {
-          // The lock disappeared; retry acquisition.
-        }
+      const snapshot = readStartupLock(lockPath);
+      if (!snapshot) continue;
+      const stale = Date.now() - snapshot.mtimeMs > STARTUP_LOCK_STALE_MS;
+      if ((snapshot.valid && !isProcessAlive(snapshot.pid)) || stale) {
+        removeStartupLockIfUnchanged(lockPath, snapshot);
         continue;
       }
       await sleep(100);
@@ -447,12 +455,58 @@ function removeStartupLockIfOwned(lockPath: string, token: string): void {
   }
 }
 
+interface StartupLockSnapshot {
+  contents: string;
+  device: number;
+  inode: number;
+  mtimeMs: number;
+  size: number;
+  pid?: number;
+  valid: boolean;
+}
+
+function readStartupLock(lockPath: string): StartupLockSnapshot | null {
+  try {
+    const stat = fs.statSync(lockPath);
+    const contents = fs.readFileSync(lockPath, 'utf8');
+    let pid: number | undefined;
+    let valid = false;
+    try {
+      const lock = JSON.parse(contents) as { pid?: unknown; token?: unknown };
+      if (typeof lock.pid === 'number' && typeof lock.token === 'string') {
+        pid = lock.pid;
+        valid = true;
+      }
+    } catch {
+      // A process may have created the file and not written its payload yet.
+    }
+    return {
+      contents,
+      device: stat.dev,
+      inode: stat.ino,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      pid,
+      valid,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function removeStartupLockIfUnchanged(
   lockPath: string,
-  expectedContents: string,
+  expected: StartupLockSnapshot,
 ): void {
   try {
-    if (fs.readFileSync(lockPath, 'utf8') !== expectedContents) return;
+    const current = fs.statSync(lockPath);
+    if (
+      current.dev !== expected.device ||
+      current.ino !== expected.inode ||
+      current.mtimeMs !== expected.mtimeMs ||
+      current.size !== expected.size ||
+      fs.readFileSync(lockPath, 'utf8') !== expected.contents
+    ) return;
     fs.unlinkSync(lockPath);
   } catch {
     // The lock may have been replaced or removed concurrently.
@@ -460,6 +514,7 @@ function removeStartupLockIfUnchanged(
 }
 
 export async function cleanupStaleDaemonRecords(): Promise<void> {
+  ensureConfigDir();
   let entries: string[];
   try {
     entries = fs.readdirSync(getConfigDir());
@@ -487,27 +542,11 @@ export async function cleanupStaleDaemonRecords(): Promise<void> {
       const lockMatch = /^daemon-([a-f0-9]+)\.lock$/.exec(entry);
       if (!lockMatch) return;
       const lockPath = getDaemonLockPath(lockMatch[1]);
-      let contents: string;
-      try {
-        contents = fs.readFileSync(lockPath, 'utf8');
-        const lock = JSON.parse(contents) as {
-          pid?: number;
-        };
-        const stat = fs.statSync(lockPath);
-        if (
-          isProcessAlive(lock.pid) &&
-          Date.now() - stat.mtimeMs <= STARTUP_LOCK_STALE_MS
-        ) {
-          return;
-        }
-      } catch {
-        try {
-          contents = fs.readFileSync(lockPath, 'utf8');
-        } catch {
-          return;
-        }
-      }
-      removeStartupLockIfUnchanged(lockPath, contents);
+      const snapshot = readStartupLock(lockPath);
+      if (!snapshot) return;
+      const stale = Date.now() - snapshot.mtimeMs > STARTUP_LOCK_STALE_MS;
+      if (!stale && (!snapshot.valid || isProcessAlive(snapshot.pid))) return;
+      removeStartupLockIfUnchanged(lockPath, snapshot);
     }),
   );
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -17,6 +17,9 @@ const DAEMON_KEY_ENV = 'METRO_MCP_DAEMON_KEY';
 const DAEMON_CONFIG_DIR_ENV = 'METRO_MCP_DAEMON_CONFIG_DIR';
 const STARTUP_LOCK_TIMEOUT_MS = 10_000;
 const STARTUP_LOCK_STALE_MS = 30_000;
+const DAEMON_LEASE_RENEW_MS = 10_000;
+export const DAEMON_LEASE_TTL_MS = 30_000;
+export const DAEMON_IDLE_GRACE_MS = 30_000;
 const DAEMON_ENV_KEYS = [
   'METRO_HOST',
   'METRO_PORT',
@@ -57,6 +60,85 @@ export interface DaemonHealth {
     key: string;
     identity: DaemonIdentity;
   };
+}
+
+export interface DaemonLeaseRegistryOptions {
+  leaseTtlMs?: number;
+  idleGraceMs?: number;
+  onIdle: () => void | Promise<void>;
+}
+
+export class DaemonLeaseRegistry {
+  private leases = new Map<string, ReturnType<typeof setTimeout>>();
+  private graceTimer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
+  private idleTriggered = false;
+  private readonly leaseTtlMs: number;
+  private readonly idleGraceMs: number;
+
+  constructor(private readonly options: DaemonLeaseRegistryOptions) {
+    this.leaseTtlMs = options.leaseTtlMs ?? DAEMON_LEASE_TTL_MS;
+    this.idleGraceMs = options.idleGraceMs ?? DAEMON_IDLE_GRACE_MS;
+    this.scheduleGrace();
+  }
+
+  renew(clientId: string): void {
+    if (this.closed || this.idleTriggered) return;
+    const existing = this.leases.get(clientId);
+    if (existing) clearTimeout(existing);
+    if (this.graceTimer) {
+      clearTimeout(this.graceTimer);
+      this.graceTimer = null;
+    }
+    const expiry = setTimeout(() => {
+      this.leases.delete(clientId);
+      this.scheduleGrace();
+    }, this.leaseTtlMs);
+    expiry.unref?.();
+    this.leases.set(clientId, expiry);
+  }
+
+  release(clientId: string): void {
+    if (this.closed || this.idleTriggered) return;
+    const expiry = this.leases.get(clientId);
+    if (!expiry) return;
+    clearTimeout(expiry);
+    this.leases.delete(clientId);
+    this.scheduleGrace();
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const expiry of this.leases.values()) clearTimeout(expiry);
+    this.leases.clear();
+    if (this.graceTimer) clearTimeout(this.graceTimer);
+    this.graceTimer = null;
+  }
+
+  get size(): number {
+    return this.leases.size;
+  }
+
+  private scheduleGrace(): void {
+    if (
+      this.closed ||
+      this.idleTriggered ||
+      this.leases.size > 0 ||
+      this.graceTimer
+    ) {
+      return;
+    }
+    this.graceTimer = setTimeout(() => {
+      this.graceTimer = null;
+      if (this.closed || this.leases.size > 0 || this.idleTriggered) return;
+      this.idleTriggered = true;
+      Promise.resolve(this.options.onIdle()).catch((err) => {
+        logger.error('Managed daemon idle shutdown failed:', err);
+      });
+    }, this.idleGraceMs);
+    this.graceTimer.unref?.();
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -124,7 +206,7 @@ export function getDaemonRecordPath(key: string): string {
   return path.join(getConfigDir(), `daemon-${key}.json`);
 }
 
-function getDaemonLockPath(key: string): string {
+export function getDaemonLockPath(key: string): string {
   return path.join(getConfigDir(), `daemon-${key}.lock`);
 }
 
@@ -301,19 +383,52 @@ export async function cleanupStaleDaemonRecords(): Promise<void> {
 
   await Promise.all(
     entries.map(async (entry) => {
-      const match = /^daemon-([a-f0-9]+)\.json$/.exec(entry);
-      if (!match) return;
-
-      const key = match[1];
-      try {
-        const record = JSON.parse(
-          fs.readFileSync(getDaemonRecordPath(key), 'utf8'),
-        ) as DaemonRecord;
-        if (await isRecordLive(record)) return;
-      } catch {
-        // Corrupt records are stale.
+      const recordMatch = /^daemon-([a-f0-9]+)\.json$/.exec(entry);
+      if (recordMatch) {
+        const key = recordMatch[1];
+        try {
+          const record = JSON.parse(
+            fs.readFileSync(getDaemonRecordPath(key), 'utf8'),
+          ) as DaemonRecord;
+          if (await isRecordLive(record)) return;
+        } catch {
+          // Corrupt records are stale.
+        }
+        removeDaemonRecord(key);
+        return;
       }
-      removeDaemonRecord(key);
+
+      const lockMatch = /^daemon-([a-f0-9]+)\.lock$/.exec(entry);
+      if (!lockMatch) return;
+      const lockPath = getDaemonLockPath(lockMatch[1]);
+      try {
+        const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+          pid?: number;
+        };
+        const stat = fs.statSync(lockPath);
+        let processAlive = false;
+        if (typeof lock.pid === 'number') {
+          try {
+            process.kill(lock.pid, 0);
+            processAlive = true;
+          } catch {
+            processAlive = false;
+          }
+        }
+        if (
+          processAlive &&
+          Date.now() - stat.mtimeMs <= STARTUP_LOCK_STALE_MS
+        ) {
+          return;
+        }
+      } catch {
+        // Corrupt locks are stale.
+      }
+      try {
+        fs.unlinkSync(lockPath);
+      } catch {
+        // Already removed.
+      }
     }),
   );
 }
@@ -358,13 +473,38 @@ export function getDaemonKeyFromEnv(
   return process.env[DAEMON_KEY_ENV] || getDaemonKey(args, identity);
 }
 
+export function isManagedDaemonProcess(): boolean {
+  return Boolean(process.env[DAEMON_KEY_ENV]);
+}
+
+async function updateDaemonLease(
+  record: DaemonRecord,
+  clientId: string,
+  method: 'PUT' | 'DELETE',
+): Promise<void> {
+  const leaseUrl = new URL(
+    `/_metro-mcp/clients/${encodeURIComponent(clientId)}`,
+    record.url,
+  );
+  const response = await fetch(leaseUrl, {
+    method,
+    headers: { 'x-metro-mcp-daemon-key': record.key },
+    signal: AbortSignal.timeout(2000),
+  });
+  if (!response.ok) {
+    throw new Error(`Daemon lease ${method} failed with HTTP ${response.status}`);
+  }
+}
+
 export async function startStdioProxy(args: string[]): Promise<void> {
   const record = await ensureDaemon(args);
+  const clientId = randomUUID();
   const stdio = new StdioServerTransport();
   const daemonTransport = new StreamableHTTPClientTransport(
     new URL(record.url),
   );
   let closing = false;
+  let leaseTimer: ReturnType<typeof setInterval> | null = null;
 
   async function closeQuietly(transport: {
     close(): Promise<void>;
@@ -375,6 +515,9 @@ export async function startStdioProxy(args: string[]): Promise<void> {
   async function close(): Promise<void> {
     if (closing) return;
     closing = true;
+    if (leaseTimer) clearInterval(leaseTimer);
+    leaseTimer = null;
+    await updateDaemonLease(record, clientId, 'DELETE').catch(() => {});
     await Promise.all([closeQuietly(stdio), closeQuietly(daemonTransport)]);
     process.exit(0);
   }
@@ -396,6 +539,14 @@ export async function startStdioProxy(args: string[]): Promise<void> {
     logger.error('daemon transport error:', err);
   stdio.onclose = () => void close();
   daemonTransport.onclose = () => void close();
+
+  await updateDaemonLease(record, clientId, 'PUT');
+  leaseTimer = setInterval(() => {
+    updateDaemonLease(record, clientId, 'PUT').catch((err) => {
+      logger.warn('Failed to renew daemon lease:', err);
+    });
+  }, DAEMON_LEASE_RENEW_MS);
+  leaseTimer.unref?.();
 
   await daemonTransport.start();
   await stdio.start();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -630,12 +630,13 @@ export interface DaemonLeaseClientOptions {
   update?: DaemonLeaseUpdater;
 }
 
-/** Serializes lease shutdown behind any in-flight renewal. */
+/** Serializes lease shutdown behind initial acquisition and any renewal. */
 export class DaemonLeaseClient {
   private readonly clientId: string;
   private readonly renewIntervalMs: number;
   private readonly update: DaemonLeaseUpdater;
   private renewalTimer: ReturnType<typeof setInterval> | null = null;
+  private startPromise: Promise<void> | null = null;
   private renewalRequest: Promise<void> | null = null;
   private stopPromise: Promise<void> | null = null;
   private acquired = false;
@@ -651,14 +652,18 @@ export class DaemonLeaseClient {
     this.update = options.update ?? updateDaemonLease;
   }
 
-  async start(): Promise<void> {
-    if (this.record.managed !== true) return;
+  start(): Promise<void> {
+    if (this.record.managed !== true || this.stopping) {
+      return Promise.resolve();
+    }
+    if (!this.startPromise) this.startPromise = this.acquire();
+    return this.startPromise;
+  }
+
+  private async acquire(): Promise<void> {
     await this.update(this.record, this.clientId, 'PUT');
     this.acquired = true;
-    if (this.stopping) {
-      await this.release();
-      return;
-    }
+    if (this.stopping) return;
     this.renewalTimer = setInterval(
       () => this.renew(),
       this.renewIntervalMs,
@@ -672,6 +677,7 @@ export class DaemonLeaseClient {
     if (this.renewalTimer) clearInterval(this.renewalTimer);
     this.renewalTimer = null;
     this.stopPromise = (async () => {
+      await this.startPromise?.catch(() => {});
       await this.renewalRequest?.catch(() => {});
       await this.release();
     })();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
+import type { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -699,6 +700,32 @@ export class DaemonLeaseClient {
   }
 }
 
+/** SDK stdio transports do not turn stdin EOF into an onclose notification. */
+export function registerStdioProxyShutdown(
+  shutdown: () => void,
+  input: EventEmitter = process.stdin,
+  lifecycle: EventEmitter = process,
+): () => void {
+  let requested = false;
+  const requestShutdown = () => {
+    if (requested) return;
+    requested = true;
+    shutdown();
+  };
+  input.on('end', requestShutdown);
+  input.on('close', requestShutdown);
+  lifecycle.on('SIGINT', requestShutdown);
+  lifecycle.on('SIGTERM', requestShutdown);
+  lifecycle.on('beforeExit', requestShutdown);
+  return () => {
+    input.off('end', requestShutdown);
+    input.off('close', requestShutdown);
+    lifecycle.off('SIGINT', requestShutdown);
+    lifecycle.off('SIGTERM', requestShutdown);
+    lifecycle.off('beforeExit', requestShutdown);
+  };
+}
+
 export async function startStdioProxy(args: string[]): Promise<void> {
   const record = await ensureDaemon(args);
   const lease = new DaemonLeaseClient(record);
@@ -707,6 +734,7 @@ export async function startStdioProxy(args: string[]): Promise<void> {
     new URL(record.url),
   );
   let closing = false;
+  const removeShutdownListeners = registerStdioProxyShutdown(() => void close());
 
   async function closeQuietly(transport: {
     close(): Promise<void>;
@@ -719,6 +747,7 @@ export async function startStdioProxy(args: string[]): Promise<void> {
     closing = true;
     await lease.stop().catch(() => {});
     await Promise.all([closeQuietly(stdio), closeQuietly(daemonTransport)]);
+    removeShutdownListeners();
     process.exit(0);
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -299,11 +299,7 @@ async function isRecordLive(
   record: DaemonRecord,
   expectedIdentity?: DaemonIdentity,
 ): Promise<boolean> {
-  try {
-    process.kill(record.pid, 0);
-  } catch {
-    return false;
-  }
+  if (!isProcessAlive(record.pid)) return false;
 
   try {
     const health = await readHealth(record);
@@ -426,12 +422,13 @@ export async function withStartupLock<T>(
 }
 
 function isProcessAlive(pid: number | undefined): boolean {
-  if (typeof pid !== 'number') return false;
+  if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // A process we cannot signal still exists; only a missing/invalid PID is dead.
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
   }
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -49,6 +49,8 @@ export interface DaemonRecord {
   cwd: string;
   args: string[];
   identity?: DaemonIdentity;
+  /** Whether the server was auto-spawned and requires client leases. */
+  managed?: boolean;
   startedAt: string;
 }
 
@@ -59,6 +61,7 @@ export interface DaemonHealth {
   daemon?: {
     key: string;
     identity: DaemonIdentity;
+    managed?: boolean;
   };
 }
 
@@ -82,8 +85,8 @@ export class DaemonLeaseRegistry {
     this.scheduleGrace();
   }
 
-  renew(clientId: string): void {
-    if (this.closed || this.idleTriggered) return;
+  renew(clientId: string): boolean {
+    if (this.closed || this.idleTriggered) return false;
     const existing = this.leases.get(clientId);
     if (existing) clearTimeout(existing);
     if (this.graceTimer) {
@@ -96,6 +99,7 @@ export class DaemonLeaseRegistry {
     }, this.leaseTtlMs);
     expiry.unref?.();
     this.leases.set(clientId, expiry);
+    return true;
   }
 
   release(clientId: string): void {
@@ -246,8 +250,26 @@ function identityMatches(
   return JSON.stringify(actual) === JSON.stringify(expected);
 }
 
+function parseLocalDaemonUrl(value: string): URL | null {
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase();
+    if (
+      url.protocol !== 'http:' ||
+      !['localhost', '127.0.0.1', '[::1]', '::1'].includes(hostname)
+    ) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
+
 async function readHealth(record: DaemonRecord): Promise<DaemonHealth | null> {
-  const healthUrl = new URL('/health', record.url);
+  const daemonUrl = parseLocalDaemonUrl(record.url);
+  if (!daemonUrl) return null;
+  const healthUrl = new URL('/health', daemonUrl);
   const response = await fetch(healthUrl, {
     signal: AbortSignal.timeout(1000),
   });
@@ -287,6 +309,7 @@ async function isRecordLive(
       return false;
     }
 
+    record.managed = health.daemon.managed === true;
     return true;
   } catch {
     return false;
@@ -322,7 +345,7 @@ async function waitForRecord(
   throw new Error('Timed out waiting for metro-mcp daemon to start');
 }
 
-async function withStartupLock<T>(
+export async function withStartupLock<T>(
   key: string,
   fn: () => Promise<T>,
 ): Promise<T> {
@@ -332,45 +355,108 @@ async function withStartupLock<T>(
 
   while (Date.now() < deadline) {
     let fd: number | null = null;
+    let lockToken: string | null = null;
+    let heartbeat: ReturnType<typeof setInterval> | null = null;
     try {
       fd = fs.openSync(lockPath, 'wx');
+      lockToken = randomUUID();
       fs.writeFileSync(
         fd,
         JSON.stringify({
           pid: process.pid,
           createdAt: new Date().toISOString(),
+          token: lockToken,
         }),
       );
+      heartbeat = setInterval(() => {
+        try {
+          const now = new Date();
+          fs.futimesSync(fd!, now, now);
+        } catch {
+          // The owned lock descriptor may already be closing.
+        }
+      }, Math.floor(STARTUP_LOCK_STALE_MS / 3));
+      heartbeat.unref?.();
       return await fn();
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
       try {
+        const contents = fs.readFileSync(lockPath, 'utf8');
+        const lock = JSON.parse(contents) as { pid?: number };
         const stat = fs.statSync(lockPath);
-        if (Date.now() - stat.mtimeMs > STARTUP_LOCK_STALE_MS) {
-          fs.unlinkSync(lockPath);
+        if (
+          !isProcessAlive(lock.pid) ||
+          Date.now() - stat.mtimeMs > STARTUP_LOCK_STALE_MS
+        ) {
+          removeStartupLockIfUnchanged(lockPath, contents);
           continue;
         }
       } catch {
+        try {
+          const contents = fs.readFileSync(lockPath, 'utf8');
+          removeStartupLockIfUnchanged(lockPath, contents);
+        } catch {
+          // The lock disappeared; retry acquisition.
+        }
         continue;
       }
       await sleep(100);
     } finally {
+      if (heartbeat) clearInterval(heartbeat);
       if (fd !== null) {
         try {
           fs.closeSync(fd);
         } catch {
           /* ignore */
         }
-        try {
-          fs.unlinkSync(lockPath);
-        } catch {
-          /* ignore */
-        }
+        if (lockToken) removeStartupLockIfOwned(lockPath, lockToken);
       }
     }
   }
 
   throw new Error('Timed out waiting for metro-mcp daemon startup lock');
+}
+
+function isProcessAlive(pid: number | undefined): boolean {
+  if (typeof pid !== 'number') return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readStartupLockToken(lockPath: string): string | null {
+  try {
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+      token?: unknown;
+    };
+    return typeof lock.token === 'string' ? lock.token : null;
+  } catch {
+    return null;
+  }
+}
+
+function removeStartupLockIfOwned(lockPath: string, token: string): void {
+  if (readStartupLockToken(lockPath) !== token) return;
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // The lock may have been removed concurrently.
+  }
+}
+
+function removeStartupLockIfUnchanged(
+  lockPath: string,
+  expectedContents: string,
+): void {
+  try {
+    if (fs.readFileSync(lockPath, 'utf8') !== expectedContents) return;
+    fs.unlinkSync(lockPath);
+  } catch {
+    // The lock may have been replaced or removed concurrently.
+  }
 }
 
 export async function cleanupStaleDaemonRecords(): Promise<void> {
@@ -401,34 +487,27 @@ export async function cleanupStaleDaemonRecords(): Promise<void> {
       const lockMatch = /^daemon-([a-f0-9]+)\.lock$/.exec(entry);
       if (!lockMatch) return;
       const lockPath = getDaemonLockPath(lockMatch[1]);
+      let contents: string;
       try {
-        const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+        contents = fs.readFileSync(lockPath, 'utf8');
+        const lock = JSON.parse(contents) as {
           pid?: number;
         };
         const stat = fs.statSync(lockPath);
-        let processAlive = false;
-        if (typeof lock.pid === 'number') {
-          try {
-            process.kill(lock.pid, 0);
-            processAlive = true;
-          } catch {
-            processAlive = false;
-          }
-        }
         if (
-          processAlive &&
+          isProcessAlive(lock.pid) &&
           Date.now() - stat.mtimeMs <= STARTUP_LOCK_STALE_MS
         ) {
           return;
         }
       } catch {
-        // Corrupt locks are stale.
+        try {
+          contents = fs.readFileSync(lockPath, 'utf8');
+        } catch {
+          return;
+        }
       }
-      try {
-        fs.unlinkSync(lockPath);
-      } catch {
-        // Already removed.
-      }
+      removeStartupLockIfUnchanged(lockPath, contents);
     }),
   );
 }
@@ -482,9 +561,13 @@ async function updateDaemonLease(
   clientId: string,
   method: 'PUT' | 'DELETE',
 ): Promise<void> {
+  const daemonUrl = parseLocalDaemonUrl(record.url);
+  if (!daemonUrl) {
+    throw new Error(`Refusing daemon lease request to non-local URL: ${record.url}`);
+  }
   const leaseUrl = new URL(
     `/_metro-mcp/clients/${encodeURIComponent(clientId)}`,
-    record.url,
+    daemonUrl,
   );
   const response = await fetch(leaseUrl, {
     method,
@@ -496,15 +579,92 @@ async function updateDaemonLease(
   }
 }
 
+type DaemonLeaseUpdater = (
+  record: DaemonRecord,
+  clientId: string,
+  method: 'PUT' | 'DELETE',
+) => Promise<void>;
+
+export interface DaemonLeaseClientOptions {
+  clientId?: string;
+  renewIntervalMs?: number;
+  update?: DaemonLeaseUpdater;
+}
+
+/** Serializes lease shutdown behind any in-flight renewal. */
+export class DaemonLeaseClient {
+  private readonly clientId: string;
+  private readonly renewIntervalMs: number;
+  private readonly update: DaemonLeaseUpdater;
+  private renewalTimer: ReturnType<typeof setInterval> | null = null;
+  private renewalRequest: Promise<void> | null = null;
+  private stopPromise: Promise<void> | null = null;
+  private acquired = false;
+  private stopping = false;
+
+  constructor(
+    private readonly record: DaemonRecord,
+    options: DaemonLeaseClientOptions = {},
+  ) {
+    this.clientId = options.clientId ?? randomUUID();
+    this.renewIntervalMs =
+      options.renewIntervalMs ?? DAEMON_LEASE_RENEW_MS;
+    this.update = options.update ?? updateDaemonLease;
+  }
+
+  async start(): Promise<void> {
+    if (this.record.managed !== true) return;
+    await this.update(this.record, this.clientId, 'PUT');
+    this.acquired = true;
+    if (this.stopping) {
+      await this.release();
+      return;
+    }
+    this.renewalTimer = setInterval(
+      () => this.renew(),
+      this.renewIntervalMs,
+    );
+    this.renewalTimer.unref?.();
+  }
+
+  stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
+    this.stopping = true;
+    if (this.renewalTimer) clearInterval(this.renewalTimer);
+    this.renewalTimer = null;
+    this.stopPromise = (async () => {
+      await this.renewalRequest?.catch(() => {});
+      await this.release();
+    })();
+    return this.stopPromise;
+  }
+
+  private renew(): void {
+    if (this.stopping || !this.acquired || this.renewalRequest) return;
+    const request = this.update(this.record, this.clientId, 'PUT');
+    this.renewalRequest = request;
+    void request
+      .catch((err) => logger.warn('Failed to renew daemon lease:', err))
+      .finally(() => {
+        if (this.renewalRequest === request) this.renewalRequest = null;
+      });
+  }
+
+  private async release(): Promise<void> {
+    if (!this.acquired) return;
+    this.acquired = false;
+    await this.update(this.record, this.clientId, 'DELETE');
+  }
+}
+
 export async function startStdioProxy(args: string[]): Promise<void> {
   const record = await ensureDaemon(args);
-  const clientId = randomUUID();
+  const lease = new DaemonLeaseClient(record);
   const stdio = new StdioServerTransport();
   const daemonTransport = new StreamableHTTPClientTransport(
     new URL(record.url),
   );
   let closing = false;
-  let leaseTimer: ReturnType<typeof setInterval> | null = null;
 
   async function closeQuietly(transport: {
     close(): Promise<void>;
@@ -515,9 +675,7 @@ export async function startStdioProxy(args: string[]): Promise<void> {
   async function close(): Promise<void> {
     if (closing) return;
     closing = true;
-    if (leaseTimer) clearInterval(leaseTimer);
-    leaseTimer = null;
-    await updateDaemonLease(record, clientId, 'DELETE').catch(() => {});
+    await lease.stop().catch(() => {});
     await Promise.all([closeQuietly(stdio), closeQuietly(daemonTransport)]);
     process.exit(0);
   }
@@ -540,13 +698,7 @@ export async function startStdioProxy(args: string[]): Promise<void> {
   stdio.onclose = () => void close();
   daemonTransport.onclose = () => void close();
 
-  await updateDaemonLease(record, clientId, 'PUT');
-  leaseTimer = setInterval(() => {
-    updateDaemonLease(record, clientId, 'PUT').catch((err) => {
-      logger.warn('Failed to renew daemon lease:', err);
-    });
-  }, DAEMON_LEASE_RENEW_MS);
-  leaseTimer.unref?.();
+  await lease.start();
 
   await daemonTransport.start();
   await stdio.start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   createDaemonIdentity,
   getDaemonCwd,
   getDaemonKeyFromEnv,
+  isManagedDaemonProcess,
   removeDaemonRecordForProcess,
   startStdioProxy,
   writeDaemonRecord,
@@ -112,7 +113,7 @@ Examples:
         removeDaemonRecordForProcess(key, process.pid);
       await startHttpServer(config, serverArgs, {
         port: mcpPort,
-        daemon: { key, identity },
+        daemon: { key, identity, managed: isManagedDaemonProcess() },
         onListening: ({ host, port, url }) => {
           writeDaemonRecord({
             pid: process.pid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,11 +109,12 @@ Examples:
         projectRoot: config.projectRoot,
       });
       const key = getDaemonKeyFromEnv(serverArgs, identity);
+      const managed = isManagedDaemonProcess();
       const cleanupDaemonRecord = () =>
         removeDaemonRecordForProcess(key, process.pid);
       await startHttpServer(config, serverArgs, {
         port: mcpPort,
-        daemon: { key, identity, managed: isManagedDaemonProcess() },
+        daemon: { key, identity, managed },
         onListening: ({ host, port, url }) => {
           writeDaemonRecord({
             pid: process.pid,
@@ -124,6 +125,7 @@ Examples:
             cwd: config.projectRoot ?? getDaemonCwd(),
             args: serverArgs,
             identity,
+            managed,
             startedAt: new Date().toISOString(),
           });
           process.once('exit', cleanupDaemonRecord);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1179,7 +1179,10 @@ export async function startHttpServer(
           return;
         }
         if (req.method === 'PUT') {
-          leaseRegistry.renew(leaseMatch[1]);
+          if (!leaseRegistry.renew(leaseMatch[1])) {
+            res.writeHead(409).end('Daemon is shutting down');
+            return;
+          }
           res.writeHead(204).end();
           return;
         }
@@ -1201,6 +1204,7 @@ export async function startHttpServer(
           daemon: {
             key: daemonKey,
             identity: daemonIdentity,
+            managed: options.daemon?.managed === true,
           },
         });
         return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1004,6 +1004,7 @@ export async function createMetroRuntime(
     clearReconnectStabilityTimer();
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
+    process.off('beforeExit', handleBeforeExit);
     process.off('exit', handleExit);
     const sessionsToClose = [...sessions];
     const stdioToClose = stdioHandle;
@@ -1035,13 +1036,23 @@ export async function createMetroRuntime(
   const handleSigterm = () => {
     void closeRuntime().finally(() => process.exit(0));
   };
+  const handleBeforeExit = () => {
+    void closeRuntime().catch((err) => {
+      logger.error('Runtime shutdown failed:', err);
+    });
+  };
   const handleExit = () => {
-    void closeRuntime();
+    // The exit event cannot await promises. Limit this fallback to synchronous
+    // cleanup; normal signals and beforeExit use the complete async path above.
+    eventsClient.disconnect();
+    cleanProxyLock();
+    cdpSession.disconnect();
   };
 
   // Clean up on shutdown
   process.on('SIGINT', handleSigint);
   process.on('SIGTERM', handleSigterm);
+  process.on('beforeExit', handleBeforeExit);
   process.on('exit', handleExit);
 
   // Try connecting to Metro (non-blocking — server works without connection).

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,8 @@ import {
   createDaemonIdentity,
   DaemonLeaseRegistry,
   getDaemonKey,
+  getDaemonIdentityFingerprint,
+  getDaemonKeyFingerprint,
 } from './daemon.js';
 import type { DaemonIdentity } from './daemon.js';
 
@@ -1202,8 +1204,8 @@ export async function startHttpServer(
           name: 'metro-mcp',
           version,
           daemon: {
-            key: daemonKey,
-            identity: daemonIdentity,
+            keyHash: getDaemonKeyFingerprint(daemonKey),
+            identityHash: getDaemonIdentityFingerprint(daemonIdentity),
             managed: options.daemon?.managed === true,
           },
         });

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,11 @@ import { createPreferredFrameSizeMeta, withAppSizing } from './utils/apps.js';
 import { ResourceSubscriptionManager } from './utils/resource-subscriptions.js';
 import { createResourceUpdateScheduler } from './utils/resource-updates.js';
 import { version } from './version.js';
-import { createDaemonIdentity, getDaemonKey } from './daemon.js';
+import {
+  createDaemonIdentity,
+  DaemonLeaseRegistry,
+  getDaemonKey,
+} from './daemon.js';
 import type { DaemonIdentity } from './daemon.js';
 
 // Built-in plugins
@@ -131,7 +135,11 @@ interface HttpServerOptions {
   daemon?: {
     key: string;
     identity: DaemonIdentity;
+    managed?: boolean;
+    leaseTtlMs?: number;
+    idleGraceMs?: number;
   };
+  onManagedDaemonIdle?: () => void | Promise<void>;
   onListening?: (info: { host: string; port: number; url: string }) => void;
 }
 
@@ -187,6 +195,7 @@ export async function createMetroRuntime(
   const resourceSubscriptions = new ResourceSubscriptionManager();
   let isInitializingPlugins = false;
   let runtimeClosed = false;
+  let runtimeClosePromise: Promise<void> | null = null;
   let modernResourceNotifier: ((uri: string) => void) | null = null;
   let stdioHandle: { close(): Promise<void> } | null = null;
 
@@ -983,8 +992,8 @@ export async function createMetroRuntime(
     logger.info('MCP stdio server started');
   }
 
-  function closeRuntime(): void {
-    if (runtimeClosed) return;
+  function closeRuntime(): Promise<void> {
+    if (runtimeClosePromise) return runtimeClosePromise;
     runtimeClosed = true;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
@@ -994,32 +1003,38 @@ export async function createMetroRuntime(
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
     process.off('exit', handleExit);
-    for (const session of sessions) {
-      resourceSubscriptions.unsubscribeAll(session);
-      resourceUpdates.removeTarget(session.id);
-      for (const registration of session.registrations) registration.remove();
-      session.server.close().catch(() => {});
-    }
-    sessions.clear();
-    modernStdioServers.clear();
-    stdioHandle?.close().catch(() => {});
+    const sessionsToClose = [...sessions];
+    const stdioToClose = stdioHandle;
     stdioHandle = null;
     resourceUpdates.close();
-    eventsClient.disconnect();
-    cleanProxyLock();
-    cdpMultiplexer?.stop();
+    runtimeClosePromise = (async () => {
+      for (const session of sessionsToClose) {
+        resourceSubscriptions.unsubscribeAll(session);
+        resourceUpdates.removeTarget(session.id);
+        for (const registration of session.registrations) registration.remove();
+      }
+      sessions.clear();
+      modernStdioServers.clear();
+      await Promise.all(
+        sessionsToClose.map((session) => session.server.close().catch(() => {})),
+      );
+      await stdioToClose?.close().catch(() => {});
+      eventsClient.disconnect();
+      cleanProxyLock();
+      await cdpMultiplexer?.stop().catch(() => {});
+      cdpSession.disconnect();
+    })();
+    return runtimeClosePromise;
   }
 
   const handleSigint = () => {
-    closeRuntime();
-    process.exit(0);
+    void closeRuntime().finally(() => process.exit(0));
   };
   const handleSigterm = () => {
-    closeRuntime();
-    process.exit(0);
+    void closeRuntime().finally(() => process.exit(0));
   };
   const handleExit = () => {
-    closeRuntime();
+    void closeRuntime();
   };
 
   // Clean up on shutdown
@@ -1078,6 +1093,8 @@ export async function startHttpServer(
     string,
     NodeStreamableHTTPServerTransport
   >();
+  let leaseRegistry: DaemonLeaseRegistry | null = null;
+  let shutdownPromise: Promise<void> | null = null;
 
   const modernHandler: McpHttpHandler = createMcpHandler(
     () => runtime.createServer(),
@@ -1144,6 +1161,38 @@ export async function startHttpServer(
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? host}`);
 
     try {
+      const leaseMatch =
+        /^\/_metro-mcp\/clients\/([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i.exec(
+          url.pathname,
+        );
+      if (leaseMatch) {
+        if (!leaseRegistry) {
+          res.writeHead(404).end('Not found');
+          return;
+        }
+        const suppliedKey = req.headers['x-metro-mcp-daemon-key'];
+        if (
+          typeof suppliedKey !== 'string' ||
+          suppliedKey !== options.daemon?.key
+        ) {
+          res.writeHead(403).end('Forbidden');
+          return;
+        }
+        if (req.method === 'PUT') {
+          leaseRegistry.renew(leaseMatch[1]);
+          res.writeHead(204).end();
+          return;
+        }
+        if (req.method === 'DELETE') {
+          leaseRegistry.release(leaseMatch[1]);
+          res.writeHead(204).end();
+          return;
+        }
+        res.setHeader('allow', 'PUT, DELETE');
+        res.writeHead(405).end('Method not allowed');
+        return;
+      }
+
       if (url.pathname === '/health') {
         sendJson(res, 200, {
           ok: true,
@@ -1206,19 +1255,45 @@ export async function startHttpServer(
   options.onListening?.({ host, port, url });
   logger.info(`MCP HTTP server listening on ${url}`);
 
+  async function shutdown(): Promise<void> {
+    if (shutdownPromise) return shutdownPromise;
+    shutdownPromise = (async () => {
+      leaseRegistry?.close();
+      leaseRegistry = null;
+      for (const transport of streamableTransports.values()) {
+        await closeQuietly(transport);
+      }
+      streamableTransports.clear();
+      await modernHandler.close();
+      await runtime.close();
+      if (!server.listening) return;
+      await new Promise<void>((resolveClose) =>
+        server.close(() => resolveClose()),
+      );
+    })();
+    return shutdownPromise;
+  }
+
+  if (options.daemon?.managed) {
+    leaseRegistry = new DaemonLeaseRegistry({
+      leaseTtlMs: options.daemon.leaseTtlMs,
+      idleGraceMs: options.daemon.idleGraceMs,
+      onIdle: async () => {
+        logger.info('Managed daemon is idle; shutting down');
+        if (options.onManagedDaemonIdle) {
+          await options.onManagedDaemonIdle();
+          return;
+        }
+        await shutdown();
+        process.exit(0);
+      },
+    });
+  }
+
   return {
     host,
     port,
     url,
-    close: async () => {
-      for (const transport of streamableTransports.values()) {
-        await closeQuietly(transport);
-      }
-      await modernHandler.close();
-      runtime.close();
-      await new Promise<void>((resolveClose) =>
-        server.close(() => resolveClose()),
-      );
-    },
+    close: shutdown,
   };
 }

--- a/tests/daemon-leases.test.ts
+++ b/tests/daemon-leases.test.ts
@@ -261,6 +261,28 @@ describe('stdio daemon lease client', () => {
     expect(methods).toEqual(['PUT', 'PUT', 'DELETE']);
   });
 
+  test('waits for an in-flight initial acquisition before releasing', async () => {
+    const methods: string[] = [];
+    const acquisition = deferred();
+    const client = new DaemonLeaseClient(leaseRecord(true), {
+      renewIntervalMs: 5,
+      update: async (_record, _clientId, method) => {
+        methods.push(method);
+        if (method === 'PUT') await acquisition.promise;
+      },
+    });
+
+    const starting = client.start();
+    await waitUntil(() => methods.length === 1);
+    const stopping = client.stop();
+    await expectPending(stopping, 10);
+    acquisition.resolve();
+    await Promise.all([starting, stopping]);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(methods).toEqual(['PUT', 'DELETE']);
+  });
+
   test('refuses to send a daemon key to a non-local URL', async () => {
     const client = new DaemonLeaseClient(
       leaseRecord(true, 'http://example.com:8765/mcp'),

--- a/tests/daemon-leases.test.ts
+++ b/tests/daemon-leases.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { loadConfig } from '../src/config.js';
+import { createDaemonIdentity, getDaemonKey } from '../src/daemon.js';
+import { startHttpServer } from '../src/server.js';
+
+const servers: Array<Awaited<ReturnType<typeof startHttpServer>>> = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await server.close();
+  }
+});
+
+async function startLeaseServer(options: {
+  managed?: boolean;
+  leaseTtlMs?: number;
+  idleGraceMs?: number;
+  onIdle: () => void | Promise<void>;
+}) {
+  const args = ['--project-root', process.cwd(), '--port', '65535'];
+  const config = await loadConfig(args);
+  config.metro.host = '127.0.0.1';
+  config.metro.port = 65535;
+  config.metro.autoDiscover = false;
+  config.proxy.enabled = false;
+  const identity = createDaemonIdentity(args, {
+    projectRoot: config.projectRoot,
+  });
+  const key = getDaemonKey(args, identity);
+  const server = await startHttpServer(config, args, {
+    port: 0,
+    daemon: {
+      key,
+      identity,
+      managed: options.managed ?? true,
+      leaseTtlMs: options.leaseTtlMs,
+      idleGraceMs: options.idleGraceMs,
+    },
+    onManagedDaemonIdle: options.onIdle,
+  });
+  servers.push(server);
+  return { server, key };
+}
+
+async function updateLease(
+  server: Awaited<ReturnType<typeof startHttpServer>>,
+  key: string,
+  clientId: string,
+  method: 'PUT' | 'DELETE',
+  suppliedKey = key,
+): Promise<Response> {
+  return fetch(
+    new URL(`/_metro-mcp/clients/${clientId}`, server.url),
+    {
+      method,
+      headers: { 'x-metro-mcp-daemon-key': suppliedKey },
+    },
+  );
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function expectPending(promise: Promise<void>, durationMs: number) {
+  const settled = await Promise.race([
+    promise.then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), durationMs)),
+  ]);
+  expect(settled).toBe(false);
+}
+
+describe('managed daemon leases', () => {
+  test('requires the matching daemon key', async () => {
+    const idle = deferred();
+    const { server, key } = await startLeaseServer({
+      idleGraceMs: 500,
+      onIdle: idle.resolve,
+    });
+
+    const response = await updateLease(
+      server,
+      key,
+      randomUUID(),
+      'PUT',
+      'wrong-key',
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  test('renews one lease and shuts down after it is released', async () => {
+    const idle = deferred();
+    const { server, key } = await startLeaseServer({
+      leaseTtlMs: 100,
+      idleGraceMs: 35,
+      onIdle: idle.resolve,
+    });
+    const clientId = randomUUID();
+
+    expect((await updateLease(server, key, clientId, 'PUT')).status).toBe(204);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect((await updateLease(server, key, clientId, 'PUT')).status).toBe(204);
+    await expectPending(idle.promise, 45);
+    expect((await updateLease(server, key, clientId, 'DELETE')).status).toBe(
+      204,
+    );
+    await expect(idle.promise).resolves.toBeUndefined();
+  });
+
+  test('keeps the daemon alive until the final concurrent client releases', async () => {
+    const idle = deferred();
+    const { server, key } = await startLeaseServer({
+      leaseTtlMs: 200,
+      idleGraceMs: 35,
+      onIdle: idle.resolve,
+    });
+    const first = randomUUID();
+    const second = randomUUID();
+    await updateLease(server, key, first, 'PUT');
+    await updateLease(server, key, second, 'PUT');
+
+    await updateLease(server, key, first, 'DELETE');
+    await expectPending(idle.promise, 50);
+    await updateLease(server, key, second, 'DELETE');
+    await expect(idle.promise).resolves.toBeUndefined();
+  });
+
+  test('expires crashed clients and allows a new lease to cancel grace', async () => {
+    const expiredIdle = deferred();
+    const expired = await startLeaseServer({
+      leaseTtlMs: 25,
+      idleGraceMs: 25,
+      onIdle: expiredIdle.resolve,
+    });
+    await updateLease(expired.server, expired.key, randomUUID(), 'PUT');
+    await expect(expiredIdle.promise).resolves.toBeUndefined();
+
+    const cancelledIdle = deferred();
+    const cancelled = await startLeaseServer({
+      leaseTtlMs: 200,
+      idleGraceMs: 45,
+      onIdle: cancelledIdle.resolve,
+    });
+    const first = randomUUID();
+    const second = randomUUID();
+    await updateLease(cancelled.server, cancelled.key, first, 'PUT');
+    await updateLease(cancelled.server, cancelled.key, first, 'DELETE');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await updateLease(cancelled.server, cancelled.key, second, 'PUT');
+    await expectPending(cancelledIdle.promise, 40);
+    await updateLease(cancelled.server, cancelled.key, second, 'DELETE');
+    await expect(cancelledIdle.promise).resolves.toBeUndefined();
+  });
+
+  test('does not apply idle shutdown to an explicit foreground server', async () => {
+    const idle = deferred();
+    await startLeaseServer({
+      managed: false,
+      leaseTtlMs: 20,
+      idleGraceMs: 20,
+      onIdle: idle.resolve,
+    });
+
+    await expectPending(idle.promise, 60);
+  });
+});

--- a/tests/daemon-leases.test.ts
+++ b/tests/daemon-leases.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { randomUUID } from 'node:crypto';
 import { loadConfig } from '../src/config.js';
-import { createDaemonIdentity, getDaemonKey } from '../src/daemon.js';
+import {
+  DaemonLeaseClient,
+  createDaemonIdentity,
+  getDaemonKey,
+  type DaemonRecord,
+} from '../src/daemon.js';
 import { startHttpServer } from '../src/server.js';
 
 const servers: Array<Awaited<ReturnType<typeof startHttpServer>>> = [];
@@ -168,5 +173,101 @@ describe('managed daemon leases', () => {
     });
 
     await expectPending(idle.promise, 60);
+  });
+
+  test('rejects new leases after idle shutdown becomes irrevocable', async () => {
+    const idle = deferred();
+    const { server, key } = await startLeaseServer({
+      idleGraceMs: 20,
+      onIdle: idle.resolve,
+    });
+    await idle.promise;
+
+    const response = await updateLease(
+      server,
+      key,
+      randomUUID(),
+      'PUT',
+    );
+
+    expect(response.status).toBe(409);
+  });
+});
+
+function leaseRecord(
+  managed: boolean,
+  url = 'http://127.0.0.1:8765/mcp',
+): DaemonRecord {
+  const daemonIdentity = createDaemonIdentity([], {
+    projectRoot: process.cwd(),
+  });
+  return {
+    pid: process.pid,
+    host: new URL(url).hostname,
+    port: Number(new URL(url).port),
+    url,
+    key: getDaemonKey([], daemonIdentity),
+    cwd: process.cwd(),
+    args: [],
+    identity: daemonIdentity,
+    managed,
+    startedAt: new Date().toISOString(),
+  };
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Condition timed out');
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+}
+
+describe('stdio daemon lease client', () => {
+  test('does not lease an explicit foreground server', async () => {
+    const methods: string[] = [];
+    const client = new DaemonLeaseClient(leaseRecord(false), {
+      update: async (_record, _clientId, method) => {
+        methods.push(method);
+      },
+    });
+
+    await client.start();
+    await client.stop();
+
+    expect(methods).toEqual([]);
+  });
+
+  test('waits for an in-flight renewal before releasing the lease', async () => {
+    const methods: string[] = [];
+    const renewal = deferred();
+    let putCount = 0;
+    const client = new DaemonLeaseClient(leaseRecord(true), {
+      renewIntervalMs: 5,
+      update: async (_record, _clientId, method) => {
+        methods.push(method);
+        if (method === 'PUT' && ++putCount === 2) await renewal.promise;
+      },
+    });
+    await client.start();
+    await waitUntil(() => putCount === 2);
+
+    const stopping = client.stop();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(methods).toEqual(['PUT', 'PUT']);
+    renewal.resolve();
+    await stopping;
+
+    expect(methods).toEqual(['PUT', 'PUT', 'DELETE']);
+  });
+
+  test('refuses to send a daemon key to a non-local URL', async () => {
+    const client = new DaemonLeaseClient(
+      leaseRecord(true, 'http://example.com:8765/mcp'),
+    );
+
+    await expect(client.start()).rejects.toThrow(
+      'Refusing daemon lease request to non-local URL',
+    );
   });
 });

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
@@ -303,6 +303,40 @@ describe('daemon records', () => {
     expect(fs.existsSync(deadPath)).toBe(false);
     expect(fs.existsSync(stalePath)).toBe(false);
     expect(fs.existsSync(livePath)).toBe(true);
+  });
+
+  test('preserves live records and fresh locks when PID probing returns EPERM', async () => {
+    const expected = identity();
+    const key = getDaemonKey(expected.args, expected);
+    const lockPath = getDaemonLockPath(key);
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, token: 'live' }));
+
+    await withHealthServer(
+      {
+        ok: true,
+        name: 'metro-mcp',
+        version: expected.version,
+        daemon: {
+          keyHash: getDaemonKeyFingerprint(key),
+          identityHash: getDaemonIdentityFingerprint(expected),
+          managed: true,
+        },
+      },
+      async (url) => {
+        writeDaemonRecord(record(key, url, expected));
+        const kill = spyOn(process, 'kill').mockImplementation(() => {
+          throw Object.assign(new Error('Operation not permitted'), { code: 'EPERM' });
+        });
+        try {
+          await cleanupStaleDaemonRecords();
+          expect(fs.existsSync(lockPath)).toBe(true);
+          expect(fs.existsSync(getDaemonRecordPath(key))).toBe(true);
+          expect((await readLiveRecord(key, expected))?.managed).toBe(true);
+        } finally {
+          kill.mockRestore();
+        }
+      },
+    );
   });
 
   test('preserves a fresh startup lock while its payload is being written', async () => {

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -11,6 +11,7 @@ import {
   getDaemonRecordPath,
   readLiveRecord,
   removeDaemonRecordForProcess,
+  withStartupLock,
   writeDaemonRecord,
 } from '../src/daemon.js';
 import { loadConfig } from '../src/config.js';
@@ -147,13 +148,14 @@ describe('daemon records', () => {
     const key = getDaemonKey(expected.args, expected);
 
     await withHealthServer(
-      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key, identity: expected } },
+      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key, identity: expected, managed: true } },
       async (url) => {
         writeDaemonRecord(record(key, url, expected));
 
         const live = await readLiveRecord(key, expected);
 
         expect(live?.url).toBe(url);
+        expect(live?.managed).toBe(true);
         expect(fs.existsSync(getDaemonRecordPath(key))).toBe(true);
       },
     );
@@ -266,6 +268,36 @@ describe('daemon records', () => {
     expect(fs.existsSync(stalePath)).toBe(false);
     expect(fs.existsSync(livePath)).toBe(true);
   });
+
+  test('does not remove a replacement lock when the previous owner finishes', async () => {
+    const key = 'cccccccccccccccc';
+    const lockPath = getDaemonLockPath(key);
+    await withStartupLock(key, async () => {
+      fs.unlinkSync(lockPath);
+      fs.writeFileSync(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          token: 'replacement-owner',
+        }),
+      );
+    });
+
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf8')).token).toBe(
+      'replacement-owner',
+    );
+  });
+
+  test('rejects daemon records that point outside localhost', async () => {
+    const expected = identity();
+    const key = getDaemonKey(expected.args, expected);
+    writeDaemonRecord(record(key, 'http://example.com:8080/mcp', expected));
+
+    await expect(readLiveRecord(key, expected)).resolves.toBeNull();
+    expect(fs.existsSync(getDaemonRecordPath(key))).toBe(false);
+  });
 });
 
 describe('HTTP health', () => {
@@ -292,6 +324,7 @@ describe('HTTP health', () => {
       expect(body.version).toBe(version);
       expect(body.daemon?.key).toBe(key);
       expect(body.daemon?.identity).toEqual(daemonIdentity);
+      expect(body.daemon?.managed).toBe(false);
     } finally {
       await server.close();
     }

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -7,6 +7,7 @@ import {
   cleanupStaleDaemonRecords,
   createDaemonIdentity,
   getDaemonKey,
+  getDaemonLockPath,
   getDaemonRecordPath,
   readLiveRecord,
   removeDaemonRecordForProcess,
@@ -247,6 +248,23 @@ describe('daemon records', () => {
 
     expect(fs.existsSync(getDaemonRecordPath(ownedKey))).toBe(false);
     expect(fs.existsSync(getDaemonRecordPath(otherKey))).toBe(true);
+  });
+
+  test('cleans dead and stale startup locks while preserving a fresh live lock', async () => {
+    const deadPath = getDaemonLockPath('deadbeefdeadbeef');
+    const stalePath = getDaemonLockPath('aaaaaaaaaaaaaaaa');
+    const livePath = getDaemonLockPath('bbbbbbbbbbbbbbbb');
+    fs.writeFileSync(deadPath, JSON.stringify({ pid: 2_147_483_647 }));
+    fs.writeFileSync(stalePath, JSON.stringify({ pid: process.pid }));
+    fs.writeFileSync(livePath, JSON.stringify({ pid: process.pid }));
+    const staleDate = new Date(Date.now() - 31_000);
+    fs.utimesSync(stalePath, staleDate, staleDate);
+
+    await cleanupStaleDaemonRecords();
+
+    expect(fs.existsSync(deadPath)).toBe(false);
+    expect(fs.existsSync(stalePath)).toBe(false);
+    expect(fs.existsSync(livePath)).toBe(true);
   });
 });
 

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -6,7 +6,9 @@ import path from 'node:path';
 import {
   cleanupStaleDaemonRecords,
   createDaemonIdentity,
+  getDaemonIdentityFingerprint,
   getDaemonKey,
+  getDaemonKeyFingerprint,
   getDaemonLockPath,
   getDaemonRecordPath,
   readLiveRecord,
@@ -148,7 +150,16 @@ describe('daemon records', () => {
     const key = getDaemonKey(expected.args, expected);
 
     await withHealthServer(
-      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key, identity: expected, managed: true } },
+      {
+        ok: true,
+        name: 'metro-mcp',
+        version: expected.version,
+        daemon: {
+          keyHash: getDaemonKeyFingerprint(key),
+          identityHash: getDaemonIdentityFingerprint(expected),
+          managed: true,
+        },
+      },
       async (url) => {
         writeDaemonRecord(record(key, url, expected));
 
@@ -157,6 +168,7 @@ describe('daemon records', () => {
         expect(live?.url).toBe(url);
         expect(live?.managed).toBe(true);
         expect(fs.existsSync(getDaemonRecordPath(key))).toBe(true);
+        expect(fs.statSync(getDaemonRecordPath(key)).mode & 0o777).toBe(0o600);
       },
     );
   });
@@ -166,7 +178,15 @@ describe('daemon records', () => {
     const key = getDaemonKey(expected.args, expected);
 
     await withHealthServer(
-      { ok: true, name: 'metro-mcp', version: '0.9.0', daemon: { key, identity: expected } },
+      {
+        ok: true,
+        name: 'metro-mcp',
+        version: '0.9.0',
+        daemon: {
+          keyHash: getDaemonKeyFingerprint(key),
+          identityHash: getDaemonIdentityFingerprint(expected),
+        },
+      },
       async (url) => {
         writeDaemonRecord(record(key, url, expected));
 
@@ -182,7 +202,15 @@ describe('daemon records', () => {
     const key = getDaemonKey(expected.args, expected);
 
     await withHealthServer(
-      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key, identity: actual } },
+      {
+        ok: true,
+        name: 'metro-mcp',
+        version: expected.version,
+        daemon: {
+          keyHash: getDaemonKeyFingerprint(key),
+          identityHash: getDaemonIdentityFingerprint(actual),
+        },
+      },
       async (url) => {
         writeDaemonRecord(record(key, url, expected));
 
@@ -205,7 +233,15 @@ describe('daemon records', () => {
     });
 
     await withHealthServer(
-      { ok: true, name: 'metro-mcp', version: expected.version, daemon: { key: liveKey, identity: expected } },
+      {
+        ok: true,
+        name: 'metro-mcp',
+        version: expected.version,
+        daemon: {
+          keyHash: getDaemonKeyFingerprint(liveKey),
+          identityHash: getDaemonIdentityFingerprint(expected),
+        },
+      },
       async (url) => {
         writeDaemonRecord(record(liveKey, url, expected));
 
@@ -256,9 +292,9 @@ describe('daemon records', () => {
     const deadPath = getDaemonLockPath('deadbeefdeadbeef');
     const stalePath = getDaemonLockPath('aaaaaaaaaaaaaaaa');
     const livePath = getDaemonLockPath('bbbbbbbbbbbbbbbb');
-    fs.writeFileSync(deadPath, JSON.stringify({ pid: 2_147_483_647 }));
-    fs.writeFileSync(stalePath, JSON.stringify({ pid: process.pid }));
-    fs.writeFileSync(livePath, JSON.stringify({ pid: process.pid }));
+    fs.writeFileSync(deadPath, JSON.stringify({ pid: 2_147_483_647, token: 'dead' }));
+    fs.writeFileSync(stalePath, JSON.stringify({ pid: process.pid, token: 'stale' }));
+    fs.writeFileSync(livePath, JSON.stringify({ pid: process.pid, token: 'live' }));
     const staleDate = new Date(Date.now() - 31_000);
     fs.utimesSync(stalePath, staleDate, staleDate);
 
@@ -267,6 +303,26 @@ describe('daemon records', () => {
     expect(fs.existsSync(deadPath)).toBe(false);
     expect(fs.existsSync(stalePath)).toBe(false);
     expect(fs.existsSync(livePath)).toBe(true);
+  });
+
+  test('preserves a fresh startup lock while its payload is being written', async () => {
+    const lockPath = getDaemonLockPath('dddddddddddddddd');
+    fs.writeFileSync(lockPath, '');
+
+    await cleanupStaleDaemonRecords();
+
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  test('removes an unparsable startup lock only after it becomes stale', async () => {
+    const lockPath = getDaemonLockPath('eeeeeeeeeeeeeeee');
+    fs.writeFileSync(lockPath, '');
+    const staleDate = new Date(Date.now() - 31_000);
+    fs.utimesSync(lockPath, staleDate, staleDate);
+
+    await cleanupStaleDaemonRecords();
+
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 
   test('does not remove a replacement lock when the previous owner finishes', async () => {
@@ -301,7 +357,7 @@ describe('daemon records', () => {
 });
 
 describe('HTTP health', () => {
-  test('exposes daemon identity while keeping name and version', async () => {
+  test('exposes a daemon fingerprint without leaking its lease key', async () => {
     const args = ['--port', '65535'];
     const daemonIdentity = identity({ version, args });
     const key = getDaemonKey(args, daemonIdentity);
@@ -322,8 +378,12 @@ describe('HTTP health', () => {
 
       expect(body.name).toBe('metro-mcp');
       expect(body.version).toBe(version);
-      expect(body.daemon?.key).toBe(key);
-      expect(body.daemon?.identity).toEqual(daemonIdentity);
+      expect(body.daemon?.keyHash).toBe(getDaemonKeyFingerprint(key));
+      expect(body.daemon?.identityHash).toBe(
+        getDaemonIdentityFingerprint(daemonIdentity),
+      );
+      expect(body.daemon).not.toHaveProperty('key');
+      expect(body.daemon).not.toHaveProperty('identity');
       expect(body.daemon?.managed).toBe(false);
     } finally {
       await server.close();

--- a/tests/stdio-proxy-shutdown.test.ts
+++ b/tests/stdio-proxy-shutdown.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { registerStdioProxyShutdown } from '../src/daemon.js';
+
+describe('stdio proxy shutdown triggers', () => {
+  for (const event of ['end', 'close', 'SIGINT', 'SIGTERM', 'beforeExit']) {
+    test(`releases on ${event} exactly once and removes its listeners`, () => {
+      const input = new EventEmitter();
+      const lifecycle = new EventEmitter();
+      let shutdowns = 0;
+      const cleanup = registerStdioProxyShutdown(
+        () => shutdowns++,
+        input,
+        lifecycle,
+      );
+      (event === 'end' || event === 'close' ? input : lifecycle).emit(event);
+      input.emit('end');
+      input.emit('close');
+      lifecycle.emit('SIGTERM');
+      expect(shutdowns).toBe(1);
+      cleanup();
+      cleanup();
+      expect(input.eventNames()).toEqual([]);
+      expect(lifecycle.eventNames()).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- add an authenticated localhost lease endpoint for auto-spawned daemon clients
- renew stdio proxy leases every 10 seconds, expire them after 30 seconds, and shut down after a 30-second zero-client grace period
- keep explicit metro-mcp serve processes long-lived
- make runtime and HTTP shutdown idempotent and close MCP, Metro, CDP proxy, and HTTP resources
- clean stale daemon JSON records and dead or stale startup locks

## Testing

- bun run typecheck
- bun test (54 passing)
- bun run build
- bun run docs:build

Closes #73.

## Integration follow-up

- Explicitly release the proxy lease on stdin EOF/close, SIGINT/SIGTERM, and natural shutdown; keep shutdown idempotent and remove listeners.
- Added regression coverage for every shutdown trigger and listener cleanup.
- Independently validated this branch with typecheck, 54 passing tests, production build, and docs build.
- Real built-process integration smoke tests verified concurrent leases, renewal, grace cancellation, SIGKILL expiry, and graceful daemon exit after about 30 seconds.
- Reviewed the follow-up through reuse, quality, and efficiency passes; no behavior-preserving simplification was applied.