### PR TITLE
Add path and inline screenshot delivery

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -97,6 +97,27 @@ handler: async ({ items }, { sendProgress }) => {
 },
 ```
 
+### Native MCP tool results
+
+Ordinary objects returned by handlers are JSON-serialized into a text content
+block. To deliberately return native MCP content such as an image, validate and
+mark the result with `nativeToolResult()`:
+
+```typescript
+import { definePlugin, nativeToolResult } from 'metro-mcp';
+
+handler: async () => nativeToolResult({
+  content: [{
+    type: 'image',
+    data: pngBuffer.toString('base64'),
+    mimeType: 'image/png',
+  }],
+}),
+```
+
+The explicit helper prevents an existing plugin object that merely has a
+`content` property from being reinterpreted as MCP protocol output.
+
 ## Registering resources
 
 Resources expose readable data to AI clients (component trees, logs, state snapshots, etc.).
@@ -228,6 +249,15 @@ Run shell commands and capture output:
 ```typescript
 const devices = await ctx.exec('xcrun simctl list devices --json');
 const parsed = JSON.parse(devices);
+```
+
+Use `ctx.execFile()` when arguments must be passed literally or stdout is
+binary. It does not invoke a shell and returns a `Buffer`:
+
+```typescript
+const png = await ctx.execFile('adb', ['exec-out', 'screencap', '-p'], {
+  maxBuffer: 64 * 1024 * 1024,
+});
 ```
 
 ### `ctx.format` — Formatting helpers

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -77,7 +77,7 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 
 ## Simulator
 
-- **`take_screenshot`** — Capture a simulator/device screenshot. Returns a retained temporary PNG path by default; set `delivery` to `inline` for a native MCP image block.
+- **`take_screenshot`** — Capture a simulator/device screenshot. Returns a retained temporary PNG path by default; set `delivery` to `inline` for a native MCP image block. Captures larger than 64 MiB are rejected and removed.
 - **`list_simulators`** — List iOS simulators and Android emulators.
 - **`install_certificate`** — Add root certificate to device.
 - **`get_native_logs`** — Native logs (iOS syslog / Android logcat).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -77,7 +77,7 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 
 ## Simulator
 
-- **`take_screenshot`** — Capture simulator/device screenshot.
+- **`take_screenshot`** — Capture a simulator/device screenshot. Returns a retained temporary PNG path by default; set `delivery` to `inline` for a native MCP image block.
 - **`list_simulators`** — List iOS simulators and Android emulators.
 - **`install_certificate`** — Add root certificate to device.
 - **`get_native_logs`** — Native logs (iOS syslog / Android logcat).

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/server';
 import type { CircularBuffer } from './utils/buffer.js';
 import type { MetroTarget } from 'metro-bridge';
 
@@ -54,6 +55,19 @@ export interface ToolHandlerContext {
   ) => Promise<void>;
 }
 
+/** A native MCP content block returned directly by a plugin tool. */
+export type NativeToolContentBlock = ContentBlock;
+
+/** A validated native MCP tool result, including image/audio/resource blocks. */
+export type NativeToolResult = CallToolResult;
+
+/**
+ * Plugin handlers may return a native MCP result or any JSON-serializable value.
+ * Native results are validated before being passed through; other values are
+ * preserved as the existing JSON text response.
+ */
+export type ToolHandlerResult = NativeToolResult | unknown;
+
 export interface ToolConfig<
   T extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
 > {
@@ -68,7 +82,7 @@ export interface ToolConfig<
    * Example: `'ui://metro/network'`
    */
   appUri?: string;
-  handler: (args: z.infer<T>, ctx: ToolHandlerContext) => Promise<unknown>;
+  handler: (args: z.infer<T>, ctx: ToolHandlerContext) => Promise<ToolHandlerResult>;
 }
 
 export interface ResourceConfig {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/server';
+import {
+  isCallToolResult,
+  type CallToolResult,
+  type ContentBlock,
+} from '@modelcontextprotocol/server';
 import type { CircularBuffer } from './utils/buffer.js';
 import type { MetroTarget } from 'metro-bridge';
 
@@ -58,8 +62,41 @@ export interface ToolHandlerContext {
 /** A native MCP content block returned directly by a plugin tool. */
 export type NativeToolContentBlock = ContentBlock;
 
+const NATIVE_TOOL_RESULT_BRAND = Symbol.for(
+  'io.github.steve228uk.metro-mcp.native-tool-result',
+);
+declare const nativeToolResultTypeBrand: unique symbol;
+
 /** A validated native MCP tool result, including image/audio/resource blocks. */
-export type NativeToolResult = CallToolResult;
+export type NativeToolResult = CallToolResult & {
+  readonly [nativeToolResultTypeBrand]: true;
+};
+
+/**
+ * Validate and explicitly opt a plugin result into native MCP delivery.
+ * Ordinary objects remain JSON text, even when they happen to be shaped like
+ * a CallToolResult.
+ */
+export function nativeToolResult(result: CallToolResult): NativeToolResult {
+  if (!isCallToolResult(result)) {
+    throw new TypeError('Invalid native MCP tool result');
+  }
+
+  const brandedResult = { ...result };
+  Object.defineProperty(brandedResult, NATIVE_TOOL_RESULT_BRAND, {
+    value: true,
+  });
+  return brandedResult as NativeToolResult;
+}
+
+export function isNativeToolResult(result: unknown): result is NativeToolResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    (result as Record<PropertyKey, unknown>)[NATIVE_TOOL_RESULT_BRAND] === true &&
+    isCallToolResult(result)
+  );
+}
 
 /**
  * Plugin handlers may return a native MCP result or any JSON-serializable value.
@@ -160,6 +197,12 @@ export interface PluginContext {
     fetch(path: string): Promise<Response>;
   };
   exec(command: string): Promise<string>;
+  /** Run an executable with literal arguments and return its binary stdout. */
+  execFile(
+    command: string,
+    args: string[],
+    options?: { maxBuffer?: number },
+  ): Promise<Buffer>;
   format: FormatUtils;
   /** Evaluate a JavaScript expression in the connected app runtime */
   evalInApp(expression: string, options?: EvalOptions): Promise<unknown>;

--- a/src/plugins/network.test.ts
+++ b/src/plugins/network.test.ts
@@ -60,6 +60,7 @@ async function createNetworkHarness(responseBody: string) {
       fetch: async () => new Response(),
     },
     exec: async () => '',
+    execFile: async () => Buffer.alloc(0),
     format: {
       summarize: () => '',
       compact: (value: unknown) => JSON.stringify(value),

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -1,7 +1,17 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { readFile, stat, unlink, utimes, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  unlink,
+  utimes,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { z } from 'zod';
@@ -10,7 +20,7 @@ import type {
   PluginContext,
   ToolHandlerResult,
 } from '../plugin.js';
-import { simulatorPlugin } from './simulator.js';
+import { prepareScreenshotDirectory, simulatorPlugin } from './simulator.js';
 
 type RegisteredTool = {
   parameters: z.ZodType;
@@ -197,5 +207,21 @@ describe('take_screenshot', () => {
     await capture(tool, { platform: 'ios' });
 
     expect(existsSync(oldPath)).toBe(false);
+  });
+
+  test('refuses a pre-existing screenshot directory symlink', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'metro-mcp-symlink-test-'));
+    const target = join(root, 'target');
+    const linkedDirectory = join(root, 'screenshots');
+    await mkdir(target);
+    await symlink(target, linkedDirectory, 'dir');
+
+    try {
+      await expect(prepareScreenshotDirectory(linkedDirectory)).rejects.toThrow(
+        'Screenshot directory is not a real directory',
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -142,6 +142,9 @@ describe('take_screenshot', () => {
     const path = (result as { structuredContent: { path: string } })
       .structuredContent.path;
     expect(path.startsWith(tmpdir())).toBe(true);
+    if (process.getuid) {
+      expect(dirname(path).endsWith(`-${process.getuid()}`)).toBe(true);
+    }
     expect(existsSync(path)).toBe(true);
     expect(await readFile(path)).toEqual(Buffer.from(png));
     expect((await stat(path)).mode & 0o777).toBe(0o600);

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -22,7 +22,6 @@ import type {
 } from '../plugin.js';
 import {
   prepareScreenshotDirectory,
-  quoteShellArgument,
   simulatorPlugin,
 } from './simulator.js';
 
@@ -43,7 +42,11 @@ afterEach(async () => {
 });
 
 async function createSimulatorHarness(
-  options: { writeCapture?: boolean; execError?: Error } = {},
+  options: {
+    writeCapture?: boolean;
+    execError?: Error;
+    execFileCalls?: Array<{ command: string; args: string[] }>;
+  } = {},
 ) {
   const tools = new Map<string, RegisteredTool>();
   const registerTool: PluginContext['registerTool'] = (name, config) => {
@@ -84,17 +87,16 @@ async function createSimulatorHarness(
       port: 8081,
       fetch: async () => new Response(),
     },
-    exec: async (command) => {
-      const quotedPath = command.match(/('(?:[^']|'\\'')*')$/)?.[1];
-      const path = quotedPath
-        ?.slice(1, -1)
-        .replaceAll(`'\\''`, "'");
+    exec: async () => '',
+    execFile: async (command, args) => {
+      options.execFileCalls?.push({ command, args });
+      const path = command === 'xcrun' ? args.at(-1) : undefined;
       if (writeCapture && path) {
         createdFiles.add(path);
         await writeFile(path, png);
       }
       if (options.execError) throw options.execError;
-      return '';
+      return Buffer.from(png);
     },
     format: {
       summarize: () => '',
@@ -122,10 +124,25 @@ async function capture(
 }
 
 describe('take_screenshot', () => {
-  test('shell-quotes environment-derived screenshot paths', () => {
-    expect(quoteShellArgument("/tmp/path with 'quotes'/$HOME;$(id).png")).toBe(
-      "'/tmp/path with '\\''quotes'\\''/$HOME;$(id).png'",
-    );
+  test('uses direct executable arguments instead of shell path quoting', async () => {
+    const execFileCalls: Array<{ command: string; args: string[] }> = [];
+    const tool = await createSimulatorHarness({ execFileCalls });
+
+    await capture(tool, { platform: 'ios' });
+    await capture(tool, { platform: 'android' });
+
+    expect(execFileCalls[0].command).toBe('xcrun');
+    expect(execFileCalls[0].args.slice(0, -1)).toEqual([
+      'simctl',
+      'io',
+      'booted',
+      'screenshot',
+    ]);
+    expect(execFileCalls[0].args.at(-1)?.startsWith(tmpdir())).toBe(true);
+    expect(execFileCalls[1]).toEqual({
+      command: 'adb',
+      args: ['exec-out', 'screencap', '-p'],
+    });
   });
 
   test('defaults to a retained temporary path with structured metadata', async () => {

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { readFile, unlink, utimes, writeFile } from 'node:fs/promises';
+import { readFile, stat, unlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { z } from 'zod';
 import type {
   ComponentNode,
@@ -15,6 +15,7 @@ import { simulatorPlugin } from './simulator.js';
 type RegisteredTool = {
   parameters: z.ZodType;
   handler: (args: Record<string, unknown>) => Promise<ToolHandlerResult>;
+  annotations?: { readOnlyHint?: boolean; openWorldHint?: boolean };
 };
 
 const createdFiles = new Set<string>();
@@ -35,6 +36,7 @@ async function createSimulatorHarness(
     tools.set(name, {
       parameters: config.parameters,
       handler: config.handler as RegisteredTool['handler'],
+      annotations: config.annotations,
     });
   };
   const writeCapture = options.writeCapture ?? true;
@@ -119,6 +121,9 @@ describe('take_screenshot', () => {
     expect(path.startsWith(tmpdir())).toBe(true);
     expect(existsSync(path)).toBe(true);
     expect(await readFile(path)).toEqual(Buffer.from(png));
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect((await stat(dirname(path))).mode & 0o777).toBe(0o700);
+    expect(tool.annotations).toEqual({ openWorldHint: true });
   });
 
   test('returns a native inline image and deletes the capture file', async () => {
@@ -175,8 +180,13 @@ describe('take_screenshot', () => {
   });
 
   test('removes only old Metro MCP screenshot files opportunistically', async () => {
+    const tool = await createSimulatorHarness();
+    const first = await capture(tool, { platform: 'ios' });
+    const screenshotDirectory = dirname(
+      (first as { structuredContent: { path: string } }).structuredContent.path,
+    );
     const oldPath = join(
-      tmpdir(),
+      screenshotDirectory,
       `metro-mcp-screenshot-${randomUUID()}.png`,
     );
     createdFiles.add(oldPath);
@@ -184,7 +194,6 @@ describe('take_screenshot', () => {
     const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
     await utimes(oldPath, oldDate, oldDate);
 
-    const tool = await createSimulatorHarness();
     await capture(tool, { platform: 'ios' });
 
     expect(existsSync(oldPath)).toBe(false);

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -8,6 +8,7 @@ import {
   rm,
   stat,
   symlink,
+  truncate,
   unlink,
   utimes,
   writeFile,
@@ -45,6 +46,7 @@ async function createSimulatorHarness(
   options: {
     writeCapture?: boolean;
     execError?: Error;
+    captureSize?: number;
     execFileCalls?: Array<{ command: string; args: string[] }>;
   } = {},
 ) {
@@ -94,6 +96,9 @@ async function createSimulatorHarness(
       if (writeCapture && path) {
         createdFiles.add(path);
         await writeFile(path, png);
+        if (options.captureSize !== undefined) {
+          await truncate(path, options.captureSize);
+        }
       }
       if (options.execError) throw options.execError;
       return Buffer.from(png);
@@ -209,6 +214,15 @@ describe('take_screenshot', () => {
     await expect(
       capture(tool, { platform: 'ios', delivery: 'path' }),
     ).rejects.toThrow('Failed to capture screenshot');
+  });
+
+  test('rejects and removes oversized iOS captures before delivery', async () => {
+    const tool = await createSimulatorHarness({ captureSize: 65 * 1024 * 1024 });
+
+    await expect(capture(tool, { platform: 'ios' })).rejects.toThrow(
+      '64 MiB screenshot limit',
+    );
+    for (const path of createdFiles) expect(existsSync(path)).toBe(false);
   });
 
   test('removes a partial capture when the platform command fails', async () => {

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { readFile, unlink, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { z } from 'zod';
+import type {
+  ComponentNode,
+  PluginContext,
+  ToolHandlerResult,
+} from '../plugin.js';
+import { simulatorPlugin } from './simulator.js';
+
+type RegisteredTool = {
+  parameters: z.ZodType;
+  handler: (args: Record<string, unknown>) => Promise<ToolHandlerResult>;
+};
+
+const createdFiles = new Set<string>();
+const png = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+afterEach(async () => {
+  await Promise.all(
+    [...createdFiles].map((path) => unlink(path).catch(() => {})),
+  );
+  createdFiles.clear();
+});
+
+async function createSimulatorHarness(
+  options: { writeCapture?: boolean; execError?: Error } = {},
+) {
+  const tools = new Map<string, RegisteredTool>();
+  const registerTool: PluginContext['registerTool'] = (name, config) => {
+    tools.set(name, {
+      parameters: config.parameters,
+      handler: config.handler as RegisteredTool['handler'],
+    });
+  };
+  const writeCapture = options.writeCapture ?? true;
+
+  const ctx: PluginContext = {
+    cdp: {
+      on: () => {},
+      off: () => {},
+      isConnected: false,
+      getTarget: () => null,
+      send: async () => ({}),
+    },
+    events: {
+      on: () => {},
+      off: () => {},
+      isConnected: () => false,
+    },
+    registerTool,
+    registerResource: () => {},
+    registerAppResource: () => {},
+    registerPrompt: () => {},
+    config: {},
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
+    metro: {
+      host: 'localhost',
+      port: 8081,
+      fetch: async () => new Response(),
+    },
+    exec: async (command) => {
+      const path = command.match(/"([^"]+)"$/)?.[1];
+      if (writeCapture && path) {
+        createdFiles.add(path);
+        await writeFile(path, png);
+      }
+      if (options.execError) throw options.execError;
+      return '';
+    },
+    format: {
+      summarize: () => '',
+      compact: (value: unknown) => JSON.stringify(value),
+      truncate: (value: string) => value,
+      structureOnly: (value: ComponentNode) => value,
+    },
+    evalInApp: async () => null,
+    getActiveDeviceKey: () => null,
+    getActiveDeviceName: () => null,
+    notifyResourceUpdated: () => {},
+  };
+
+  await simulatorPlugin.setup(ctx);
+  const screenshot = tools.get('take_screenshot');
+  if (!screenshot) throw new Error('take_screenshot was not registered');
+  return screenshot;
+}
+
+async function capture(
+  tool: RegisteredTool,
+  args: Record<string, unknown>,
+): Promise<ToolHandlerResult> {
+  return tool.handler(tool.parameters.parse(args) as Record<string, unknown>);
+}
+
+describe('take_screenshot', () => {
+  test('defaults to a retained temporary path with structured metadata', async () => {
+    const tool = await createSimulatorHarness();
+    const result = await capture(tool, { platform: 'ios' });
+
+    expect(result).toMatchObject({
+      content: [{ type: 'text' }],
+      structuredContent: {
+        mimeType: 'image/png',
+        platform: 'ios',
+      },
+    });
+    const path = (result as { structuredContent: { path: string } })
+      .structuredContent.path;
+    expect(path.startsWith(tmpdir())).toBe(true);
+    expect(existsSync(path)).toBe(true);
+    expect(await readFile(path)).toEqual(Buffer.from(png));
+  });
+
+  test('returns a native inline image and deletes the capture file', async () => {
+    const tool = await createSimulatorHarness();
+    const result = await capture(tool, {
+      platform: 'android',
+      delivery: 'inline',
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'image',
+          data: Buffer.from(png).toString('base64'),
+          mimeType: 'image/png',
+        },
+      ],
+    });
+    for (const path of createdFiles) expect(existsSync(path)).toBe(false);
+  });
+
+  test('uses unique files for concurrent path captures', async () => {
+    const tool = await createSimulatorHarness();
+    const results = await Promise.all([
+      capture(tool, { platform: 'ios' }),
+      capture(tool, { platform: 'ios' }),
+    ]);
+    const paths = results.map(
+      (result) =>
+        (result as { structuredContent: { path: string } }).structuredContent
+          .path,
+    );
+
+    expect(new Set(paths).size).toBe(2);
+    expect(paths.every((path) => existsSync(path))).toBe(true);
+  });
+
+  test('reports a failed capture when no file is produced', async () => {
+    const tool = await createSimulatorHarness({ writeCapture: false });
+    await expect(
+      capture(tool, { platform: 'ios', delivery: 'path' }),
+    ).rejects.toThrow('Failed to capture screenshot');
+  });
+
+  test('removes a partial capture when the platform command fails', async () => {
+    const tool = await createSimulatorHarness({
+      execError: new Error('simctl failed'),
+    });
+
+    await expect(capture(tool, { platform: 'ios' })).rejects.toThrow(
+      'simctl failed',
+    );
+    for (const path of createdFiles) expect(existsSync(path)).toBe(false);
+  });
+
+  test('removes only old Metro MCP screenshot files opportunistically', async () => {
+    const oldPath = join(
+      tmpdir(),
+      `metro-mcp-screenshot-${randomUUID()}.png`,
+    );
+    createdFiles.add(oldPath);
+    await writeFile(oldPath, png);
+    const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    await utimes(oldPath, oldDate, oldDate);
+
+    const tool = await createSimulatorHarness();
+    await capture(tool, { platform: 'ios' });
+
+    expect(existsSync(oldPath)).toBe(false);
+  });
+});

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -20,7 +20,11 @@ import type {
   PluginContext,
   ToolHandlerResult,
 } from '../plugin.js';
-import { prepareScreenshotDirectory, simulatorPlugin } from './simulator.js';
+import {
+  prepareScreenshotDirectory,
+  quoteShellArgument,
+  simulatorPlugin,
+} from './simulator.js';
 
 type RegisteredTool = {
   parameters: z.ZodType;
@@ -81,7 +85,10 @@ async function createSimulatorHarness(
       fetch: async () => new Response(),
     },
     exec: async (command) => {
-      const path = command.match(/"([^"]+)"$/)?.[1];
+      const quotedPath = command.match(/('(?:[^']|'\\'')*')$/)?.[1];
+      const path = quotedPath
+        ?.slice(1, -1)
+        .replaceAll(`'\\''`, "'");
       if (writeCapture && path) {
         createdFiles.add(path);
         await writeFile(path, png);
@@ -115,6 +122,12 @@ async function capture(
 }
 
 describe('take_screenshot', () => {
+  test('shell-quotes environment-derived screenshot paths', () => {
+    expect(quoteShellArgument("/tmp/path with 'quotes'/$HOME;$(id).png")).toBe(
+      "'/tmp/path with '\\''quotes'\\''/$HOME;$(id).png'",
+    );
+  });
+
   test('defaults to a retained temporary path with structured metadata', async () => {
     const tool = await createSimulatorHarness();
     const result = await capture(tool, { platform: 'ios' });

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -20,6 +20,10 @@ const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const SCREENSHOT_FILE_PATTERN = /^metro-mcp-screenshot-[a-zA-Z0-9-]+\.png$/;
 const SCREENSHOT_DIRECTORY = join(tmpdir(), 'metro-mcp-screenshots');
 
+export function quoteShellArgument(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
 export async function prepareScreenshotDirectory(
   directory = SCREENSHOT_DIRECTORY,
 ): Promise<void> {
@@ -120,9 +124,13 @@ export const simulatorPlugin = definePlugin({
 
         try {
           if (p === 'ios') {
-            await ctx.exec(`xcrun simctl io booted screenshot "${tmpFile}"`);
+            await ctx.exec(
+              `xcrun simctl io booted screenshot ${quoteShellArgument(tmpFile)}`,
+            );
           } else {
-            await ctx.exec(`adb exec-out screencap -p > "${tmpFile}"`);
+            await ctx.exec(
+              `adb exec-out screencap -p > ${quoteShellArgument(tmpFile)}`,
+            );
           }
 
           await chmod(tmpFile, 0o600);

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -9,23 +9,21 @@ import {
   readFile,
   stat,
   unlink,
+  writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
-import { definePlugin } from '../plugin.js';
+import { definePlugin, nativeToolResult } from '../plugin.js';
 
 const SCREENSHOT_PREFIX = 'metro-mcp-screenshot-';
 const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const SCREENSHOT_MAX_BYTES = 64 * 1024 * 1024;
 const SCREENSHOT_FILE_PATTERN = /^metro-mcp-screenshot-[a-zA-Z0-9-]+\.png$/;
 const SCREENSHOT_DIRECTORY = join(
   tmpdir(),
   `metro-mcp-screenshots-${process.getuid?.() ?? 'user'}`,
 );
-
-export function quoteShellArgument(value: string): string {
-  return `'${value.replaceAll("'", `'\\''`)}'`;
-}
 
 export async function prepareScreenshotDirectory(
   directory = SCREENSHOT_DIRECTORY,
@@ -127,13 +125,18 @@ export const simulatorPlugin = definePlugin({
 
         try {
           if (p === 'ios') {
-            await ctx.exec(
-              `xcrun simctl io booted screenshot ${quoteShellArgument(tmpFile)}`,
+            await ctx.execFile(
+              'xcrun',
+              ['simctl', 'io', 'booted', 'screenshot', tmpFile],
+              { maxBuffer: SCREENSHOT_MAX_BYTES },
             );
           } else {
-            await ctx.exec(
-              `adb exec-out screencap -p > ${quoteShellArgument(tmpFile)}`,
+            const capture = await ctx.execFile(
+              'adb',
+              ['exec-out', 'screencap', '-p'],
+              { maxBuffer: SCREENSHOT_MAX_BYTES },
             );
+            await writeFile(tmpFile, capture, { flag: 'wx', mode: 0o600 });
           }
 
           await chmod(tmpFile, 0o600);
@@ -149,21 +152,21 @@ export const simulatorPlugin = definePlugin({
         }
 
         if (delivery === 'path') {
-          return {
+          return nativeToolResult({
             content: [{ type: 'text', text: `Screenshot saved to ${tmpFile}` }],
             structuredContent: {
               path: tmpFile,
               mimeType: 'image/png',
               platform: p,
             },
-          };
+          });
         }
 
         try {
           const data = (await readFile(tmpFile)).toString('base64');
-          return {
+          return nativeToolResult({
             content: [{ type: 'image', data, mimeType: 'image/png' }],
-          };
+          });
         } finally {
           await unlink(tmpFile).catch(() => {});
         }

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -144,6 +144,9 @@ export const simulatorPlugin = definePlugin({
           if (!metadata.isFile()) {
             throw new Error('capture did not produce a regular file');
           }
+          if (metadata.size > SCREENSHOT_MAX_BYTES) {
+            throw new Error('capture exceeds the 64 MiB screenshot limit');
+          }
         } catch (error) {
           await unlink(tmpFile).catch(() => {});
           throw new Error(

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { readdir, readFile, stat, unlink } from 'node:fs/promises';
+import { chmod, mkdir, readdir, readFile, stat, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
@@ -8,15 +8,22 @@ import { definePlugin } from '../plugin.js';
 const SCREENSHOT_PREFIX = 'metro-mcp-screenshot-';
 const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const SCREENSHOT_FILE_PATTERN = /^metro-mcp-screenshot-[a-zA-Z0-9-]+\.png$/;
+const SCREENSHOT_DIRECTORY = join(tmpdir(), 'metro-mcp-screenshots');
+
+async function prepareScreenshotDirectory(): Promise<void> {
+  await mkdir(SCREENSHOT_DIRECTORY, { recursive: true, mode: 0o700 });
+  // mkdir's mode is affected by the umask and does not repair an existing directory.
+  await chmod(SCREENSHOT_DIRECTORY, 0o700);
+}
 
 async function cleanupOldScreenshots(now = Date.now()): Promise<void> {
   try {
-    const files = await readdir(tmpdir());
+    const files = await readdir(SCREENSHOT_DIRECTORY);
     await Promise.all(
       files
         .filter((file) => SCREENSHOT_FILE_PATTERN.test(file))
         .map(async (file) => {
-          const path = join(tmpdir(), file);
+          const path = join(SCREENSHOT_DIRECTORY, file);
           try {
             const metadata = await stat(path);
             if (metadata.isFile() && now - metadata.mtimeMs > SCREENSHOT_MAX_AGE_MS) {
@@ -52,7 +59,7 @@ export const simulatorPlugin = definePlugin({
 
     ctx.registerTool('take_screenshot', {
       description: 'Capture a screenshot from the connected iOS simulator or Android device.',
-      annotations: { readOnlyHint: true, openWorldHint: true },
+      annotations: { openWorldHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
         delivery: z
@@ -64,8 +71,12 @@ export const simulatorPlugin = definePlugin({
         const p = platform === 'auto' ? await detectPlatform() : platform;
         if (!p) return 'No simulator/emulator detected.';
 
+        await prepareScreenshotDirectory();
         await cleanupOldScreenshots();
-        const tmpFile = join(tmpdir(), `${SCREENSHOT_PREFIX}${randomUUID()}.png`);
+        const tmpFile = join(
+          SCREENSHOT_DIRECTORY,
+          `${SCREENSHOT_PREFIX}${randomUUID()}.png`,
+        );
 
         try {
           if (p === 'ios') {
@@ -74,6 +85,7 @@ export const simulatorPlugin = definePlugin({
             await ctx.exec(`adb exec-out screencap -p > "${tmpFile}"`);
           }
 
+          await chmod(tmpFile, 0o600);
           const metadata = await stat(tmpFile);
           if (!metadata.isFile()) {
             throw new Error('capture did not produce a regular file');

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -1,7 +1,36 @@
-import { readFile } from 'fs/promises';
-import { existsSync } from 'fs';
+import { randomUUID } from 'node:crypto';
+import { readdir, readFile, stat, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
+
+const SCREENSHOT_PREFIX = 'metro-mcp-screenshot-';
+const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const SCREENSHOT_FILE_PATTERN = /^metro-mcp-screenshot-[a-zA-Z0-9-]+\.png$/;
+
+async function cleanupOldScreenshots(now = Date.now()): Promise<void> {
+  try {
+    const files = await readdir(tmpdir());
+    await Promise.all(
+      files
+        .filter((file) => SCREENSHOT_FILE_PATTERN.test(file))
+        .map(async (file) => {
+          const path = join(tmpdir(), file);
+          try {
+            const metadata = await stat(path);
+            if (metadata.isFile() && now - metadata.mtimeMs > SCREENSHOT_MAX_AGE_MS) {
+              await unlink(path);
+            }
+          } catch {
+            // The file may have been removed concurrently.
+          }
+        }),
+    );
+  } catch {
+    // Screenshot cleanup is opportunistic and must not block a capture.
+  }
+}
 
 export const simulatorPlugin = definePlugin({
   name: 'simulator',
@@ -26,32 +55,55 @@ export const simulatorPlugin = definePlugin({
       annotations: { readOnlyHint: true, openWorldHint: true },
       parameters: z.object({
         platform: z.enum(['ios', 'android', 'auto']).default('auto').describe('Target platform'),
+        delivery: z
+          .enum(['path', 'inline'])
+          .default('path')
+          .describe('Return a retained temporary file path or an inline MCP image'),
       }),
-      handler: async ({ platform }) => {
+      handler: async ({ platform, delivery }) => {
         const p = platform === 'auto' ? await detectPlatform() : platform;
         if (!p) return 'No simulator/emulator detected.';
 
-        const tmpFile = `/tmp/metro-mcp-screenshot-${Date.now()}.png`;
+        await cleanupOldScreenshots();
+        const tmpFile = join(tmpdir(), `${SCREENSHOT_PREFIX}${randomUUID()}.png`);
 
-        if (p === 'ios') {
-          await ctx.exec(`xcrun simctl io booted screenshot "${tmpFile}"`);
-        } else {
-          await ctx.exec(`adb exec-out screencap -p > "${tmpFile}"`);
+        try {
+          if (p === 'ios') {
+            await ctx.exec(`xcrun simctl io booted screenshot "${tmpFile}"`);
+          } else {
+            await ctx.exec(`adb exec-out screencap -p > "${tmpFile}"`);
+          }
+
+          const metadata = await stat(tmpFile);
+          if (!metadata.isFile()) {
+            throw new Error('capture did not produce a regular file');
+          }
+        } catch (error) {
+          await unlink(tmpFile).catch(() => {});
+          throw new Error(
+            `Failed to capture screenshot: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
 
-        // Read file and return as base64
-        if (existsSync(tmpFile)) {
-          const buffer = await readFile(tmpFile);
-          const base64 = buffer.toString('base64');
-          await ctx.exec(`rm -f "${tmpFile}"`);
+        if (delivery === 'path') {
           return {
-            type: 'image',
-            format: 'png',
-            data: base64,
-            note: 'Screenshot captured successfully',
+            content: [{ type: 'text', text: `Screenshot saved to ${tmpFile}` }],
+            structuredContent: {
+              path: tmpFile,
+              mimeType: 'image/png',
+              platform: p,
+            },
           };
         }
-        return 'Failed to capture screenshot.';
+
+        try {
+          const data = (await readFile(tmpFile)).toString('base64');
+          return {
+            content: [{ type: 'image', data, mimeType: 'image/png' }],
+          };
+        } finally {
+          await unlink(tmpFile).catch(() => {});
+        }
       },
     });
 

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -1,5 +1,15 @@
 import { randomUUID } from 'node:crypto';
-import { chmod, mkdir, readdir, readFile, stat, unlink } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  stat,
+  unlink,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
@@ -10,10 +20,40 @@ const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const SCREENSHOT_FILE_PATTERN = /^metro-mcp-screenshot-[a-zA-Z0-9-]+\.png$/;
 const SCREENSHOT_DIRECTORY = join(tmpdir(), 'metro-mcp-screenshots');
 
-async function prepareScreenshotDirectory(): Promise<void> {
-  await mkdir(SCREENSHOT_DIRECTORY, { recursive: true, mode: 0o700 });
-  // mkdir's mode is affected by the umask and does not repair an existing directory.
-  await chmod(SCREENSHOT_DIRECTORY, 0o700);
+export async function prepareScreenshotDirectory(
+  directory = SCREENSHOT_DIRECTORY,
+): Promise<void> {
+  try {
+    await mkdir(directory, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
+
+  const pathMetadata = await lstat(directory);
+  if (!pathMetadata.isDirectory() || pathMetadata.isSymbolicLink()) {
+    throw new Error('Screenshot directory is not a real directory');
+  }
+
+  const handle = await open(
+    directory,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const openedMetadata = await handle.stat();
+    const currentUid = process.getuid?.();
+    if (
+      !openedMetadata.isDirectory() ||
+      openedMetadata.dev !== pathMetadata.dev ||
+      openedMetadata.ino !== pathMetadata.ino ||
+      (currentUid !== undefined && openedMetadata.uid !== currentUid)
+    ) {
+      throw new Error('Screenshot directory ownership changed');
+    }
+    // mkdir's mode is affected by the umask and does not repair an existing directory.
+    await handle.chmod(0o700);
+  } finally {
+    await handle.close();
+  }
 }
 
 async function cleanupOldScreenshots(now = Date.now()): Promise<void> {

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -18,7 +18,10 @@ import { definePlugin } from '../plugin.js';
 const SCREENSHOT_PREFIX = 'metro-mcp-screenshot-';
 const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const SCREENSHOT_FILE_PATTERN = /^metro-mcp-screenshot-[a-zA-Z0-9-]+\.png$/;
-const SCREENSHOT_DIRECTORY = join(tmpdir(), 'metro-mcp-screenshots');
+const SCREENSHOT_DIRECTORY = join(
+  tmpdir(),
+  `metro-mcp-screenshots-${process.getuid?.() ?? 'user'}`,
+);
 
 export function quoteShellArgument(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,7 @@ import {
   selectPinnedTarget,
   type MetroTargetPin,
 } from './utils/target-selection.js';
+import { normalizeToolResult } from './utils/tool-results.js';
 import { version } from './version.js';
 import {
   createDaemonIdentity,
@@ -399,11 +400,7 @@ export async function createMetroRuntime(
               const result = await toolConfig.handler(args as z.infer<T>, {
                 sendProgress,
               });
-              const content =
-                typeof result === 'string' ? result : JSON.stringify(result);
-              return {
-                content: [{ type: 'text' as const, text: content }],
-              };
+              return normalizeToolResult(result);
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
               return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { exec } from 'node:child_process';
+import { exec, execFile } from 'node:child_process';
 import fs from 'node:fs';
 import http from 'node:http';
 import { tmpdir } from 'node:os';
@@ -97,6 +97,7 @@ import { filesystemPlugin } from './plugins/filesystem.js';
 import { environmentPlugin } from './plugins/environment.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const logger = createLogger('server');
 const RESOURCE_UPDATE_COALESCE_MS = 250;
 
@@ -607,6 +608,13 @@ export async function createMetroRuntime(
       exec: async (command: string) => {
         const { stdout } = await execAsync(command);
         return stdout;
+      },
+      execFile: async (command, args, options) => {
+        const { stdout } = await execFileAsync(command, args, {
+          encoding: 'buffer',
+          maxBuffer: options?.maxBuffer,
+        });
+        return Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout);
       },
       format: formatUtils,
       getActiveDeviceKey: () => activeDeviceKey,

--- a/src/utils/tool-results.test.ts
+++ b/src/utils/tool-results.test.ts
@@ -21,3 +21,11 @@ test('serializes ordinary plugin results as text', () => {
     content: [{ type: 'text', text: '{"ok":true}' }],
   });
 });
+
+test('serializes content-shaped objects that are not valid MCP results', () => {
+  const result = { content: [{ type: 'custom', value: 42 }] };
+
+  expect(normalizeToolResult(result)).toEqual({
+    content: [{ type: 'text', text: JSON.stringify(result) }],
+  });
+});

--- a/src/utils/tool-results.test.ts
+++ b/src/utils/tool-results.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test';
+import { normalizeToolResult } from './tool-results.js';
+
+test('preserves a native MCP tool result', () => {
+  const result = {
+    content: [
+      {
+        type: 'image' as const,
+        data: 'iVBORw0KGgo=',
+        mimeType: 'image/png',
+      },
+    ],
+    structuredContent: { source: 'fixture' },
+  };
+
+  expect(normalizeToolResult(result)).toBe(result);
+});
+
+test('serializes ordinary plugin results as text', () => {
+  expect(normalizeToolResult({ ok: true })).toEqual({
+    content: [{ type: 'text', text: '{"ok":true}' }],
+  });
+});

--- a/src/utils/tool-results.test.ts
+++ b/src/utils/tool-results.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from 'bun:test';
+import { nativeToolResult } from '../plugin.js';
 import { normalizeToolResult } from './tool-results.js';
 
 test('preserves a native MCP tool result', () => {
-  const result = {
+  const result = nativeToolResult({
     content: [
       {
         type: 'image' as const,
@@ -11,7 +12,7 @@ test('preserves a native MCP tool result', () => {
       },
     ],
     structuredContent: { source: 'fixture' },
-  };
+  });
 
   expect(normalizeToolResult(result)).toBe(result);
 });
@@ -28,4 +29,23 @@ test('serializes content-shaped objects that are not valid MCP results', () => {
   expect(normalizeToolResult(result)).toEqual({
     content: [{ type: 'text', text: JSON.stringify(result) }],
   });
+});
+
+test('serializes valid content-shaped objects without explicit opt-in', () => {
+  const result = {
+    content: [{ type: 'text' as const, text: 'ordinary plugin data' }],
+    isError: true,
+  };
+
+  expect(normalizeToolResult(result)).toEqual({
+    content: [{ type: 'text', text: JSON.stringify(result) }],
+  });
+});
+
+test('rejects invalid explicitly native results', () => {
+  expect(() =>
+    nativeToolResult({
+      content: [{ type: 'custom', value: 42 }],
+    } as never),
+  ).toThrow('Invalid native MCP tool result');
 });

--- a/src/utils/tool-results.ts
+++ b/src/utils/tool-results.ts
@@ -1,11 +1,11 @@
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import {
-  isCallToolResult,
-  type CallToolResult,
-} from '@modelcontextprotocol/server';
-import type { ToolHandlerResult } from '../plugin.js';
+  isNativeToolResult,
+  type ToolHandlerResult,
+} from '../plugin.js';
 
 export function normalizeToolResult(result: ToolHandlerResult): CallToolResult {
-  if (isCallToolResult(result)) return result;
+  if (isNativeToolResult(result)) return result;
   const text =
     typeof result === 'string'
       ? result

--- a/src/utils/tool-results.ts
+++ b/src/utils/tool-results.ts
@@ -1,0 +1,14 @@
+import {
+  isCallToolResult,
+  type CallToolResult,
+} from '@modelcontextprotocol/server';
+import type { ToolHandlerResult } from '../plugin.js';
+
+export function normalizeToolResult(result: ToolHandlerResult): CallToolResult {
+  if (isCallToolResult(result)) return result;
+  const text =
+    typeof result === 'string'
+      ? result
+      : (JSON.stringify(result) ?? String(result));
+  return { content: [{ type: 'text', text }] };
+}

--- a/tests/fixtures/native-result-plugin.ts
+++ b/tests/fixtures/native-result-plugin.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { definePlugin } from '../../src/plugin.js';
+
+export default definePlugin({
+  name: 'native-result-fixture',
+  async setup(ctx) {
+    ctx.registerTool('test_native_image', {
+      description: 'Return a native MCP image block for protocol tests.',
+      parameters: z.object({}),
+      handler: async () => ({
+        content: [
+          {
+            type: 'image',
+            data: 'iVBORw0KGgo=',
+            mimeType: 'image/png',
+          },
+        ],
+        structuredContent: { source: 'fixture' },
+      }),
+    });
+  },
+});

--- a/tests/fixtures/native-result-plugin.ts
+++ b/tests/fixtures/native-result-plugin.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { definePlugin } from '../../src/plugin.js';
+import { definePlugin, nativeToolResult } from '../../src/plugin.js';
 
 export default definePlugin({
   name: 'native-result-fixture',
@@ -7,7 +7,7 @@ export default definePlugin({
     ctx.registerTool('test_native_image', {
       description: 'Return a native MCP image block for protocol tests.',
       parameters: z.object({}),
-      handler: async () => ({
+      handler: async () => nativeToolResult({
         content: [
           {
             type: 'image',

--- a/tests/protocol-v2.test.ts
+++ b/tests/protocol-v2.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
 import {
   Client,
   StreamableHTTPClientTransport,
@@ -16,16 +17,41 @@ afterEach(async () => {
   server = undefined;
 });
 
-async function startTestServer() {
+async function startTestServer(plugins: string[] = []) {
   const config = await loadConfig(['--project-root', process.cwd()]);
   config.metro.host = '127.0.0.1';
   config.metro.port = 65535;
   config.metro.autoDiscover = false;
   config.proxy.enabled = false;
+  config.plugins = plugins;
   server = await startHttpServer(config, ['--project-root', process.cwd()], {
     port: 0,
   });
   return server;
+}
+
+const nativeResultPlugin = resolve(
+  import.meta.dir,
+  'fixtures/native-result-plugin.ts',
+);
+
+async function expectNativeImageResult(modern: boolean): Promise<void> {
+  const running = await startTestServer([nativeResultPlugin]);
+  const client = createClient(running.url, modern);
+  await client.connect(new StreamableHTTPClientTransport(new URL(running.url)));
+
+  const result = await client.callTool({
+    name: 'test_native_image',
+    arguments: {},
+  });
+  expect(result.content).toEqual([
+    {
+      type: 'image',
+      data: 'iVBORw0KGgo=',
+      mimeType: 'image/png',
+    },
+  ]);
+  expect(result.structuredContent).toEqual({ source: 'fixture' });
 }
 
 function createClient(url: string, modern: boolean): Client {
@@ -145,6 +171,14 @@ describe('V2 HTTP compatibility', () => {
     expect(client.getProtocolEra()).toBe('legacy');
     expect((await client.listTools()).tools.length).toBeGreaterThan(20);
     await client.subscribeResource({ uri: 'metro://logs' });
+  });
+
+  test('passes native image content through modern protocol negotiation', async () => {
+    await expectNativeImageResult(true);
+  });
+
+  test('passes native image content through legacy protocol negotiation', async () => {
+    await expectNativeImageResult(false);
   });
 });
 


### PR DESCRIPTION
Closes #69

## Summary
- allow plugin tools to return validated native MCP content blocks while preserving JSON-text results
- make `take_screenshot` retain a unique temporary PNG by default with structured metadata
- add opt-in inline MCP image delivery with reliable temporary-file cleanup
- opportunistically remove Metro MCP screenshot files older than 24 hours

## Validation
- `bun run typecheck`
- `bun test` (78 passing)
- `bun run build`
- `bun run docs:build`

Rebased onto main after the CDP and daemon PRs; retained both required server imports. The resulting tree matches the validated integration preview.