### PR TITLE
Make fiber inspection focused, deep, and bounded

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -57,10 +57,12 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 
 > No app changes needed.
 
-- **`get_component_tree`** — Get the React component tree. Use `structureOnly=true` for compact output (~1-3KB).
-- **`find_components`** — Search by component name pattern.
+- **`get_component_tree`** — Get a paged flat React component snapshot. Follow `nextCursor` to retrieve all nodes, then reconstruct hierarchy from `id` and `parentId`.
+- **`find_components`** — Search by component name pattern inside the app runtime.
 - **`inspect_component`** — Get detailed props, state, and hooks for a specific component.
 - **`get_testable_elements`** — List all elements with `testID` or `accessibilityLabel`.
+
+All component read tools return `traversal` metadata. Check `complete` before interpreting an empty result as “not found”; `depthReached`, `scannedNodes`, and `truncationReason` explain bounded results. Traversal defaults to `maxDepth=200` and `maxNodes=1200`, supports depths up to 600, and reports whether it inspected the `focused-scene` or `all-scenes`.
 
 ## Storage
 
@@ -121,7 +123,7 @@ Inspect and manage app permissions on iOS Simulator and Android Emulator without
 
 All tools use the CDP fiber tree first, falling back to `simctl`/`adb`, then IDB as a last resort. IDB is optional — tools will prompt you to install it when needed.
 
-- **`list_elements`** — Get interactive elements from the React component tree (labels, testIDs, roles). No IDB needed.
+- **`list_elements`** — Get interactive elements from the React component tree (labels, testIDs, roles) with traversal completeness metadata. No IDB needed.
 - **`tap_element`** — Tap by label/testID (CDP fiber tree) or coordinates (simctl/adb → IDB fallback).
 - **`type_text`** — Type into a TextInput by testID/label or the first visible input (CDP → adb → IDB).
 - **`long_press`** — Long press by label/testID (CDP) or coordinates (adb → IDB).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -64,6 +64,12 @@ Jump to: [Console](#console) · [Network](#network) · [Errors](#errors) · [Eva
 
 All component read tools return `traversal` metadata. Check `complete` before interpreting an empty result as “not found”; `depthReached`, `scannedNodes`, and `truncationReason` explain bounded results. Traversal defaults to `maxDepth=200` and `maxNodes=1200`, supports depths up to 600, and reports whether it inspected the `focused-scene` or `all-scenes`.
 
+Projected props share a 256 KiB UTF-8 JSON budget across each runtime capture,
+including all pages of a component-tree snapshot. Once it is exhausted, later
+props are omitted and `truncationReason` is `max-prop-bytes` (unless a traversal
+limit was already reached). Use `structureOnly=true` when only hierarchy and
+selectors are needed.
+
 ## Storage
 
 > No app changes needed.

--- a/src/app-sources/components/index.tsx
+++ b/src/app-sources/components/index.tsx
@@ -5,6 +5,9 @@ import { initialize, callTool, getToolText } from '../shared/bridge';
 import { useKeyboard } from '../shared/useKeyboard';
 
 interface FiberNode {
+  id: string;
+  parentId: string | null;
+  depth: number;
   name: string;
   children?: FiberNode[];
   props?: Record<string, unknown>;
@@ -19,27 +22,73 @@ interface InspectResult {
   hooks: Array<{ index: number; value: unknown }>;
 }
 
+interface Traversal {
+  scope: 'focused-scene' | 'all-scenes';
+  complete: boolean;
+  depthReached: number;
+  scannedNodes: number;
+  truncationReason?: string;
+}
+
+interface TreePage {
+  snapshotId: string | null;
+  nodes: FiberNode[];
+  traversal: Traversal;
+  nextCursor?: string;
+  error?: string;
+}
+
+interface InspectEnvelope {
+  result: InspectResult | null;
+  traversal: Traversal;
+}
+
 function App() {
-  const [tree, setTree] = useState<FiberNode | null>(null);
+  const [tree, setTree] = useState<FiberNode[]>([]);
   const [selected, setSelected] = useState<InspectResult | null>(null);
   const [inspecting, setInspecting] = useState('');
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [msg, setMsg] = useState('');
+  const [warning, setWarning] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
 
   const fetchTree = useCallback(async () => {
     try {
-      const result = await callTool('get_component_tree', { structureOnly: true, maxDepth: 30 });
-      const text = getToolText(result);
-      if (text.startsWith('Component tree not available')) {
-        setMsg(text);
+      const nodes: FiberNode[] = [];
+      const seenCursors = new Set<string>();
+      let cursor: string | undefined;
+      let lastPage: TreePage | null = null;
+      do {
+        const result = await callTool('get_component_tree', {
+          structureOnly: true,
+          pageSize: 250,
+          ...(cursor ? { cursor } : {}),
+        });
+        const page = JSON.parse(getToolText(result)) as TreePage;
+        lastPage = page;
+        nodes.push(...page.nodes);
+        cursor = page.nextCursor;
+        if (cursor && seenCursors.has(cursor)) throw new Error('Repeated component-tree cursor');
+        if (cursor) seenCursors.add(cursor);
+      } while (cursor);
+
+      if (lastPage?.error) {
+        setMsg(lastPage.error);
+        setTree([]);
+        setWarning('');
       } else {
-        setTree(JSON.parse(text) as FiberNode);
+        setTree(reconstructTree(nodes));
         setMsg('');
+        setWarning(
+          lastPage && !lastPage.traversal.complete
+            ? `Incomplete ${lastPage.traversal.scope} traversal: ${lastPage.traversal.truncationReason ?? 'limit reached'} after ${lastPage.traversal.scannedNodes} fibers (depth ${lastPage.traversal.depthReached}).`
+            : '',
+        );
       }
     } catch {
       setMsg('Component tree unavailable. Ensure the app is running.');
+      setWarning('');
     } finally {
       setLoading(false);
     }
@@ -49,12 +98,8 @@ function App() {
     setInspecting(name);
     try {
       const result = await callTool('inspect_component', { name });
-      const text = getToolText(result);
-      if (text.includes('not found')) {
-        setSelected(null);
-      } else {
-        setSelected(JSON.parse(text) as InspectResult);
-      }
+      const envelope = JSON.parse(getToolText(result)) as InspectEnvelope;
+      setSelected(envelope.result);
     } catch {
       setSelected(null);
     } finally {
@@ -78,18 +123,24 @@ function App() {
       </div>
       <div class="split">
         <div class="split-main" style="padding:8px">
+          {warning && (
+            <div style="margin:0 0 8px;padding:7px 9px;border:1px solid var(--warn);border-radius:var(--r);color:var(--warn);font-size:11px">
+              {warning}
+            </div>
+          )}
           {loading && <div class="empty">Loading…</div>}
           {!loading && msg && <div class="empty">{msg}<p>Ensure the app is running and React DevTools hook is active.</p></div>}
-          {!loading && !msg && tree && (
+          {!loading && !msg && tree.map(node => (
             <NodeTree
-              node={tree}
+              key={node.id}
+              node={node}
               search={search}
               depth={0}
               activeInspect={selected?.name ?? ''}
               onInspect={inspect}
               inspecting={inspecting}
             />
-          )}
+          ))}
         </div>
         {selected && (
           <div class="split-side open">
@@ -127,6 +178,21 @@ function App() {
       </div>
     </div>
   );
+}
+
+function reconstructTree(flatNodes: FiberNode[]): FiberNode[] {
+  const byId = new Map<string, FiberNode>();
+  const roots: FiberNode[] = [];
+  for (const flatNode of flatNodes) {
+    byId.set(flatNode.id, { ...flatNode, children: [] });
+  }
+  for (const flatNode of flatNodes) {
+    const node = byId.get(flatNode.id)!;
+    const parent = flatNode.parentId ? byId.get(flatNode.parentId) : undefined;
+    if (parent) parent.children!.push(node);
+    else roots.push(node);
+  }
+  return roots;
 }
 
 function NodeTree({ node, search, depth, activeInspect, onInspect, inspecting }: {

--- a/src/plugins/automation.ts
+++ b/src/plugins/automation.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { collectElements } from '../utils/fiber.js';
+import {
+  collectElements,
+  DEFAULT_FIBER_MAX_DEPTH,
+  DEFAULT_FIBER_MAX_NODES,
+  MAX_FIBER_DEPTH,
+  MAX_FIBER_NODES,
+} from '../utils/fiber.js';
 
 const CURRENT_ROUTE_JS = `(function() {
   try {
@@ -20,7 +26,8 @@ export const automationPlugin = definePlugin({
       description:
         'Poll the component tree until an element matching the given testID or accessibilityLabel appears. ' +
         'Returns element info on success. Use after tap_element, navigate(), or any action that triggers ' +
-        'async screen transitions or data loading — instead of immediately calling the next tool.',
+        'async screen transitions or data loading — instead of immediately calling the next tool. ' +
+        'Returns traversal metadata immediately when the bounded search is incomplete.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         selector: z.string().describe('testID or accessibilityLabel to wait for'),
@@ -28,17 +35,43 @@ export const automationPlugin = definePlugin({
           .describe('Maximum wait time in milliseconds (default 10000)'),
         pollInterval: z.number().int().min(100).max(5000).default(500)
           .describe('How often to check in milliseconds (default 500)'),
+        maxDepth: z.number().int().min(0).max(MAX_FIBER_DEPTH)
+          .default(DEFAULT_FIBER_MAX_DEPTH)
+          .describe('Maximum fiber depth inspected per poll'),
+        maxNodes: z.number().int().min(1).max(MAX_FIBER_NODES)
+          .default(DEFAULT_FIBER_MAX_NODES)
+          .describe('Maximum fibers inspected per poll'),
       }),
-      handler: async ({ selector, timeout, pollInterval }, { sendProgress }) => {
+      handler: async (
+        { selector, timeout, pollInterval, maxDepth, maxNodes },
+        { sendProgress },
+      ) => {
         const start = Date.now();
         while (Date.now() - start < timeout) {
           try {
-            const elements = await collectElements(ctx.evalInApp);
-            const match = elements.find(
+            const collection = await collectElements(ctx.evalInApp, {
+              maxDepth,
+              maxNodes,
+            });
+            const match = collection.elements.find(
               (el) => el.testID === selector || el.accessibilityLabel === selector,
             );
             if (match) {
-              return { found: true, element: match, elapsedMs: Date.now() - start };
+              return {
+                found: true,
+                element: match,
+                traversal: collection.traversal,
+                elapsedMs: Date.now() - start,
+              };
+            }
+            if (!collection.traversal.complete) {
+              return {
+                found: false,
+                traversal: collection.traversal,
+                elapsedMs: Date.now() - start,
+                reason:
+                  'Fiber traversal was incomplete; raise maxDepth or maxNodes before treating the element as absent.',
+              };
             }
           } catch {
             // CDP may not be ready yet — keep polling

--- a/src/plugins/components.ts
+++ b/src/plugins/components.ts
@@ -1,286 +1,255 @@
 import { z } from 'zod';
-import { definePlugin } from '../plugin.js';
-import { escapeJsString } from '../utils/format.js';
 import { buildComponentsHtml } from '../apps/components.js';
+import { definePlugin } from '../plugin.js';
+import {
+  DEFAULT_FIBER_MAX_DEPTH,
+  DEFAULT_FIBER_MAX_NODES,
+  MAX_FIBER_DEPTH,
+  MAX_FIBER_NODES,
+  buildFiberReadExpression,
+  type FiberTraversalMetadata,
+} from '../utils/fiber.js';
+import {
+  FiberSnapshotStore,
+  type FlatFiberNode,
+} from '../utils/fiber-snapshots.js';
 
-// JS expression to walk the React fiber tree
-const WALK_FIBER_EXPR = `
-(function() {
-  var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-  if (!hook || !hook.getFiberRoots) return null;
+const traversalParameters = {
+  maxDepth: z
+    .number()
+    .int()
+    .min(0)
+    .max(MAX_FIBER_DEPTH)
+    .default(DEFAULT_FIBER_MAX_DEPTH)
+    .describe('Maximum fiber depth to traverse (default 200, maximum 600)'),
+  maxNodes: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_FIBER_NODES)
+    .default(DEFAULT_FIBER_MAX_NODES)
+    .describe('Maximum fibers to scan (default 1200)'),
+};
 
-  var roots = [];
-  try {
-    var fiberRoots = hook.getFiberRoots(1);
-    if (!fiberRoots || fiberRoots.size === 0) {
-      // Try renderer IDs 1-5
-      for (var i = 1; i <= 5; i++) {
-        fiberRoots = hook.getFiberRoots(i);
-        if (fiberRoots && fiberRoots.size > 0) break;
-      }
-    }
-    if (!fiberRoots || fiberRoots.size === 0) return null;
-    roots = Array.from(fiberRoots);
-  } catch(e) { return null; }
-
-  var OPTIONS = __OPTIONS__;
-
-  function getName(fiber) {
-    if (!fiber || !fiber.type) return null;
-    if (typeof fiber.type === 'string') return fiber.type;
-    return fiber.type.displayName || fiber.type.name || null;
-  }
-
-  function walkFiber(fiber, depth) {
-    if (!fiber || depth > (OPTIONS.maxDepth || 200)) return null;
-
-    var name = getName(fiber);
-    var node = null;
-
-    if (name) {
-      node = { name: name };
-
-      if (!OPTIONS.structureOnly) {
-        if (fiber.memoizedProps && Object.keys(fiber.memoizedProps).length > 0) {
-          try {
-            var props = {};
-            var propKeys = Object.keys(fiber.memoizedProps);
-            for (var i = 0; i < Math.min(propKeys.length, 20); i++) {
-              var key = propKeys[i];
-              var val = fiber.memoizedProps[key];
-              if (key === 'children') continue;
-              if (typeof val === 'function') { props[key] = '[function]'; }
-              else if (typeof val === 'object' && val !== null) { props[key] = '[object]'; }
-              else { props[key] = val; }
-            }
-            if (Object.keys(props).length > 0) node.props = props;
-          } catch(e) {}
-        }
-      }
-
-      if (OPTIONS.includeTestIds) {
-        var testID = fiber.memoizedProps?.testID;
-        var accessibilityLabel = fiber.memoizedProps?.accessibilityLabel;
-        var accessibilityRole = fiber.memoizedProps?.accessibilityRole;
-        if (testID) node.testID = testID;
-        if (accessibilityLabel) node.accessibilityLabel = accessibilityLabel;
-        if (accessibilityRole) node.accessibilityRole = accessibilityRole;
-      }
-    }
-
-    var children = [];
-    var child = fiber.child;
-    while (child) {
-      var childNode = walkFiber(child, depth + 1);
-      if (childNode) children.push(childNode);
-      child = child.sibling;
-    }
-
-    if (node) {
-      if (children.length > 0) node.children = children;
-      return node;
-    }
-
-    if (children.length === 1) return children[0];
-    if (children.length > 1) return { name: 'Fragment', children: children };
-    return null;
-  }
-
-  var rootFiber = roots[0].current;
-  return walkFiber(rootFiber, 0);
-})()
-`;
+interface RuntimeTreeResult {
+  nodes: FlatFiberNode[];
+  traversal: FiberTraversalMetadata;
+}
 
 export const componentsPlugin = definePlugin({
   name: 'components',
-
-  description: 'React component tree inspection via fiber tree walking',
+  description: 'React component tree inspection via bounded fiber traversal',
 
   async setup(ctx) {
+    const snapshots = new FiberSnapshotStore();
+
     ctx.registerAppResource('ui://metro/components', {
       name: 'Component Tree',
-      description: 'Interactive React fiber tree explorer with props, state, and testID viewer',
+      description:
+        'Interactive React fiber tree explorer with props, state, and testID viewer',
       handler: async () => buildComponentsHtml(),
     });
 
     ctx.registerTool('get_component_tree', {
       description:
-        'Get the React component tree of the running app. Use structureOnly=true for a compact view (~1-3KB).',
+        'Get a paged flat React component tree. Follow nextCursor to complete the snapshot and check traversal.complete before treating an empty page as authoritative.',
       annotations: { readOnlyHint: true },
       appUri: 'ui://metro/components',
       parameters: z.object({
-        structureOnly: z.boolean().default(false).describe('Return only component names without props/state'),
-        maxDepth: z.number().default(30).describe('Maximum depth to traverse'),
-        compact: z.boolean().default(false).describe('Return compact single-line format'),
+        structureOnly: z
+          .boolean()
+          .default(false)
+          .describe('Return component names and selectors without props'),
+        pageSize: z
+          .number()
+          .int()
+          .min(1)
+          .max(250)
+          .default(100)
+          .describe('Nodes per page (default 100, maximum 250)'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Opaque nextCursor returned by the previous page'),
+        ...traversalParameters,
       }),
-      handler: async ({ structureOnly, maxDepth, compact: isCompact }) => {
-        const options = JSON.stringify({ structureOnly, maxDepth, includeTestIds: true });
-        const expr = WALK_FIBER_EXPR.replace('__OPTIONS__', options);
-        const tree = await ctx.evalInApp(expr, { timeout: 5000 });
-        if (!tree) return 'Component tree not available. Ensure React DevTools hook is present.';
-        if (isCompact) return ctx.format.compact(tree);
-        return tree;
+      handler: async ({
+        structureOnly,
+        pageSize,
+        cursor,
+        maxDepth,
+        maxNodes,
+      }) => {
+        if (cursor) return snapshots.read(cursor, pageSize);
+
+        const expression = buildFiberReadExpression(
+          `
+            var nodes = [];
+            var nextId = 1;
+            var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
+              var name = metroFiberName(fiber);
+              if (!name) return;
+              var props = fiber.memoizedProps || {};
+              var id = 'fiber-' + nextId++;
+              var node = {
+                id: id,
+                parentId: context.parentContext || null,
+                depth: context.depth,
+                name: name
+              };
+              if (!${structureOnly}) {
+                var safeProps = metroSafeProps(fiber, 20);
+                if (Object.keys(safeProps).length) node.props = safeProps;
+              }
+              if (typeof props.testID === 'string') node.testID = props.testID;
+              if (typeof props.accessibilityLabel === 'string') {
+                node.accessibilityLabel = props.accessibilityLabel;
+              }
+              if (typeof props.accessibilityRole === 'string') {
+                node.accessibilityRole = props.accessibilityRole;
+              }
+              nodes.push(node);
+              return { childContext: id };
+            });
+            return { nodes: nodes, traversal: traversal };
+          `,
+          { maxDepth, maxNodes },
+        );
+        const result = (await ctx.evalInApp(expression, {
+          timeout: 10_000,
+        })) as RuntimeTreeResult | null;
+        if (!result) {
+          return snapshots.create(
+            [],
+            {
+              scope: 'all-scenes',
+              complete: false,
+              depthReached: 0,
+              scannedNodes: 0,
+              truncationReason: 'fiber-roots-unavailable',
+            },
+            pageSize,
+          );
+        }
+        return snapshots.create(result.nodes, result.traversal, pageSize);
       },
     });
 
     ctx.registerTool('find_components', {
-      description: 'Search for components by name pattern in the React tree.',
+      description:
+        'Search for components by name inside the app runtime. Check traversal.complete before treating no matches as definitive.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
-        pattern: z.string().describe('Component name or pattern to search for'),
-        includeProps: z.boolean().default(true).describe('Include component props in results'),
+        pattern: z.string().describe('Case-insensitive component name pattern'),
+        includeProps: z
+          .boolean()
+          .default(true)
+          .describe('Include component props in matches'),
+        ...traversalParameters,
       }),
-      handler: async ({ pattern, includeProps }) => {
-        const options = JSON.stringify({
-          structureOnly: !includeProps,
-          maxDepth: 50,
-          includeTestIds: true,
-        });
-        const expr = WALK_FIBER_EXPR.replace('__OPTIONS__', options);
-        const tree = await ctx.evalInApp(expr, { timeout: 5000 });
-        if (!tree) return 'Component tree not available.';
-
-        const matches: unknown[] = [];
-        const regex = new RegExp(pattern, 'i');
-
-        function search(node: Record<string, unknown>) {
-          if (typeof node.name === 'string' && regex.test(node.name)) {
-            matches.push(node);
-          }
-          if (Array.isArray(node.children)) {
-            for (const child of node.children) {
-              search(child as Record<string, unknown>);
-            }
-          }
-        }
-
-        search(tree as Record<string, unknown>);
-        return matches.length > 0
-          ? matches
-          : `No components matching "${pattern}" found.`;
+      handler: async ({ pattern, includeProps, maxDepth, maxNodes }) => {
+        // Validate here for a concise tool error; matching itself stays in-app.
+        new RegExp(pattern, 'i');
+        const expression = buildFiberReadExpression(
+          `
+            var matches = [];
+            var matcher = new RegExp(${JSON.stringify(pattern)}, 'i');
+            var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
+              var name = metroFiberName(fiber);
+              if (!name || !matcher.test(name)) return;
+              var props = fiber.memoizedProps || {};
+              var match = { name: name, depth: context.depth };
+              if (${includeProps}) match.props = metroSafeProps(fiber, 20);
+              if (typeof props.testID === 'string') match.testID = props.testID;
+              if (typeof props.accessibilityLabel === 'string') {
+                match.accessibilityLabel = props.accessibilityLabel;
+              }
+              if (typeof props.accessibilityRole === 'string') {
+                match.accessibilityRole = props.accessibilityRole;
+              }
+              matches.push(match);
+            });
+            return { matches: matches, traversal: traversal };
+          `,
+          { maxDepth, maxNodes },
+        );
+        return ctx.evalInApp(expression, { timeout: 10_000 });
       },
     });
 
     ctx.registerTool('inspect_component', {
-      description: 'Get detailed props, state, and hooks info for a specific component.',
+      description:
+        'Get props, state, and hooks for the first exact component-name match, with traversal completeness metadata.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         name: z.string().describe('Exact component name to inspect'),
+        ...traversalParameters,
       }),
-      handler: async ({ name }) => {
-        const expr = `
-          (function() {
-            var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-            if (!hook || !hook.getFiberRoots) return null;
-
-            var fiberRoots;
-            for (var i = 1; i <= 5; i++) {
-              fiberRoots = hook.getFiberRoots(i);
-              if (fiberRoots && fiberRoots.size > 0) break;
-            }
-            if (!fiberRoots || fiberRoots.size === 0) return null;
-
-            var rootFiber = Array.from(fiberRoots)[0].current;
-            var target = null;
-
-            function find(fiber) {
-              if (!fiber) return;
-              var n = fiber.type?.displayName || fiber.type?.name;
-              if (n === '${escapeJsString(name)}') { target = fiber; return; }
-              find(fiber.child);
-              if (!target) find(fiber.sibling);
-            }
-            find(rootFiber);
-
-            if (!target) return null;
-
-            var result = {
-              name: '${name}',
-              props: {},
-              state: null,
-              hooks: [],
-            };
-
-            // Props
-            if (target.memoizedProps) {
-              var pkeys = Object.keys(target.memoizedProps);
-              for (var i = 0; i < pkeys.length; i++) {
-                var k = pkeys[i];
-                var v = target.memoizedProps[k];
-                if (typeof v === 'function') result.props[k] = '[function]';
-                else if (typeof v === 'object' && v !== null) {
-                  try { result.props[k] = JSON.parse(JSON.stringify(v)); }
-                  catch(e) { result.props[k] = '[object]'; }
-                }
-                else result.props[k] = v;
-              }
-            }
-
-            // State (hooks)
-            var hookState = target.memoizedState;
-            var hookIdx = 0;
-            while (hookState && hookIdx < 20) {
-              try {
-                var val = hookState.memoizedState;
-                if (val !== undefined) {
-                  if (typeof val === 'function') result.hooks.push({ index: hookIdx, value: '[function]' });
-                  else if (typeof val === 'object' && val !== null) {
-                    try { result.hooks.push({ index: hookIdx, value: JSON.parse(JSON.stringify(val)) }); }
-                    catch(e) { result.hooks.push({ index: hookIdx, value: '[object]' }); }
+      handler: async ({ name, maxDepth, maxNodes }) => {
+        const expression = buildFiberReadExpression(
+          `
+            var result = null;
+            var targetName = ${JSON.stringify(name)};
+            var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
+              if (result || metroFiberName(fiber) !== targetName) return;
+              var hooks = [];
+              var hookState = fiber.memoizedState;
+              var hookIndex = 0;
+              while (hookState && hookIndex < 20) {
+                try {
+                  var value = hookState.memoizedState;
+                  if (value !== undefined) {
+                    if (typeof value === 'function') value = '[function]';
+                    else if (value && typeof value === 'object') {
+                      try { value = JSON.parse(JSON.stringify(value)); }
+                      catch (_) { value = '[object]'; }
+                    }
+                    hooks.push({ index: hookIndex, value: value });
                   }
-                  else result.hooks.push({ index: hookIdx, value: val });
-                }
-              } catch(e) {}
-              hookState = hookState.next;
-              hookIdx++;
-            }
-
-            return result;
-          })()
-        `;
-        const result = await ctx.evalInApp(expr, { timeout: 5000 });
-        if (!result) return `Component "${name}" not found in the tree.`;
-        return result;
+                } catch (_) {}
+                hookState = hookState.next;
+                hookIndex++;
+              }
+              result = {
+                name: targetName,
+                depth: context.depth,
+                props: metroSafeProps(fiber, 50),
+                state: null,
+                hooks: hooks
+              };
+            });
+            return { result: result, traversal: traversal };
+          `,
+          { maxDepth, maxNodes },
+        );
+        return ctx.evalInApp(expression, { timeout: 10_000 });
       },
     });
 
     ctx.registerTool('get_testable_elements', {
       description:
-        'Get all elements with testID or accessibilityLabel — useful for test generation.',
+        'Get elements with testID or accessibilityLabel. Check traversal.complete before treating an empty elements array as definitive.',
       annotations: { readOnlyHint: true },
-      parameters: z.object({}),
-      handler: async () => {
-        const options = JSON.stringify({
-          structureOnly: true,
-          maxDepth: 50,
-          includeTestIds: true,
-        });
-        const expr = WALK_FIBER_EXPR.replace('__OPTIONS__', options);
-        const tree = await ctx.evalInApp(expr, { timeout: 5000 });
-        if (!tree) return 'Component tree not available.';
-
-        const elements: Array<{ name: string; testID?: string; accessibilityLabel?: string; accessibilityRole?: string }> = [];
-
-        function collect(node: Record<string, unknown>) {
-          if (node.testID || node.accessibilityLabel) {
-            elements.push({
-              name: node.name as string,
-              testID: node.testID as string | undefined,
-              accessibilityLabel: node.accessibilityLabel as string | undefined,
-              accessibilityRole: node.accessibilityRole as string | undefined,
+      parameters: z.object({ ...traversalParameters }),
+      handler: async ({ maxDepth, maxNodes }) => {
+        const expression = buildFiberReadExpression(
+          `
+            var elements = [];
+            var seen = new Set();
+            var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
+              var element = metroElementFromFiber(fiber);
+              if (!element || (!element.testID && !element.accessibilityLabel)) return;
+              var key = element.testID || element.accessibilityLabel;
+              if (seen.has(key)) return;
+              seen.add(key);
+              element.depth = context.depth;
+              elements.push(element);
             });
-          }
-          if (Array.isArray(node.children)) {
-            for (const child of node.children) {
-              collect(child as Record<string, unknown>);
-            }
-          }
-        }
-
-        collect(tree as Record<string, unknown>);
-        return elements.length > 0
-          ? elements
-          : 'No elements with testID or accessibilityLabel found.';
+            return { elements: elements, traversal: traversal };
+          `,
+          { maxDepth, maxNodes },
+        );
+        return ctx.evalInApp(expression, { timeout: 10_000 });
       },
     });
   },

--- a/src/plugins/components.ts
+++ b/src/plugins/components.ts
@@ -235,13 +235,9 @@ export const componentsPlugin = definePlugin({
         const expression = buildFiberReadExpression(
           `
             var elements = [];
-            var seen = new Set();
             var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
               var element = metroElementFromFiber(fiber);
               if (!element || (!element.testID && !element.accessibilityLabel)) return;
-              var key = element.testID || element.accessibilityLabel;
-              if (seen.has(key)) return;
-              seen.add(key);
               element.depth = context.depth;
               elements.push(element);
             });

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -196,6 +196,49 @@ describe('fiber read tools', () => {
     expect(first.traversal.complete).toBe(true);
   });
 
+  test('bounds nested component props before returning them', async () => {
+    const root = fiber('LargeProps', {
+      payload: {
+        items: Array.from({ length: 500 }, (_, index) => ({
+          index,
+          value: 'x'.repeat(2_000),
+        })),
+      },
+    });
+    const call = await createHarness(runtimeFor([root]), [componentsPlugin]);
+    const result = (await call('get_component_tree', {
+      structureOnly: false,
+    })) as {
+      nodes: Array<{ props: { payload: { items: unknown[] } } }>;
+    };
+
+    expect(result.nodes[0].props.payload.items).toHaveLength(21);
+    expect(result.nodes[0].props.payload.items.at(-1)).toBe('[truncated]');
+    expect(JSON.stringify(result).length).toBeLessThan(25_000);
+  });
+
+  test('keeps distinct sibling controls that share a label', async () => {
+    const root = append(
+      fiber('Root'),
+      fiber('Pressable', { accessibilityLabel: 'Option', onPress: () => {} }),
+      fiber('Pressable', { accessibilityLabel: 'Option', onPress: () => {} }),
+    );
+    const call = await createHarness(runtimeFor([root]), [
+      componentsPlugin,
+      uiInteractPlugin,
+    ]);
+
+    const testable = (await call('get_testable_elements')) as {
+      elements: Array<{ accessibilityLabel: string }>;
+    };
+    const listed = (await call('list_elements', { interactiveOnly: true })) as {
+      elements: Array<{ label: string }>;
+    };
+
+    expect(testable.elements).toHaveLength(2);
+    expect(listed.elements).toHaveLength(2);
+  });
+
   test('list_elements returns an explicit envelope and deep elements', async () => {
     const root = fiber('Root');
     let current = root;

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -9,6 +9,7 @@ import { automationPlugin } from './automation.js';
 import { componentsPlugin } from './components.js';
 import { inspectPointPlugin } from './inspect-point.js';
 import { uiInteractPlugin } from './ui-interact.js';
+import { MAX_FIBER_PROP_BYTES } from '../utils/fiber.js';
 
 interface Fiber {
   type: string | { displayName: string } | null;
@@ -216,6 +217,49 @@ describe('fiber read tools', () => {
     expect(result.nodes[0].props.payload.items).toHaveLength(21);
     expect(result.nodes[0].props.payload.items.at(-1)).toBe('[truncated]');
     expect(JSON.stringify(result).length).toBeLessThan(25_000);
+  });
+
+  test('shares a UTF-8 prop-byte budget across the entire paged snapshot', async () => {
+    const sharedProps = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `value${index}`,
+        '😀'.repeat(1_000),
+      ]),
+    );
+    const root = append(
+      fiber('Root'),
+      ...Array.from({ length: 300 }, (_, index) => fiber(`Item${index}`, sharedProps)),
+    );
+    const call = await createHarness(runtimeFor([root]), [componentsPlugin]);
+    type Page = {
+      nodes: Array<{ props?: Record<string, unknown> }>;
+      nextCursor?: string;
+      traversal: Record<string, unknown>;
+    };
+    let page = (await call('get_component_tree', {
+      structureOnly: false,
+      pageSize: 100,
+    })) as Page;
+    const nodes = [...page.nodes];
+    while (page.nextCursor) {
+      page = (await call('get_component_tree', { cursor: page.nextCursor })) as Page;
+      nodes.push(...page.nodes);
+    }
+
+    const propBytes = nodes.reduce(
+      (total, node) => total + (node.props
+        ? Buffer.byteLength(JSON.stringify(node.props), 'utf8')
+        : 0),
+      0,
+    );
+    expect(nodes).toHaveLength(301);
+    expect(propBytes).toBeGreaterThan(0);
+    expect(propBytes).toBeLessThanOrEqual(MAX_FIBER_PROP_BYTES);
+    expect(page.traversal).toMatchObject({
+      complete: false,
+      scannedNodes: 301,
+      truncationReason: 'max-prop-bytes',
+    });
   });
 
   test('keeps distinct sibling controls that share a label', async () => {

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -5,6 +5,7 @@ import type {
   PluginContext,
   PluginDefinition,
 } from '../plugin.js';
+import { automationPlugin } from './automation.js';
 import { componentsPlugin } from './components.js';
 import { inspectPointPlugin } from './inspect-point.js';
 import { uiInteractPlugin } from './ui-interact.js';
@@ -237,6 +238,61 @@ describe('fiber read tools', () => {
 
     expect(testable.elements).toHaveLength(2);
     expect(listed.elements).toHaveLength(2);
+  });
+
+  test('bounds primitive child-array text extraction', async () => {
+    const values = new Proxy(
+      Array.from({ length: 10_000 }, () => 'x'),
+      {
+        get(target, property, receiver) {
+          if (typeof property === 'string' && /^\d+$/.test(property)) {
+            if (Number(property) >= 100) {
+              throw new Error('text extraction exceeded its item budget');
+            }
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+    const root = fiber('Text', {
+      accessibilityLabel: 'Bounded text',
+      children: values,
+    });
+    const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
+
+    const result = (await call('list_elements')) as {
+      elements: Array<{ text: string }>;
+    };
+
+    expect(result.elements[0].text.length).toBeLessThanOrEqual(300);
+  });
+
+  test('reports incomplete traversal from wait_for_element', async () => {
+    const root = append(
+      fiber('Root'),
+      ...Array.from({ length: 10 }, (_, index) =>
+        fiber('Item', index === 9 ? { testID: 'late-item' } : {}),
+      ),
+    );
+    const call = await createHarness(runtimeFor([root]), [automationPlugin]);
+
+    const result = (await call('wait_for_element', {
+      selector: 'late-item',
+      timeout: 100,
+      pollInterval: 100,
+      maxNodes: 3,
+    })) as {
+      found: boolean;
+      traversal: { complete: boolean; truncationReason?: string };
+    };
+
+    expect(result).toMatchObject({
+      found: false,
+      traversal: {
+        complete: false,
+        truncationReason: 'max-nodes',
+      },
+    });
   });
 
   test('list_elements returns an explicit envelope and deep elements', async () => {

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -21,6 +21,15 @@ interface Fiber {
   return?: Fiber | null;
 }
 
+type MeasureCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number,
+) => void;
+
 interface RegisteredTool {
   parameters: z.ZodType;
   handler: (
@@ -415,19 +424,41 @@ describe('inspect_at_point', () => {
     expect(envelope.traversal.complete).toBe(true);
   });
 
+  test('measures Fabric shadow nodes before their public instance exists', async () => {
+    const host = fiber('RCTText', {}, true);
+    const shadowNode = {};
+    const canonical = { publicInstance: null };
+    host.stateNode = { node: shadowNode, canonical };
+    const root = append(fiber('Label'), host);
+    const runtime = {
+      ...runtimeFor([root]),
+      nativeFabricUIManager: {
+        measure: (node: unknown, callback: MeasureCallback) => {
+          expect(node).toBe(shadowNode);
+          setTimeout(() => callback(0, 0, 80, 30, 5, 6), 5);
+        },
+      },
+    };
+    const call = await createHarness(runtime, [inspectPointPlugin]);
+    const envelope = (await call('inspect_at_point', { x: 10, y: 10 })) as {
+      result: Record<string, unknown>;
+      traversal: { complete: boolean };
+    };
+
+    expect(envelope.result).toMatchObject({
+      found: true,
+      hostComponent: 'RCTText',
+      reactComponent: 'Label',
+      layout: { x: 5, y: 6, width: 80, height: 30 },
+    });
+    expect(envelope.traversal.complete).toBe(true);
+    expect(canonical.publicInstance).toBeNull();
+  });
+
   test('awaits callback-based Paper measurement', async () => {
     const host = fiber('Text', {}, true);
     host.stateNode = {
-      measure: (
-        callback: (
-          x: number,
-          y: number,
-          width: number,
-          height: number,
-          pageX: number,
-          pageY: number,
-        ) => void,
-      ) => callback(0, 0, 80, 30, 5, 6),
+      measure: (callback: MeasureCallback) => callback(0, 0, 80, 30, 5, 6),
     };
     const root = append(fiber('Label'), host);
     const call = await createHarness(runtimeFor([root]), [inspectPointPlugin]);

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -75,6 +75,11 @@ async function createHarness(
       handler: config.handler as unknown as RegisteredTool['handler'],
     });
   };
+  // Also works when the screenshot plugin's execFile context API is present.
+  const commandStubs = {
+    exec: async () => '',
+    execFile: async () => Buffer.alloc(0),
+  };
   const ctx: PluginContext = {
     cdp: {
       on: () => {},
@@ -91,7 +96,7 @@ async function createHarness(
     config: {},
     logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
     metro: { host: 'localhost', port: 8081, fetch: async () => new Response() },
-    exec: async () => '',
+    ...commandStubs,
     format: {
       summarize: () => '',
       compact: (value: unknown) => JSON.stringify(value),
@@ -103,7 +108,11 @@ async function createHarness(
         'globalThis',
         `return ${expression};`,
       ) as (globalObject: Record<string, unknown>) => unknown;
-      return evaluate(runtime);
+      // Mirror returnByValue without assuming CDP awaits an app's JS Promise.
+      const result = evaluate(runtime);
+      return result === undefined
+        ? undefined
+        : JSON.parse(JSON.stringify(result));
     },
     getActiveDeviceKey: () => 'device',
     getActiveDeviceName: () => 'Device',

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from 'bun:test';
+import type { z } from 'zod';
+import type {
+  ComponentNode,
+  PluginContext,
+  PluginDefinition,
+} from '../plugin.js';
+import { componentsPlugin } from './components.js';
+import { inspectPointPlugin } from './inspect-point.js';
+import { uiInteractPlugin } from './ui-interact.js';
+
+interface Fiber {
+  type: string | { displayName: string } | null;
+  memoizedProps: Record<string, unknown>;
+  memoizedState?: unknown;
+  stateNode?: unknown;
+  child?: Fiber | null;
+  sibling?: Fiber | null;
+  return?: Fiber | null;
+}
+
+interface RegisteredTool {
+  parameters: z.ZodType;
+  handler: (
+    args: Record<string, unknown>,
+    context: Record<string, never>,
+  ) => Promise<unknown>;
+}
+
+function fiber(
+  name: string | null,
+  props: Record<string, unknown> = {},
+  host = false,
+): Fiber {
+  return {
+    type: name ? (host ? name : { displayName: name }) : null,
+    memoizedProps: props,
+  };
+}
+
+function append(parent: Fiber, ...children: Fiber[]): Fiber {
+  parent.child = children[0] ?? null;
+  children.forEach((child, index) => {
+    child.return = parent;
+    child.sibling = children[index + 1] ?? null;
+  });
+  return parent;
+}
+
+function runtimeFor(
+  roots: Fiber[],
+  renderer: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: {
+      getFiberRoots: (rendererId: number) =>
+        rendererId === 12
+          ? new Set(roots.map((current) => ({ current })))
+          : new Set(),
+      renderers: new Map([[12, renderer]]),
+    },
+  };
+}
+
+async function createHarness(
+  runtime: Record<string, unknown>,
+  plugins: PluginDefinition[],
+) {
+  const tools = new Map<string, RegisteredTool>();
+  const registerTool: PluginContext['registerTool'] = (name, config) => {
+    tools.set(name, {
+      parameters: config.parameters,
+      handler: config.handler as unknown as RegisteredTool['handler'],
+    });
+  };
+  const ctx: PluginContext = {
+    cdp: {
+      on: () => {},
+      off: () => {},
+      isConnected: true,
+      getTarget: () => null,
+      send: async () => ({}),
+    },
+    events: { on: () => {}, off: () => {}, isConnected: () => true },
+    registerTool,
+    registerResource: () => {},
+    registerAppResource: () => {},
+    registerPrompt: () => {},
+    config: {},
+    logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    metro: { host: 'localhost', port: 8081, fetch: async () => new Response() },
+    exec: async () => '',
+    format: {
+      summarize: () => '',
+      compact: (value: unknown) => JSON.stringify(value),
+      truncate: (value: string) => value,
+      structureOnly: (value: ComponentNode) => value,
+    },
+    evalInApp: async (expression) => {
+      const evaluate = new Function(
+        'globalThis',
+        `return ${expression};`,
+      ) as (globalObject: Record<string, unknown>) => unknown;
+      return evaluate(runtime);
+    },
+    getActiveDeviceKey: () => 'device',
+    getActiveDeviceName: () => 'Device',
+    notifyResourceUpdated: () => {},
+  };
+  for (const plugin of plugins) await plugin.setup(ctx);
+
+  return async (name: string, args: Record<string, unknown> = {}) => {
+    const tool = tools.get(name);
+    if (!tool) throw new Error(`${name} was not registered`);
+    return tool.handler(
+      tool.parameters.parse(args) as Record<string, unknown>,
+      {},
+    );
+  };
+}
+
+describe('fiber read tools', () => {
+  test('finds and inspects components beyond the old depth limit', async () => {
+    const root = fiber('Provider0');
+    let current = root;
+    for (let depth = 1; depth <= 230; depth++) {
+      const child = fiber(
+        depth === 230 ? 'CustomButton' : `Provider${depth}`,
+        depth === 230
+          ? { testID: 'continue', accessibilityLabel: 'Continue' }
+          : {},
+      );
+      append(current, child);
+      current = child;
+    }
+    const call = await createHarness(runtimeFor([root]), [componentsPlugin]);
+
+    const found = (await call('find_components', {
+      pattern: 'CustomButton',
+      maxDepth: 300,
+    })) as { matches: Array<{ name: string }>; traversal: { complete: boolean } };
+    expect(found.matches).toEqual([
+      expect.objectContaining({ name: 'CustomButton' }),
+    ]);
+    expect(found.traversal.complete).toBe(true);
+
+    const testable = (await call('get_testable_elements', {
+      maxDepth: 300,
+    })) as {
+      elements: Array<{ testID: string }>;
+      traversal: { complete: boolean };
+    };
+    expect(testable.elements).toEqual([
+      expect.objectContaining({ testID: 'continue' }),
+    ]);
+
+    const inspected = (await call('inspect_component', {
+      name: 'CustomButton',
+      maxDepth: 300,
+    })) as { result: { name: string }; traversal: { complete: boolean } };
+    expect(inspected.result.name).toBe('CustomButton');
+    expect(inspected.traversal.complete).toBe(true);
+  });
+
+  test('pages flat component nodes with stable parent IDs', async () => {
+    const root = fiber('Node0');
+    let current = root;
+    for (let index = 1; index < 260; index++) {
+      const child = fiber(`Node${index}`);
+      append(current, child);
+      current = child;
+    }
+    const call = await createHarness(runtimeFor([root]), [componentsPlugin]);
+    const first = (await call('get_component_tree', {
+      structureOnly: true,
+      pageSize: 100,
+      maxDepth: 300,
+    })) as {
+      snapshotId: string;
+      nodes: Array<{ id: string; parentId: string | null; depth: number }>;
+      nextCursor: string;
+      traversal: { complete: boolean };
+    };
+    const second = (await call('get_component_tree', {
+      cursor: first.nextCursor,
+      pageSize: 100,
+    })) as typeof first;
+
+    expect(first.nodes).toHaveLength(100);
+    expect(first.nodes[0]).toMatchObject({ parentId: null, depth: 0 });
+    expect(second.snapshotId).toBe(first.snapshotId);
+    expect(second.nodes[0]).toMatchObject({
+      parentId: first.nodes.at(-1)?.id,
+      depth: 100,
+    });
+    expect(first.traversal.complete).toBe(true);
+  });
+
+  test('list_elements returns an explicit envelope and deep elements', async () => {
+    const root = fiber('Root');
+    let current = root;
+    for (let depth = 1; depth <= 210; depth++) {
+      const child = fiber(
+        depth === 210 ? 'Pressable' : `Wrapper${depth}`,
+        depth === 210
+          ? { accessibilityLabel: 'Continue', onPress: () => {} }
+          : {},
+      );
+      append(current, child);
+      current = child;
+    }
+    const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
+    const result = (await call('list_elements', {
+      interactiveOnly: true,
+      maxDepth: 300,
+    })) as {
+      elements: Array<{ label: string }>;
+      traversal: { complete: boolean; depthReached: number };
+    };
+
+    expect(result.elements).toEqual([
+      expect.objectContaining({ label: 'Continue' }),
+    ]);
+    expect(result.traversal).toMatchObject({
+      complete: true,
+      depthReached: 210,
+    });
+  });
+});
+
+describe('inspect_at_point', () => {
+  test('awaits an async Fabric public instance measurement', async () => {
+    const host = fiber('View', {}, true);
+    host.stateNode = {};
+    const root = append(fiber('CustomButton', { testID: 'button' }), host);
+    const call = await createHarness(
+      runtimeFor([root], {
+        findHostInstanceByFiber: (candidate: Fiber) =>
+          candidate === host
+            ? {
+                getBoundingClientRect: async () => ({
+                  x: 10,
+                  y: 20,
+                  width: 100,
+                  height: 50,
+                }),
+              }
+            : null,
+      }),
+      [inspectPointPlugin],
+    );
+    const envelope = (await call('inspect_at_point', { x: 30, y: 40 })) as {
+      result: Record<string, unknown>;
+      traversal: { complete: boolean };
+    };
+
+    expect(envelope.result).toMatchObject({
+      found: true,
+      hostComponent: 'View',
+      reactComponent: 'CustomButton',
+      layout: { x: 10, y: 20, width: 100, height: 50 },
+    });
+    expect(envelope.traversal.complete).toBe(true);
+  });
+
+  test('awaits callback-based Paper measurement', async () => {
+    const host = fiber('Text', {}, true);
+    host.stateNode = {
+      measure: (
+        callback: (
+          x: number,
+          y: number,
+          width: number,
+          height: number,
+          pageX: number,
+          pageY: number,
+        ) => void,
+      ) => callback(0, 0, 80, 30, 5, 6),
+    };
+    const root = append(fiber('Label'), host);
+    const call = await createHarness(runtimeFor([root]), [inspectPointPlugin]);
+    const envelope = (await call('inspect_at_point', { x: 10, y: 10 })) as {
+      result: Record<string, unknown>;
+    };
+
+    expect(envelope.result).toMatchObject({
+      found: true,
+      hostComponent: 'Text',
+      reactComponent: 'Label',
+      layout: { x: 5, y: 6, width: 80, height: 30 },
+    });
+  });
+});

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -69,6 +69,16 @@ export const inspectPointPlugin = definePlugin({
                   typeof instance.measure === 'function'
                 )) return instance;
               }
+              // Fabric may not create a public instance until a ref is used.
+              var fabricManager = globalThis.nativeFabricUIManager;
+              if (stateNode && stateNode.node && fabricManager &&
+                  typeof fabricManager.measure === 'function') {
+                return {
+                  measure: function(callback) {
+                    fabricManager.measure(stateNode.node, callback);
+                  }
+                };
+              }
               return null;
             }
 

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -1,130 +1,182 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { FIBER_ROOT_JS } from '../utils/fiber.js';
+import {
+  DEFAULT_FIBER_MAX_DEPTH,
+  DEFAULT_FIBER_MAX_NODES,
+  MAX_FIBER_DEPTH,
+  MAX_FIBER_NODES,
+  buildFiberReadExpression,
+} from '../utils/fiber.js';
 
 export const inspectPointPlugin = definePlugin({
   name: 'inspect-point',
-
   description: 'Coordinate-based React component inspection (experimental)',
 
   async setup(ctx) {
     ctx.registerTool('inspect_at_point', {
       description:
-        'Inspect the React component rendered at specific screen coordinates. ' +
-        'Walks the React fiber tree to find the component whose layout contains the given point. ' +
-        'Experimental: layout measurement varies between Old and New Architecture.',
+        'Inspect the smallest measured host component at screen coordinates. Uses awaited Fabric/Paper measurement and returns traversal completeness metadata.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         x: z.number().describe('X coordinate (points/dp)'),
         y: z.number().describe('Y coordinate (points/dp)'),
-        includeProps: z.boolean().default(true).describe('Include component props in the result'),
+        includeProps: z
+          .boolean()
+          .default(true)
+          .describe('Include component props in the result'),
+        maxDepth: z
+          .number()
+          .int()
+          .min(0)
+          .max(MAX_FIBER_DEPTH)
+          .default(DEFAULT_FIBER_MAX_DEPTH),
+        maxNodes: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_FIBER_NODES)
+          .default(DEFAULT_FIBER_MAX_NODES),
       }),
-      handler: async ({ x, y, includeProps }) => {
-        const expression = `(function() {
-          ${FIBER_ROOT_JS}
-          if (!rootFiber) return { error: 'React fiber tree not available. Is the app running in __DEV__ mode?' };
+      handler: async ({ x, y, includeProps, maxDepth, maxNodes }) => {
+        const expression = buildFiberReadExpression(
+          `
+            var targetX = ${JSON.stringify(x)};
+            var targetY = ${JSON.stringify(y)};
+            var candidates = [];
+            var measurements = [];
 
-          var targetX = ${x};
-          var targetY = ${y};
-          var bestMatch = null;
-          var bestArea = Infinity;
-
-          // Walk the fiber tree
-          function walkFiber(fiber, depth) {
-            if (!fiber || depth > 60) return;
-
-            // Check if this is a host component with a native node
-            if (fiber.stateNode && typeof fiber.type === 'string') {
-              try {
-                var node = fiber.stateNode;
-                // New Architecture (Fabric): node has a direct layout
-                var layout = null;
-                if (node._nativeTag != null) {
-                  // Try to read cached layout from the fiber's memoizedProps
-                  var props = fiber.memoizedProps || {};
-                  // On Fabric, we can try the node's layout info
-                  if (typeof nativeFabricUIManager !== 'undefined' && nativeFabricUIManager.measure) {
-                    // Async measurement not available synchronously, skip
-                  }
-                }
-                // Try reading layout from the stateNode directly (some RN versions cache this)
-                if (node.__internalInstanceHandle && node.__internalInstanceHandle.stateNode) {
-                  var sn = node.__internalInstanceHandle.stateNode;
-                  if (sn.canonical && sn.canonical.currentProps) {
-                    var style = sn.canonical.currentProps.style;
-                    if (style && style.left != null && style.top != null && style.width != null && style.height != null) {
-                      layout = { x: style.left, y: style.top, width: style.width, height: style.height };
-                    }
-                  }
-                }
-
-                if (layout) {
-                  if (targetX >= layout.x && targetX <= layout.x + layout.width &&
-                      targetY >= layout.y && targetY <= layout.y + layout.height) {
-                    var area = layout.width * layout.height;
-                    if (area < bestArea) {
-                      bestArea = area;
-                      bestMatch = { fiber: fiber, layout: layout };
-                    }
-                  }
-                }
-              } catch(e) { /* skip this fiber */ }
+            function hostInstance(fiber, renderer) {
+              var stateNode = fiber && fiber.stateNode;
+              var instances = [];
+              if (renderer && typeof renderer.findHostInstanceByFiber === 'function') {
+                try { instances.push(renderer.findHostInstanceByFiber(fiber)); }
+                catch (_) {}
+              }
+              instances.push(
+                stateNode && stateNode.canonical && stateNode.canonical.publicInstance,
+                stateNode && stateNode.publicInstance,
+                stateNode && stateNode.__internalInstanceHandle &&
+                  stateNode.__internalInstanceHandle.stateNode &&
+                  stateNode.__internalInstanceHandle.stateNode.canonical &&
+                  stateNode.__internalInstanceHandle.stateNode.canonical.publicInstance,
+                stateNode
+              );
+              for (var index = 0; index < instances.length; index++) {
+                var instance = instances[index];
+                if (instance && (
+                  typeof instance.getBoundingClientRect === 'function' ||
+                  typeof instance.measure === 'function'
+                )) return instance;
+              }
+              return null;
             }
 
-            // Recurse into children
-            if (fiber.child) walkFiber(fiber.child, depth + 1);
-            if (fiber.sibling) walkFiber(fiber.sibling, depth);
-          }
+            function measureFiber(fiber, renderer, depth) {
+              var instance = hostInstance(fiber, renderer);
+              if (!instance) return Promise.resolve(null);
+              return new Promise(function(resolve) {
+                var settled = false;
+                var finish = function(rect) {
+                  if (settled) return;
+                  settled = true;
+                  if (!rect) return resolve(null);
+                  var width = Number(rect.width);
+                  var height = Number(rect.height);
+                  var rectX = Number(rect.x != null ? rect.x : rect.left);
+                  var rectY = Number(rect.y != null ? rect.y : rect.top);
+                  if (![rectX, rectY, width, height].every(Number.isFinite)) {
+                    return resolve(null);
+                  }
+                  resolve({
+                    fiber: fiber,
+                    depth: depth,
+                    layout: { x: rectX, y: rectY, width: width, height: height }
+                  });
+                };
+                var timer = setTimeout(function() { finish(null); }, 150);
+                var done = function(rect) { clearTimeout(timer); finish(rect); };
+                try {
+                  if (typeof instance.getBoundingClientRect === 'function') {
+                    var rect = instance.getBoundingClientRect();
+                    if (rect && typeof rect.then === 'function') {
+                      rect.then(done, function() { done(null); });
+                    } else done(rect);
+                  } else {
+                    instance.measure(function(localX, localY, width, height, pageX, pageY) {
+                      done({
+                        x: pageX == null ? localX : pageX,
+                        y: pageY == null ? localY : pageY,
+                        width: width,
+                        height: height
+                      });
+                    });
+                  }
+                } catch (_) { done(null); }
+              });
+            }
 
-          walkFiber(rootFiber, 0);
+            var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
+              if (typeof fiber.type !== 'string' || !fiber.stateNode) return;
+              measurements.push(measureFiber(fiber, context.renderer, context.depth));
+            });
+            candidates = (await Promise.all(measurements)).filter(Boolean);
 
-          if (!bestMatch) {
-            return {
-              found: false,
-              message: 'No component found at (' + targetX + ', ' + targetY + '). Layout data may not be available synchronously in this architecture.'
+            var best = null;
+            var bestArea = Infinity;
+            candidates.forEach(function(candidate) {
+              var layout = candidate.layout;
+              if (
+                layout.width <= 0 || layout.height <= 0 ||
+                targetX < layout.x || targetX > layout.x + layout.width ||
+                targetY < layout.y || targetY > layout.y + layout.height
+              ) return;
+              var area = layout.width * layout.height;
+              if (area < bestArea) { best = candidate; bestArea = area; }
+            });
+
+            if (!best) {
+              return {
+                result: {
+                  found: false,
+                  message: 'No measured component contains (' + targetX + ', ' + targetY + ').'
+                },
+                traversal: traversal
+              };
+            }
+
+            var owner = best.fiber;
+            var componentName = null;
+            var componentProps = null;
+            while (owner) {
+              if (typeof owner.type !== 'string') {
+                componentName = metroFiberName(owner);
+                if (componentName) {
+                  componentProps = owner.memoizedProps;
+                  break;
+                }
+              }
+              owner = owner.return;
+            }
+            var result = {
+              found: true,
+              hostComponent: best.fiber.type,
+              reactComponent: componentName || '(anonymous)',
+              layout: best.layout,
+              depth: best.depth
             };
-          }
-
-          // Walk up from the host fiber to find the nearest named React component
-          var f = bestMatch.fiber;
-          var componentName = null;
-          var componentProps = null;
-          while (f) {
-            if (typeof f.type === 'function' || (typeof f.type === 'object' && f.type !== null)) {
-              componentName = (f.type.displayName || f.type.name || null);
-              if (componentName) {
-                componentProps = ${includeProps} ? f.memoizedProps : undefined;
-                break;
-              }
+            if (${includeProps} && componentProps) {
+              result.props = metroSafeProps({ memoizedProps: componentProps }, 20);
             }
-            f = f.return;
-          }
+            return { result: result, traversal: traversal };
+          `,
+          { maxDepth, maxNodes },
+          true,
+        );
 
-          var result = {
-            found: true,
-            hostComponent: typeof bestMatch.fiber.type === 'string' ? bestMatch.fiber.type : 'unknown',
-            reactComponent: componentName || '(anonymous)',
-            layout: bestMatch.layout,
-          };
-          if (${includeProps} && componentProps) {
-            try {
-              // Serialize props safely (avoid circular refs)
-              var safeProps = {};
-              var keys = Object.keys(componentProps);
-              for (var i = 0; i < Math.min(keys.length, 20); i++) {
-                var k = keys[i];
-                var v = componentProps[k];
-                if (typeof v === 'function') safeProps[k] = '[Function]';
-                else if (typeof v === 'object' && v !== null) safeProps[k] = '[Object]';
-                else safeProps[k] = v;
-              }
-              result.props = safeProps;
-            } catch(e) {}
-          }
-          return result;
-        })()`;
-
-        return await ctx.evalInApp(expression);
+        return ctx.evalInApp(expression, {
+          awaitPromise: true,
+          timeout: 10_000,
+        });
       },
     });
   },

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
+import { awaitAppResult } from '../utils/await-app-result.js';
 import {
   DEFAULT_FIBER_MAX_DEPTH,
   DEFAULT_FIBER_MAX_NODES,
@@ -173,10 +174,7 @@ export const inspectPointPlugin = definePlugin({
           true,
         );
 
-        return ctx.evalInApp(expression, {
-          awaitPromise: true,
-          timeout: 10_000,
-        });
+        return awaitAppResult(ctx.evalInApp, expression);
       },
     });
   },

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -85,16 +85,12 @@ export const uiInteractPlugin = definePlugin({
               'LongPressGestureHandler','TapGestureHandler',
               'Chip','FAB','IconButton','ListItem','MenuItem',
             ]);
-            var seen = new Set();
             var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
               var element = metroElementFromFiber(fiber);
               if (!element) return;
               element.interactive = element.interactive || INTERACTIVE.has(element.name);
               if (${interactiveOnly} && !element.interactive) return;
               if (!element.label && !element.testID && !element.interactive) return;
-              var key = element.testID || element.label;
-              if (key && seen.has(key)) return;
-              if (key) seen.add(key);
               element.depth = context.depth;
               elements.push(element);
             });

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -1,7 +1,17 @@
 import { readFile } from 'fs/promises';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { FIBER_ROOT_JS, FIND_AND_INVOKE_JS, GET_ROUTE_FUNC_JS, SWIPE_COORDS } from '../utils/fiber.js';
+import {
+  DEFAULT_FIBER_MAX_DEPTH,
+  DEFAULT_FIBER_MAX_NODES,
+  FIBER_ROOT_JS,
+  FIND_AND_INVOKE_JS,
+  GET_ROUTE_FUNC_JS,
+  MAX_FIBER_DEPTH,
+  MAX_FIBER_NODES,
+  SWIPE_COORDS,
+  buildFiberReadExpression,
+} from '../utils/fiber.js';
 
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let idbAvailableCache: boolean | null = null;
@@ -47,16 +57,27 @@ export const uiInteractPlugin = definePlugin({
 
     ctx.registerTool('list_elements', {
       description:
-        'Get interactive elements from the current screen via the React component tree. Returns labels, testIDs, and roles — use label or testID with tap_element.',
+        'Get labelled or interactive elements from the focused React screen. Check traversal.complete before treating an empty elements array as definitive.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         interactiveOnly: z.boolean().default(false).describe('Return only elements with onPress handlers'),
+        maxDepth: z
+          .number()
+          .int()
+          .min(0)
+          .max(MAX_FIBER_DEPTH)
+          .default(DEFAULT_FIBER_MAX_DEPTH),
+        maxNodes: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_FIBER_NODES)
+          .default(DEFAULT_FIBER_MAX_NODES),
       }),
-      handler: async ({ interactiveOnly }) => {
-        const elements = await ctx.evalInApp(`
-          (function() {
-            ${FIBER_ROOT_JS}
-            var results = [];
+      handler: async ({ interactiveOnly, maxDepth, maxNodes }) => {
+        const expression = buildFiberReadExpression(
+          `
+            var elements = [];
             var INTERACTIVE = new Set([
               'TouchableOpacity','TouchableHighlight','TouchableWithoutFeedback',
               'TouchableNativeFeedback','Pressable','Button',
@@ -64,59 +85,24 @@ export const uiInteractPlugin = definePlugin({
               'LongPressGestureHandler','TapGestureHandler',
               'Chip','FAB','IconButton','ListItem','MenuItem',
             ]);
-            function getName(fiber) {
-              if (!fiber || !fiber.type) return null;
-              if (typeof fiber.type === 'string') return fiber.type;
-              return fiber.type.displayName || fiber.type.name || null;
-            }
-            var seenTestIDs = {};
-            var stack = [{ fiber: rootFiber, depth: 0 }];
-            while (stack.length > 0) {
-              var item = stack.pop();
-              var fiber = item.fiber; var depth = item.depth;
-              if (!fiber || depth > 200) continue;
-              var name = getName(fiber);
-              if (name && name.indexOf('RCT') === 0) {
-                if (fiber.sibling) stack.push({ fiber: fiber.sibling, depth: depth });
-                if (fiber.child) stack.push({ fiber: fiber.child, depth: depth + 1 });
-                continue;
-              }
-              if (name) {
-                var props = fiber.memoizedProps || {};
-                var label = props.accessibilityLabel || props['aria-label'] || null;
-                var testID = props.testID || null;
-                var role  = props.accessibilityRole || props['role'] || null;
-                var interactive = !!(props.onPress || props.onPressIn || props.onLongPress ||
-                                     props.onTap || props.onClick || props.accessible ||
-                                     props.hitSlop || ('disabled' in props)) ||
-                                  INTERACTIVE.has(name);
-                if (label || testID || interactive) {
-                  if (!testID || !seenTestIDs[testID]) {
-                    if (testID) seenTestIDs[testID] = true;
-                    results.push({ type: name, label, testID, role, interactive,
-                                   hint: props.accessibilityHint || null });
-                  }
-                }
-              }
-              if (fiber.sibling) stack.push({ fiber: fiber.sibling, depth: depth });
-              if (fiber.child) stack.push({ fiber: fiber.child, depth: depth + 1 });
-            }
-            return results;
-          })()
-        `).catch(() => null);
-
-        if (!elements || !Array.isArray(elements)) {
-          return 'Component tree not available. Ensure the app is running and Metro is connected.';
-        }
-        const filtered = interactiveOnly
-          ? (elements as Array<Record<string, unknown>>).filter((e) => e.interactive)
-          : elements;
-        if ((filtered as unknown[]).length === 0) {
-          return interactiveOnly
-            ? 'No interactive elements found on the current screen.'
-            : 'No labelled or interactive elements found on the current screen.';
-        }
-        return filtered;
+            var seen = new Set();
+            var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
+              var element = metroElementFromFiber(fiber);
+              if (!element) return;
+              element.interactive = element.interactive || INTERACTIVE.has(element.name);
+              if (${interactiveOnly} && !element.interactive) return;
+              if (!element.label && !element.testID && !element.interactive) return;
+              var key = element.testID || element.label;
+              if (key && seen.has(key)) return;
+              if (key) seen.add(key);
+              element.depth = context.depth;
+              elements.push(element);
+            });
+            return { elements: elements, traversal: traversal };
+          `,
+          { maxDepth, maxNodes },
+        );
+        return ctx.evalInApp(expression, { timeout: 10_000 });
       },
     });
 

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import type { PluginContext } from '../plugin.js';
+import { awaitAppResult } from './await-app-result.js';
+
+function hermesHarness() {
+  const runtime = {};
+  const evaluate: PluginContext['evalInApp'] = async (expression) => {
+    const result = new Function('globalThis', `return ${expression};`)(runtime);
+    // Simulate CDP returnByValue ignoring awaitPromise, not JS-level awaiting.
+    return result === undefined ? undefined : JSON.parse(JSON.stringify(result));
+  };
+  return { runtime, evaluate };
+}
+
+describe('async app read results', () => {
+  test('awaits a promise when CDP serializes the promise object', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    expect(await evaluate('Promise.resolve(42)', { awaitPromise: true })).toEqual(
+      {},
+    );
+    expect(await awaitAppResult(
+      evaluate,
+      'new Promise(resolve => setTimeout(() => resolve({ found: true }), 10))',
+    )).toEqual({ found: true });
+    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+  });
+
+  test('propagates rejected and synchronously thrown errors and cleans up', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    await expect(awaitAppResult(
+      evaluate,
+      'Promise.reject(new Error("measurement failed"))',
+    )).rejects.toThrow('measurement failed');
+    await expect(awaitAppResult(
+      evaluate,
+      '(() => { throw new Error("sync failure"); })()',
+    )).rejects.toThrow('sync failure');
+    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+  });
+
+  test('bounds pending reads and deletes their mailbox', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    await expect(awaitAppResult(
+      evaluate,
+      'new Promise(() => {})',
+      30,
+    )).rejects.toThrow('timed out');
+    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+  });
+
+  test('isolates concurrent reads and preserves undefined and null', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    expect(await Promise.all([
+      awaitAppResult(evaluate, 'Promise.resolve(undefined)'),
+      awaitAppResult(evaluate, 'Promise.resolve(null)'),
+      awaitAppResult(evaluate, 'Promise.resolve(42)'),
+    ])).toEqual([undefined, null, 42]);
+    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+  });
+});

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import type { PluginContext } from '../plugin.js';
+
+/**
+ * Await a read expression without relying on CDP's awaitPromise support.
+ * Hermes can return a serialized JS Promise instead of its resolved value.
+ * A private, expiring mailbox lets us read the settled value synchronously.
+ */
+export async function awaitAppResult(
+  evaluate: PluginContext['evalInApp'],
+  expression: string,
+  timeout = 10_000,
+): Promise<unknown> {
+  const key = JSON.stringify(`__METRO_MCP_ASYNC_${randomUUID()}`);
+  const deadline = Date.now() + timeout;
+  try {
+    await evaluate(`(function() {
+      var state = { status: 'pending' };
+      Object.defineProperty(globalThis, ${key}, {
+        value: state, configurable: true
+      });
+      state.timer = setTimeout(function() {
+        if (globalThis[${key}] === state) delete globalThis[${key}];
+      }, ${timeout + 1000});
+      function reject(error) {
+        state.status = 'rejected';
+        state.error = String(error && error.message || error);
+      }
+      try {
+        Promise.resolve(${expression}).then(function(value) {
+          state.value = value;
+          state.status = 'fulfilled';
+        }, reject);
+      } catch (error) { reject(error); }
+      return true;
+    })()`, { timeout });
+
+    while (Date.now() < deadline) {
+      const result = await evaluate(`(function() {
+        var state = globalThis[${key}];
+        if (!state) return { status: 'missing' };
+        return {
+          status: state.status, value: state.value, error: state.error
+        };
+      })()`, { timeout: Math.max(1, deadline - Date.now()) }) as {
+        status: string;
+        value?: unknown;
+        error?: string;
+      };
+      if (result?.status === 'fulfilled') return result.value;
+      if (result?.status === 'rejected') throw new Error(result.error);
+      if (!result || result.status !== 'pending') {
+        throw new Error('App evaluation context was lost before measurement completed');
+      }
+      await delay(Math.min(25, Math.max(0, deadline - Date.now())));
+    }
+    throw new Error(`App evaluation timed out after ${timeout}ms`);
+  } finally {
+    // Also expires inside the app if the MCP process or CDP connection is lost.
+    await evaluate(`(function() {
+      var state = globalThis[${key}];
+      if (state) clearTimeout(state.timer);
+      delete globalThis[${key}];
+    })()`, { timeout: 1000 }).catch(() => {});
+  }
+}

--- a/src/utils/fiber-snapshots.test.ts
+++ b/src/utils/fiber-snapshots.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { FiberSnapshotStore, type FlatFiberNode } from './fiber-snapshots.js';
+import type { FiberTraversalMetadata } from './fiber.js';
+
+const traversal: FiberTraversalMetadata = {
+  scope: 'all-scenes',
+  complete: true,
+  depthReached: 3,
+  scannedNodes: 3,
+};
+
+function nodes(count: number): FlatFiberNode[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `node-${index}`,
+    parentId: index ? `node-${index - 1}` : null,
+    depth: index,
+    name: `Node${index}`,
+  }));
+}
+
+describe('fiber snapshot pagination', () => {
+  test('pages a stable snapshot with opaque cursors', () => {
+    const store = new FiberSnapshotStore();
+    const first = store.create(nodes(260), traversal, 100);
+    const second = store.read(first.nextCursor!, 100);
+    const third = store.read(second.nextCursor!, 100);
+
+    expect(first.nodes).toHaveLength(100);
+    expect(second.nodes[0]?.id).toBe('node-100');
+    expect(third.nodes).toHaveLength(60);
+    expect(third.nextCursor).toBeUndefined();
+    expect(new Set([first.snapshotId, second.snapshotId, third.snapshotId]).size).toBe(1);
+  });
+
+  test('expires cursors after 60 seconds', () => {
+    let now = 1_000;
+    const store = new FiberSnapshotStore(() => now);
+    const first = store.create(nodes(2), traversal, 1);
+    now += 60_001;
+
+    expect(store.read(first.nextCursor!, 1)).toMatchObject({
+      nodes: [],
+      error: 'Component-tree cursor is invalid or has expired.',
+      traversal: { complete: false, truncationReason: 'cursor-expired' },
+    });
+  });
+
+  test('retains at most eight snapshots', () => {
+    const store = new FiberSnapshotStore(() => 1_000);
+    const first = store.create(nodes(2), traversal, 1);
+    for (let index = 0; index < 8; index++) {
+      store.create(nodes(1), traversal, 1);
+    }
+
+    expect(store.read(first.nextCursor!, 1).error).toBeDefined();
+  });
+});

--- a/src/utils/fiber-snapshots.ts
+++ b/src/utils/fiber-snapshots.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from 'node:crypto';
+import type { FiberTraversalMetadata } from './fiber.js';
+
+export interface FlatFiberNode {
+  id: string;
+  parentId: string | null;
+  depth: number;
+  name: string;
+  props?: Record<string, unknown>;
+  testID?: string;
+  accessibilityLabel?: string;
+  accessibilityRole?: string;
+}
+
+interface FiberSnapshot {
+  id: string;
+  nodes: FlatFiberNode[];
+  traversal: FiberTraversalMetadata;
+  createdAt: number;
+}
+
+export interface FiberSnapshotPage {
+  snapshotId: string | null;
+  nodes: FlatFiberNode[];
+  traversal: FiberTraversalMetadata;
+  nextCursor?: string;
+  error?: string;
+}
+
+const expiredTraversal: FiberTraversalMetadata = {
+  scope: 'all-scenes',
+  complete: false,
+  depthReached: 0,
+  scannedNodes: 0,
+  truncationReason: 'cursor-expired',
+};
+
+export class FiberSnapshotStore {
+  readonly #snapshots = new Map<string, FiberSnapshot>();
+  readonly #cursors = new Map<
+    string,
+    { snapshotId: string; offset: number }
+  >();
+
+  constructor(
+    private readonly now: () => number = Date.now,
+    private readonly ttlMs = 60_000,
+    private readonly maxSnapshots = 8,
+  ) {}
+
+  create(
+    nodes: FlatFiberNode[],
+    traversal: FiberTraversalMetadata,
+    pageSize: number,
+  ): FiberSnapshotPage {
+    this.#cleanup();
+    while (this.#snapshots.size >= this.maxSnapshots) {
+      const oldest = this.#snapshots.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.#deleteSnapshot(oldest);
+    }
+
+    const snapshot: FiberSnapshot = {
+      id: randomUUID(),
+      nodes,
+      traversal,
+      createdAt: this.now(),
+    };
+    this.#snapshots.set(snapshot.id, snapshot);
+    return this.#page(snapshot, 0, pageSize);
+  }
+
+  read(cursor: string, pageSize: number): FiberSnapshotPage {
+    this.#cleanup();
+    const decoded = this.#cursors.get(cursor);
+    if (!decoded) return this.#expiredPage();
+    const snapshot = this.#snapshots.get(decoded.snapshotId);
+    if (!snapshot) return this.#expiredPage(decoded.snapshotId);
+    if (decoded.offset < 0 || decoded.offset >= snapshot.nodes.length) {
+      return this.#expiredPage(decoded.snapshotId);
+    }
+    return this.#page(snapshot, decoded.offset, pageSize);
+  }
+
+  #page(
+    snapshot: FiberSnapshot,
+    offset: number,
+    pageSize: number,
+  ): FiberSnapshotPage {
+    const size = Math.min(250, Math.max(1, Math.floor(pageSize)));
+    const nextOffset = offset + size;
+    return {
+      snapshotId: snapshot.id,
+      nodes: snapshot.nodes.slice(offset, nextOffset),
+      traversal: snapshot.traversal,
+      ...(nextOffset < snapshot.nodes.length
+        ? { nextCursor: this.#createCursor(snapshot.id, nextOffset) }
+        : {}),
+    };
+  }
+
+  #cleanup(): void {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [id, snapshot] of this.#snapshots) {
+      if (snapshot.createdAt <= cutoff) this.#deleteSnapshot(id);
+    }
+  }
+
+  #createCursor(snapshotId: string, offset: number): string {
+    const cursor = randomUUID();
+    this.#cursors.set(cursor, { snapshotId, offset });
+    return cursor;
+  }
+
+  #deleteSnapshot(snapshotId: string): void {
+    this.#snapshots.delete(snapshotId);
+    for (const [cursor, value] of this.#cursors) {
+      if (value.snapshotId === snapshotId) this.#cursors.delete(cursor);
+    }
+  }
+
+  #expiredPage(snapshotId: string | null = null): FiberSnapshotPage {
+    return {
+      snapshotId,
+      nodes: [],
+      traversal: expiredTraversal,
+      error: 'Component-tree cursor is invalid or has expired.',
+    };
+  }
+}

--- a/src/utils/fiber.test.ts
+++ b/src/utils/fiber.test.ts
@@ -145,6 +145,32 @@ describe('shared fiber walker', () => {
     });
   });
 
+  test('does not perform an unreported focus-discovery prepass', async () => {
+    const root = fiber('Root');
+    const child = fiber('Child');
+    let childReads = 0;
+    Object.defineProperty(root, 'child', {
+      configurable: true,
+      get: () => {
+        childReads++;
+        return child;
+      },
+    });
+
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(collectExpression({ maxNodes: 1 }), sandbox([root]));
+
+    expect(result.names).toEqual(['Root']);
+    expect(result.traversal).toMatchObject({
+      complete: false,
+      scannedNodes: 1,
+      truncationReason: 'max-nodes',
+    });
+    expect(childReads).toBe(1);
+  });
+
   test('distinguishes a genuinely complete empty traversal', async () => {
     const result = await evaluate<{
       names: string[];

--- a/src/utils/fiber.test.ts
+++ b/src/utils/fiber.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from 'bun:test';
+import { buildFiberReadExpression } from './fiber.js';
+
+interface Fiber {
+  type: string | { displayName: string } | null;
+  memoizedProps?: Record<string, unknown>;
+  memoizedState?: unknown;
+  stateNode?: unknown;
+  child?: Fiber | null;
+  sibling?: Fiber | null;
+  return?: Fiber | null;
+}
+
+function fiber(
+  name: string | null,
+  props: Record<string, unknown> = {},
+): Fiber {
+  return {
+    type: name ? { displayName: name } : null,
+    memoizedProps: props,
+  };
+}
+
+function append(parent: Fiber, ...children: Fiber[]): Fiber {
+  parent.child = children[0] ?? null;
+  children.forEach((child, index) => {
+    child.return = parent;
+    child.sibling = children[index + 1] ?? null;
+  });
+  return parent;
+}
+
+function sandbox(
+  roots: Fiber[],
+  extras: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: {
+      getFiberRoots: (rendererId: number) =>
+        rendererId === 7
+          ? new Set(roots.map((current) => ({ current })))
+          : new Set(),
+      renderers: new Map([[7, {}]]),
+    },
+    ...extras,
+  };
+}
+
+async function evaluate<T>(
+  expression: string,
+  runtime: Record<string, unknown>,
+): Promise<T> {
+  const evaluateExpression = new Function(
+    'globalThis',
+    `return ${expression};`,
+  ) as (globalObject: Record<string, unknown>) => T | Promise<T>;
+  return evaluateExpression(runtime);
+}
+
+function collectExpression(
+  options: { maxDepth?: number; maxNodes?: number } = {},
+): string {
+  return buildFiberReadExpression(
+    `
+      var names = [];
+      var traversal = metroWalkFibers(FIBER_OPTIONS, function(item) {
+        var name = metroFiberName(item);
+        if (name) names.push(name);
+      });
+      return { names: names, traversal: traversal };
+    `,
+    options,
+  );
+}
+
+describe('shared fiber walker', () => {
+  test('searches renderer IDs 1-20 and handles every root', async () => {
+    const result = await evaluate<{
+      names: string[];
+      traversal: { complete: boolean; scannedNodes: number };
+    }>(collectExpression(), sandbox([fiber('FirstRoot'), fiber('SecondRoot')]));
+
+    expect(result.names).toEqual(['FirstRoot', 'SecondRoot']);
+    expect(result.traversal).toMatchObject({ complete: true, scannedNodes: 2 });
+  });
+
+  test('supports a 230-level provider tree when the caller raises maxDepth', async () => {
+    const root = fiber('Provider0');
+    let current = root;
+    for (let depth = 1; depth <= 230; depth++) {
+      const child = fiber(depth === 230 ? 'DeepButton' : `Provider${depth}`);
+      append(current, child);
+      current = child;
+    }
+
+    const result = await evaluate<{
+      names: string[];
+      traversal: { complete: boolean; depthReached: number };
+    }>(
+      collectExpression({ maxDepth: 300, maxNodes: 1000 }),
+      sandbox([root]),
+    );
+
+    expect(result.names.at(-1)).toBe('DeepButton');
+    expect(result.traversal).toMatchObject({
+      complete: true,
+      depthReached: 230,
+    });
+  });
+
+  test('reports max-depth truncation instead of a complete empty result', async () => {
+    const root = fiber(null);
+    let current = root;
+    for (let depth = 1; depth <= 205; depth++) {
+      const child = fiber(depth === 205 ? 'BeyondDefaultDepth' : null);
+      append(current, child);
+      current = child;
+    }
+
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(collectExpression(), sandbox([root]));
+
+    expect(result.names).toEqual([]);
+    expect(result.traversal).toMatchObject({
+      complete: false,
+      depthReached: 200,
+      scannedNodes: 201,
+      truncationReason: 'max-depth',
+    });
+  });
+
+  test('reports max-node truncation', async () => {
+    const root = fiber('Root');
+    append(root, ...Array.from({ length: 10 }, (_, index) => fiber(`Item${index}`)));
+    const result = await evaluate<{
+      traversal: Record<string, unknown>;
+    }>(collectExpression({ maxNodes: 5 }), sandbox([root]));
+
+    expect(result.traversal).toMatchObject({
+      complete: false,
+      scannedNodes: 5,
+      truncationReason: 'max-nodes',
+    });
+  });
+
+  test('distinguishes a genuinely complete empty traversal', async () => {
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(collectExpression(), sandbox([fiber(null)]));
+
+    expect(result.names).toEqual([]);
+    expect(result.traversal).toMatchObject({
+      complete: true,
+      scannedNodes: 1,
+    });
+  });
+
+  test('prunes inactive scenes while retaining global overlays', async () => {
+    const active = append(
+      fiber('SceneView', { route: { key: 'active', name: 'Active' } }),
+      fiber('ActiveScreen'),
+    );
+    const inactive = append(
+      fiber('SceneView', { route: { key: 'inactive', name: 'Inactive' } }),
+      fiber('InactiveScreen'),
+    );
+    const root = append(fiber('Root'), active, inactive, fiber('ToastOverlay'));
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(
+      collectExpression(),
+      sandbox([root], {
+        __EXPO_ROUTER_STATE__: {
+          index: 0,
+          routes: [
+            { key: 'active', name: 'Active' },
+            { key: 'inactive', name: 'Inactive' },
+          ],
+        },
+      }),
+    );
+
+    expect(result.names).toContain('ActiveScreen');
+    expect(result.names).toContain('ToastOverlay');
+    expect(result.names).not.toContain('InactiveScreen');
+    expect(result.traversal).toMatchObject({ scope: 'focused-scene' });
+  });
+
+  test('uses all scenes when navigation focus is unavailable', async () => {
+    const root = append(
+      fiber('Root'),
+      append(fiber('SceneView', { route: { name: 'One' } }), fiber('One')),
+      append(fiber('SceneView', { route: { name: 'Two' } }), fiber('Two')),
+    );
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(collectExpression(), sandbox([root]));
+
+    expect(result.names).toEqual(['Root', 'SceneView', 'One', 'SceneView', 'Two']);
+    expect(result.traversal).toMatchObject({ scope: 'all-scenes' });
+  });
+
+  test('resolves focus from navigation fibers when globals are unavailable', async () => {
+    const navigation = fiber('BaseNavigationContainer');
+    navigation.memoizedState = {
+      memoizedState: {
+        index: 1,
+        routes: [
+          { key: 'first', name: 'First' },
+          { key: 'second', name: 'Second' },
+        ],
+      },
+      next: null,
+    };
+    append(
+      navigation,
+      append(fiber('SceneView', { route: { key: 'first' } }), fiber('First')),
+      append(fiber('SceneView', { route: { key: 'second' } }), fiber('Second')),
+    );
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(collectExpression(), sandbox([navigation]));
+
+    expect(result.names).toContain('Second');
+    expect(result.names).not.toContain('First');
+    expect(result.traversal).toMatchObject({ scope: 'focused-scene' });
+  });
+
+  test('reports unavailable fiber roots as incomplete', async () => {
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(collectExpression(), sandbox([]));
+
+    expect(result.names).toEqual([]);
+    expect(result.traversal).toMatchObject({
+      complete: false,
+      scannedNodes: 0,
+      truncationReason: 'fiber-roots-unavailable',
+    });
+  });
+});

--- a/src/utils/fiber.test.ts
+++ b/src/utils/fiber.test.ts
@@ -145,6 +145,36 @@ describe('shared fiber walker', () => {
     });
   });
 
+  test('enumerates wide sibling lists only as their nodes are scanned', async () => {
+    let siblingReads = 0;
+    function child(index: number): Fiber {
+      const item = fiber(`Child${index}`);
+      Object.defineProperty(item, 'sibling', {
+        get: () => {
+          siblingReads++;
+          if (siblingReads > 4) throw new Error('Exceeded sibling-read budget');
+          return child(index + 1);
+        },
+      });
+      return item;
+    }
+    const root = fiber('Root');
+    root.child = child(0);
+
+    const result = await evaluate<{
+      names: string[];
+      traversal: Record<string, unknown>;
+    }>(collectExpression({ maxNodes: 5 }), sandbox([root]));
+
+    expect(result.names).toEqual(['Root', 'Child0', 'Child1', 'Child2', 'Child3']);
+    expect(siblingReads).toBe(4);
+    expect(result.traversal).toMatchObject({
+      complete: false,
+      scannedNodes: 5,
+      truncationReason: 'max-nodes',
+    });
+  });
+
   test('does not perform an unreported focus-discovery prepass', async () => {
     const root = fiber('Root');
     const child = fiber('Child');

--- a/src/utils/fiber.ts
+++ b/src/utils/fiber.ts
@@ -1,21 +1,352 @@
 /**
  * Shared fiber tree utilities used across plugins.
  *
- * JS string constants are embedded into evalInApp() calls, so they must be
- * valid JavaScript and cannot reference TypeScript imports.
+ * JavaScript snippets in this file are embedded into evalInApp() calls. They
+ * must remain self-contained JavaScript and cannot reference TypeScript imports.
  */
 
+export const DEFAULT_FIBER_MAX_DEPTH = 200;
+export const MAX_FIBER_DEPTH = 600;
+export const DEFAULT_FIBER_MAX_NODES = 1200;
+export const MAX_FIBER_NODES = 5000;
+
+export interface FiberTraversalOptions {
+  maxDepth?: number;
+  maxNodes?: number;
+}
+
+export interface FiberTraversalMetadata {
+  scope: 'focused-scene' | 'all-scenes';
+  complete: boolean;
+  depthReached: number;
+  scannedNodes: number;
+  truncationReason?:
+    | 'max-depth'
+    | 'max-nodes'
+    | 'fiber-roots-unavailable'
+    | 'cursor-expired';
+}
+
+export interface TestableElement {
+  name: string;
+  testID?: string;
+  accessibilityLabel?: string;
+  accessibilityRole?: string;
+  text?: string;
+  interactive?: boolean;
+}
+
+export function normalizeFiberTraversalOptions(
+  options: FiberTraversalOptions = {},
+): Required<FiberTraversalOptions> {
+  return {
+    maxDepth: Math.min(
+      MAX_FIBER_DEPTH,
+      Math.max(0, Math.floor(options.maxDepth ?? DEFAULT_FIBER_MAX_DEPTH)),
+    ),
+    maxNodes: Math.min(
+      MAX_FIBER_NODES,
+      Math.max(1, Math.floor(options.maxNodes ?? DEFAULT_FIBER_MAX_NODES)),
+    ),
+  };
+}
+
 /**
- * Inline JS snippet that resolves `rootFiber` from the React DevTools hook.
- * Embed at the top of an IIFE; uses `return` to exit early on failure.
- * The early-return value should match the IIFE's failure sentinel (null or []).
+ * Defines the shared iterative walker used by every read-only fiber tool.
+ *
+ * `metroWalkFibers(options, visitor)` invokes visitor in pre-order with
+ * `(fiber, context)`. A visitor may return `{ childContext }` to pass a value
+ * to descendants. Inactive SceneView children are pruned only when a focused
+ * navigation route can be resolved, leaving sibling overlays visible.
+ */
+export const FIBER_WALKER_JS = `
+  function metroFiberName(fiber) {
+    if (!fiber || !fiber.type) return null;
+    if (typeof fiber.type === 'string') return fiber.type;
+    return fiber.type.displayName || fiber.type.name || null;
+  }
+
+  function metroFiberRoots() {
+    var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    var entries = [];
+    var seen = new Set();
+    if (!hook || !hook.getFiberRoots) return entries;
+    for (var rendererId = 1; rendererId <= 20; rendererId++) {
+      try {
+        var roots = hook.getFiberRoots(rendererId);
+        if (!roots || !roots.size) continue;
+        var renderer = hook.renderers && hook.renderers.get
+          ? hook.renderers.get(rendererId)
+          : null;
+        Array.from(roots).forEach(function(root) {
+          var fiber = root && root.current;
+          if (!fiber || seen.has(fiber)) return;
+          seen.add(fiber);
+          entries.push({ fiber: fiber, renderer: renderer, rendererId: rendererId });
+        });
+      } catch (_) {}
+    }
+    return entries;
+  }
+
+  function metroNavigationState(rootEntries) {
+    try {
+      var bridge = globalThis.__METRO_BRIDGE__ || globalThis.__METRO_MCP__;
+      if (bridge && bridge.navigation && bridge.navigation.getState) {
+        var bridgeState = bridge.navigation.getState();
+        if (bridgeState && bridgeState.routes) return bridgeState;
+      }
+      var navRef = globalThis.__METRO_MCP_NAV_REF__;
+      if (navRef && navRef.getRootState) {
+        var refState = navRef.getRootState();
+        if (refState && refState.routes) return refState;
+      }
+      var expoState = globalThis.__EXPO_ROUTER_STATE__;
+      if (typeof expoState === 'function') expoState = expoState();
+      if (expoState && expoState.routes) return expoState;
+    } catch (_) {}
+
+    var stack = [];
+    for (var rootIndex = rootEntries.length - 1; rootIndex >= 0; rootIndex--) {
+      stack.push({ fiber: rootEntries[rootIndex].fiber, depth: 0 });
+    }
+    var inspected = 0;
+    while (stack.length && inspected < 5000) {
+      var entry = stack.pop();
+      var fiber = entry && entry.fiber;
+      var depth = entry && entry.depth;
+      if (!fiber || depth > 600) continue;
+      inspected++;
+      var name = metroFiberName(fiber);
+      var found = null;
+      if (
+        name === 'NavigationContainer' ||
+        name === 'NavigationContainerInner' ||
+        name === 'BaseNavigationContainer'
+      ) {
+        var hookState = fiber.memoizedState;
+        while (hookState && !found) {
+          if (hookState.memoizedState && hookState.memoizedState.routes) {
+            found = hookState.memoizedState;
+          } else if (
+            hookState.queue &&
+            hookState.queue.lastRenderedState &&
+            hookState.queue.lastRenderedState.routes
+          ) {
+            found = hookState.queue.lastRenderedState;
+          }
+          hookState = hookState.next;
+        }
+        if (!found && fiber.memoizedProps && fiber.memoizedProps.state && fiber.memoizedProps.state.routes) {
+          found = fiber.memoizedProps.state;
+        }
+      }
+      if (found) return found;
+      var children = [];
+      var child = fiber.child;
+      while (child) { children.push(child); child = child.sibling; }
+      for (var childIndex = children.length - 1; childIndex >= 0; childIndex--) {
+        stack.push({ fiber: children[childIndex], depth: depth + 1 });
+      }
+    }
+    return null;
+  }
+
+  function metroFocusedRoutes(state) {
+    var names = [];
+    var keys = [];
+    var current = state;
+    while (current && Array.isArray(current.routes) && current.routes.length) {
+      var index = typeof current.index === 'number'
+        ? current.index
+        : current.routes.length - 1;
+      var route = current.routes[index];
+      if (!route) break;
+      if (typeof route.name === 'string') names.push(route.name);
+      if (typeof route.key === 'string') keys.push(route.key);
+      current = route.state;
+    }
+    return { names: names, keys: keys };
+  }
+
+  function metroSafeProps(fiber, limit) {
+    var source = fiber && fiber.memoizedProps;
+    var result = {};
+    if (!source || typeof source !== 'object') return result;
+    var keys = Object.keys(source);
+    for (var index = 0; index < Math.min(keys.length, limit || 20); index++) {
+      var key = keys[index];
+      if (key === 'children') continue;
+      var value = source[key];
+      if (typeof value === 'function') result[key] = '[function]';
+      else if (value && typeof value === 'object') {
+        try { result[key] = JSON.parse(JSON.stringify(value)); }
+        catch (_) { result[key] = '[object]'; }
+      } else result[key] = value;
+    }
+    return result;
+  }
+
+  function metroPrimitiveText(value) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      return String(value).slice(0, 300);
+    }
+    if (!Array.isArray(value)) return null;
+    var text = value
+      .filter(function(item) {
+        return typeof item === 'string' || typeof item === 'number';
+      })
+      .join(' ');
+    return text ? text.slice(0, 300) : null;
+  }
+
+  function metroElementFromFiber(fiber) {
+    var props = fiber.memoizedProps || {};
+    var name = metroFiberName(fiber);
+    if (!name || name.indexOf('RCT') === 0) return null;
+    var testID = typeof props.testID === 'string' ? props.testID : null;
+    var label = typeof props.accessibilityLabel === 'string'
+      ? props.accessibilityLabel
+      : (typeof props['aria-label'] === 'string' ? props['aria-label'] : null);
+    var role = typeof props.accessibilityRole === 'string'
+      ? props.accessibilityRole
+      : (typeof props.role === 'string' ? props.role : null);
+    var interactive = !!(
+      props.onPress || props.onPressIn || props.onLongPress || props.onTap ||
+      props.onClick || props.accessible || props.hitSlop || ('disabled' in props)
+    );
+    return {
+      name: name,
+      type: name,
+      testID: testID,
+      accessibilityLabel: label,
+      label: label,
+      accessibilityRole: role,
+      role: role,
+      text: metroPrimitiveText(props.children),
+      interactive: interactive,
+      hint: typeof props.accessibilityHint === 'string' ? props.accessibilityHint : null
+    };
+  }
+
+  function metroWalkFibers(options, visitor) {
+    var roots = metroFiberRoots();
+    var requestedDepth = Number(options.maxDepth);
+    var requestedNodes = Number(options.maxNodes);
+    var maxDepth = Math.min(600, Math.max(
+      0,
+      Number.isFinite(requestedDepth) ? requestedDepth : 200
+    ));
+    var maxNodes = Math.min(5000, Math.max(
+      1,
+      Number.isFinite(requestedNodes) ? requestedNodes : 1200
+    ));
+    var focus = metroFocusedRoutes(metroNavigationState(roots));
+    var focused = focus.keys.length > 0 || focus.names.length > 0;
+    var state = {
+      scope: focused ? 'focused-scene' : 'all-scenes',
+      complete: roots.length > 0,
+      depthReached: 0,
+      scannedNodes: 0
+    };
+    if (!roots.length) {
+      state.complete = false;
+      state.truncationReason = 'fiber-roots-unavailable';
+      return state;
+    }
+
+    function inactiveScene(route) {
+      if (!focused || !route) return false;
+      if (typeof route.key === 'string') return focus.keys.indexOf(route.key) === -1;
+      return typeof route.name === 'string' && focus.names.indexOf(route.name) === -1;
+    }
+
+    var stack = [];
+    for (var rootIndex = roots.length - 1; rootIndex >= 0; rootIndex--) {
+      stack.push({
+        fiber: roots[rootIndex].fiber,
+        renderer: roots[rootIndex].renderer,
+        rendererId: roots[rootIndex].rendererId,
+        rootIndex: rootIndex,
+        depth: 0,
+        parentContext: null
+      });
+    }
+
+    while (stack.length) {
+      if (state.scannedNodes >= maxNodes) {
+        state.complete = false;
+        state.truncationReason = 'max-nodes';
+        break;
+      }
+      var entry = stack.pop();
+      var fiber = entry && entry.fiber;
+      if (!fiber) continue;
+      if (entry.depth > maxDepth) {
+        state.complete = false;
+        if (!state.truncationReason) state.truncationReason = 'max-depth';
+        continue;
+      }
+
+      state.scannedNodes++;
+      state.depthReached = Math.max(state.depthReached, entry.depth);
+      var name = metroFiberName(fiber);
+      var props = fiber.memoizedProps || {};
+      if (name === 'SceneView' && inactiveScene(props.route)) continue;
+
+      var visitResult = visitor(fiber, {
+        depth: entry.depth,
+        parentContext: entry.parentContext,
+        renderer: entry.renderer,
+        rendererId: entry.rendererId,
+        rootIndex: entry.rootIndex
+      });
+      var childContext = visitResult && Object.prototype.hasOwnProperty.call(visitResult, 'childContext')
+        ? visitResult.childContext
+        : entry.parentContext;
+      if (visitResult && visitResult.prune) continue;
+
+      var children = [];
+      var child = fiber.child;
+      while (child) { children.push(child); child = child.sibling; }
+      for (var index = children.length - 1; index >= 0; index--) {
+        stack.push({
+          fiber: children[index],
+          renderer: entry.renderer,
+          rendererId: entry.rendererId,
+          rootIndex: entry.rootIndex,
+          depth: entry.depth + 1,
+          parentContext: childContext
+        });
+      }
+    }
+    return state;
+  }
+`;
+
+export function buildFiberReadExpression(
+  body: string,
+  options: FiberTraversalOptions = {},
+  asynchronous = false,
+): string {
+  const normalized = normalizeFiberTraversalOptions(options);
+  return `(${asynchronous ? 'async ' : ''}function() {
+    ${FIBER_WALKER_JS}
+    var FIBER_OPTIONS = ${JSON.stringify(normalized)};
+    ${body}
+  })()`;
+}
+
+/**
+ * Legacy root snippet used by write/interaction tools. Read tools use the
+ * shared walker above; interactions retain their existing behaviour.
  */
 export const FIBER_ROOT_JS = `
   var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
   if (!hook || !hook.getFiberRoots) return null;
   var fiberRoots;
   try {
-    for (var i = 1; i <= 5; i++) {
+    for (var i = 1; i <= 20; i++) {
       fiberRoots = hook.getFiberRoots(i);
       if (fiberRoots && fiberRoots.size > 0) break;
     }
@@ -24,73 +355,35 @@ export const FIBER_ROOT_JS = `
   var rootFiber = Array.from(fiberRoots)[0].current;
 `;
 
-/**
- * Complete standalone IIFE that collects testable elements from the fiber tree.
- * Returns an array of { name, testID, accessibilityLabel, accessibilityRole, text, interactive }.
- * Uses an iterative stack to safely handle deep navigation trees (depth 200+).
- */
-export const COLLECT_ELEMENTS_JS = `
-  (function() {
-    var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-    if (!hook || !hook.getFiberRoots) return [];
-    var fiberRoots;
-    try {
-      for (var i = 1; i <= 5; i++) {
-        fiberRoots = hook.getFiberRoots(i);
-        if (fiberRoots && fiberRoots.size > 0) break;
-      }
-    } catch(e) { return []; }
-    if (!fiberRoots || fiberRoots.size === 0) return [];
-    var rootFiber = Array.from(fiberRoots)[0].current;
-    var elements = [];
-    var seen = {};
-    var stack = [{ f: rootFiber, d: 0 }];
-    while (stack.length) {
-      var item = stack.pop();
-      var fiber = item.f; var depth = item.d;
-      if (!fiber || depth > 200) continue;
-      var type = fiber.type;
-      var name = typeof type === 'string' ? type : (type && (type.displayName || type.name));
-      if (name && name.indexOf('RCT') !== 0) {
-        var props = fiber.memoizedProps || {};
-        var testID = props.testID || null;
-        var label = props.accessibilityLabel || props['aria-label'] || null;
-        var key = testID || label;
-        if ((testID || label || typeof props.children === 'string') && (!key || !seen[key])) {
-          if (key) seen[key] = true;
-          elements.push({
-            name: name,
-            testID: testID,
-            accessibilityLabel: label,
-            accessibilityRole: props.accessibilityRole || props['role'] || null,
-            text: typeof props.children === 'string' ? props.children : null,
-            interactive: !!(props.onPress || props.onPressIn || props.onClick),
-          });
-        }
-      }
-      if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
-      if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
-    }
-    return elements;
-  })()
-`;
+export const COLLECT_ELEMENTS_JS = buildFiberReadExpression(`
+  var elements = [];
+  var seen = new Set();
+  var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber) {
+    var element = metroElementFromFiber(fiber);
+    if (!element) return;
+    var key = element.testID || element.accessibilityLabel;
+    if (!(element.testID || element.accessibilityLabel || element.text)) return;
+    if (key && seen.has(key)) return;
+    if (key) seen.add(key);
+    elements.push(element);
+  });
+  return { elements: elements, traversal: traversal };
+`);
 
 /**
  * Swipe coordinates [startX, startY, endX, endY] — assumes ~1080×1920 viewport.
  * Shared by test-recorder (test generation) and ui-interact (native fallback swipes).
  */
 export const SWIPE_COORDS: Record<string, [number, number, number, number]> = {
-  up:    [500, 1500, 500,  500],
-  down:  [500,  500, 500, 1500],
-  left:  [800, 1000, 200, 1000],
+  up: [500, 1500, 500, 500],
+  down: [500, 500, 500, 1500],
+  left: [800, 1000, 200, 1000],
   right: [200, 1000, 800, 1000],
 };
 
 /**
  * JS snippet defining `findAndInvoke(needle, handlerName)`.
  * Requires `rootFiber` to be set (embed after FIBER_ROOT_JS).
- * Finds the fiber matching needle by accessibilityLabel, aria-label, or testID,
- * then walks up to the nearest ancestor that has `handlerName` and calls it.
  */
 export const FIND_AND_INVOKE_JS = `
   function findAndInvoke(needle, handlerName) {
@@ -124,10 +417,7 @@ export const FIND_AND_INVOKE_JS = `
   }
 `;
 
-/**
- * JS snippet that defines a `getRoute()` function reading from the nav ref set by the
- * navigation plugin. Embed inside an IIFE that also calls `getRoute()`.
- */
+/** Defines getRoute(), reading from the navigation ref set by the navigation plugin. */
 export const GET_ROUTE_FUNC_JS = `function getRoute() {
   try {
     var n = globalThis.__METRO_MCP_NAV_REF__;
@@ -136,17 +426,14 @@ export const GET_ROUTE_FUNC_JS = `function getRoute() {
   return null;
 }`;
 
-export interface TestableElement {
-  name: string;
-  testID?: string;
-  accessibilityLabel?: string;
-  accessibilityRole?: string;
-  text?: string;
-  interactive?: boolean;
-}
-
-type EvalFn = (expr: string, opts?: { timeout?: number; awaitPromise?: boolean }) => Promise<unknown>;
+type EvalFn = (
+  expr: string,
+  opts?: { timeout?: number; awaitPromise?: boolean },
+) => Promise<unknown>;
 
 export async function collectElements(evalInApp: EvalFn): Promise<TestableElement[]> {
-  return ((await evalInApp(COLLECT_ELEMENTS_JS, { timeout: 5000 })) as TestableElement[]) ?? [];
+  const result = (await evalInApp(COLLECT_ELEMENTS_JS, {
+    timeout: 5000,
+  })) as { elements?: TestableElement[] } | null;
+  return result?.elements ?? [];
 }

--- a/src/utils/fiber.ts
+++ b/src/utils/fiber.ts
@@ -9,6 +9,7 @@ export const DEFAULT_FIBER_MAX_DEPTH = 200;
 export const MAX_FIBER_DEPTH = 600;
 export const DEFAULT_FIBER_MAX_NODES = 1200;
 export const MAX_FIBER_NODES = 5000;
+export const MAX_FIBER_PROP_BYTES = 256 * 1024;
 
 export interface FiberTraversalOptions {
   maxDepth?: number;
@@ -23,6 +24,7 @@ export interface FiberTraversalMetadata {
   truncationReason?:
     | 'max-depth'
     | 'max-nodes'
+    | 'max-prop-bytes'
     | 'fiber-roots-unavailable'
     | 'cursor-expired';
 }
@@ -60,13 +62,25 @@ export function normalizeFiberTraversalOptions(
  * navigation route can be resolved, leaving sibling overlays visible.
  */
 export const FIBER_WALKER_JS = `
+  var metroPropByteBudget = {
+    remaining: ${MAX_FIBER_PROP_BYTES},
+    traversal: null
+  };
+
+  function metroMarkPropsTruncated() {
+    var traversal = metroPropByteBudget.traversal;
+    if (!traversal) return;
+    traversal.complete = false;
+    if (!traversal.truncationReason) traversal.truncationReason = 'max-prop-bytes';
+  }
+
   function metroFiberName(fiber) {
     if (!fiber || !fiber.type) return null;
     if (typeof fiber.type === 'string') return fiber.type;
     return fiber.type.displayName || fiber.type.name || null;
   }
 
-  function metroFiberRoots() {
+  function metroFiberRoots(limit) {
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     var entries = [];
     var seen = new Set();
@@ -78,12 +92,16 @@ export const FIBER_WALKER_JS = `
         var renderer = hook.renderers && hook.renderers.get
           ? hook.renderers.get(rendererId)
           : null;
-        Array.from(roots).forEach(function(root) {
+        var iterator = roots.values();
+        var nextRoot;
+        while (!(nextRoot = iterator.next()).done) {
+          var root = nextRoot.value;
           var fiber = root && root.current;
-          if (!fiber || seen.has(fiber)) return;
+          if (!fiber || seen.has(fiber)) continue;
           seen.add(fiber);
           entries.push({ fiber: fiber, renderer: renderer, rendererId: rendererId });
-        });
+          if (entries.length >= limit) return entries;
+        }
       } catch (_) {}
     }
     return entries;
@@ -163,6 +181,10 @@ export const FIBER_WALKER_JS = `
     var source = fiber && fiber.memoizedProps;
     var result = {};
     if (!source || typeof source !== 'object') return result;
+    if (metroPropByteBudget.remaining <= 0) {
+      metroMarkPropsTruncated();
+      return result;
+    }
     var budget = { remaining: 100 };
     var seen = [];
 
@@ -225,6 +247,30 @@ export const FIBER_WALKER_JS = `
       try { result[safeKey] = safeValue(source[key], 0); }
       catch (_) { result[safeKey] = '[unavailable]'; }
     }
+    if (!Object.keys(result).length) return result;
+
+    var json = JSON.stringify(result);
+    var bytes = 0;
+    for (var byteIndex = 0; byteIndex < json.length; byteIndex++) {
+      var code = json.charCodeAt(byteIndex);
+      if (code <= 0x7f) bytes++;
+      else if (code <= 0x7ff) bytes += 2;
+      else if (
+        code >= 0xd800 && code <= 0xdbff &&
+        byteIndex + 1 < json.length &&
+        json.charCodeAt(byteIndex + 1) >= 0xdc00 &&
+        json.charCodeAt(byteIndex + 1) <= 0xdfff
+      ) {
+        bytes += 4;
+        byteIndex++;
+      } else bytes += 3;
+    }
+    if (bytes > metroPropByteBudget.remaining) {
+      metroPropByteBudget.remaining = 0;
+      metroMarkPropsTruncated();
+      return {};
+    }
+    metroPropByteBudget.remaining -= bytes;
     return result;
   }
 
@@ -278,7 +324,6 @@ export const FIBER_WALKER_JS = `
   }
 
   function metroWalkFibers(options, visitor) {
-    var roots = metroFiberRoots();
     var requestedDepth = Number(options.maxDepth);
     var requestedNodes = Number(options.maxNodes);
     var maxDepth = Math.min(600, Math.max(
@@ -289,12 +334,14 @@ export const FIBER_WALKER_JS = `
       1,
       Number.isFinite(requestedNodes) ? requestedNodes : 1200
     ));
+    var roots = metroFiberRoots(maxNodes + 1);
     var state = {
       scope: 'all-scenes',
       complete: roots.length > 0,
       depthReached: 0,
       scannedNodes: 0
     };
+    metroPropByteBudget.traversal = state;
     if (!roots.length) {
       state.complete = false;
       state.truncationReason = 'fiber-roots-unavailable';
@@ -309,7 +356,8 @@ export const FIBER_WALKER_JS = `
         rendererId: roots[rootIndex].rendererId,
         rootIndex: rootIndex,
         depth: 0,
-        parentIndex: null
+        parentIndex: null,
+        includeSiblings: false
       });
     }
 
@@ -334,6 +382,18 @@ export const FIBER_WALKER_JS = `
       state.depthReached = Math.max(state.depthReached, entry.depth);
       var entryIndex = entries.length;
       entries.push(entry);
+      var sibling = entry.includeSiblings ? fiber.sibling : null;
+      if (sibling) {
+        stack.push({
+          fiber: sibling,
+          renderer: entry.renderer,
+          rendererId: entry.rendererId,
+          rootIndex: entry.rootIndex,
+          depth: entry.depth,
+          parentIndex: entry.parentIndex,
+          includeSiblings: true
+        });
+      }
       if (!navigationState) {
         navigationState = metroNavigationStateFromFiber(fiber);
       }
@@ -349,17 +409,16 @@ export const FIBER_WALKER_JS = `
           collectionFocus.names.indexOf(entryRoute.name) === -1)
       );
       if (!pruneInactiveScene) {
-        var children = [];
         var child = fiber.child;
-        while (child) { children.push(child); child = child.sibling; }
-        for (var index = children.length - 1; index >= 0; index--) {
+        if (child) {
           stack.push({
-            fiber: children[index],
+            fiber: child,
             renderer: entry.renderer,
             rendererId: entry.rendererId,
             rootIndex: entry.rootIndex,
             depth: entry.depth + 1,
-            parentIndex: entryIndex
+            parentIndex: entryIndex,
+            includeSiblings: true
           });
         }
       }

--- a/src/utils/fiber.ts
+++ b/src/utils/fiber.ts
@@ -173,16 +173,67 @@ export const FIBER_WALKER_JS = `
     var source = fiber && fiber.memoizedProps;
     var result = {};
     if (!source || typeof source !== 'object') return result;
-    var keys = Object.keys(source);
+    var budget = { remaining: 100 };
+    var seen = [];
+
+    function safeValue(value, depth) {
+      if (typeof value === 'function') return '[function]';
+      if (typeof value === 'string') return value.slice(0, 1000);
+      if (
+        value === null ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+      ) return value;
+      if (typeof value !== 'object') return String(value).slice(0, 1000);
+      if (depth >= 3) return Array.isArray(value) ? '[array]' : '[object]';
+      if (seen.indexOf(value) !== -1) return '[circular]';
+      if (budget.remaining <= 0) return '[truncated]';
+
+      seen.push(value);
+      var output;
+      if (Array.isArray(value)) {
+        output = [];
+        var itemLimit = Math.min(value.length, 20);
+        for (var itemIndex = 0; itemIndex < itemLimit; itemIndex++) {
+          if (budget.remaining <= 0) break;
+          budget.remaining--;
+          output.push(safeValue(value[itemIndex], depth + 1));
+        }
+        if (value.length > output.length) output.push('[truncated]');
+      } else {
+        output = {};
+        var nestedKeys;
+        try { nestedKeys = Object.keys(value); }
+        catch (_) {
+          seen.pop();
+          return '[object]';
+        }
+        var propertyLimit = Math.min(nestedKeys.length, 20);
+        var copied = 0;
+        for (var propertyIndex = 0; propertyIndex < propertyLimit; propertyIndex++) {
+          if (budget.remaining <= 0) break;
+          var nestedKey = nestedKeys[propertyIndex];
+          var safeNestedKey = String(nestedKey).slice(0, 200);
+          budget.remaining--;
+          try { output[safeNestedKey] = safeValue(value[nestedKey], depth + 1); }
+          catch (_) { output[safeNestedKey] = '[unavailable]'; }
+          copied++;
+        }
+        if (nestedKeys.length > copied) output.__truncated__ = true;
+      }
+      seen.pop();
+      return output;
+    }
+
+    var keys;
+    try { keys = Object.keys(source); }
+    catch (_) { return result; }
     for (var index = 0; index < Math.min(keys.length, limit || 20); index++) {
       var key = keys[index];
       if (key === 'children') continue;
-      var value = source[key];
-      if (typeof value === 'function') result[key] = '[function]';
-      else if (value && typeof value === 'object') {
-        try { result[key] = JSON.parse(JSON.stringify(value)); }
-        catch (_) { result[key] = '[object]'; }
-      } else result[key] = value;
+      var safeKey = String(key).slice(0, 200);
+      try { result[safeKey] = safeValue(source[key], 0); }
+      catch (_) { result[safeKey] = '[unavailable]'; }
     }
     return result;
   }
@@ -357,14 +408,10 @@ export const FIBER_ROOT_JS = `
 
 export const COLLECT_ELEMENTS_JS = buildFiberReadExpression(`
   var elements = [];
-  var seen = new Set();
   var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber) {
     var element = metroElementFromFiber(fiber);
     if (!element) return;
-    var key = element.testID || element.accessibilityLabel;
     if (!(element.testID || element.accessibilityLabel || element.text)) return;
-    if (key && seen.has(key)) return;
-    if (key) seen.add(key);
     elements.push(element);
   });
   return { elements: elements, traversal: traversal };

--- a/src/utils/fiber.ts
+++ b/src/utils/fiber.ts
@@ -89,7 +89,7 @@ export const FIBER_WALKER_JS = `
     return entries;
   }
 
-  function metroNavigationState(rootEntries) {
+  function metroNavigationState() {
     try {
       var bridge = globalThis.__METRO_BRIDGE__ || globalThis.__METRO_MCP__;
       if (bridge && bridge.navigation && bridge.navigation.getState) {
@@ -106,50 +106,40 @@ export const FIBER_WALKER_JS = `
       if (expoState && expoState.routes) return expoState;
     } catch (_) {}
 
-    var stack = [];
-    for (var rootIndex = rootEntries.length - 1; rootIndex >= 0; rootIndex--) {
-      stack.push({ fiber: rootEntries[rootIndex].fiber, depth: 0 });
-    }
-    var inspected = 0;
-    while (stack.length && inspected < 5000) {
-      var entry = stack.pop();
-      var fiber = entry && entry.fiber;
-      var depth = entry && entry.depth;
-      if (!fiber || depth > 600) continue;
-      inspected++;
-      var name = metroFiberName(fiber);
-      var found = null;
-      if (
-        name === 'NavigationContainer' ||
-        name === 'NavigationContainerInner' ||
-        name === 'BaseNavigationContainer'
-      ) {
-        var hookState = fiber.memoizedState;
-        while (hookState && !found) {
-          if (hookState.memoizedState && hookState.memoizedState.routes) {
-            found = hookState.memoizedState;
-          } else if (
-            hookState.queue &&
-            hookState.queue.lastRenderedState &&
-            hookState.queue.lastRenderedState.routes
-          ) {
-            found = hookState.queue.lastRenderedState;
-          }
-          hookState = hookState.next;
-        }
-        if (!found && fiber.memoizedProps && fiber.memoizedProps.state && fiber.memoizedProps.state.routes) {
-          found = fiber.memoizedProps.state;
-        }
-      }
-      if (found) return found;
-      var children = [];
-      var child = fiber.child;
-      while (child) { children.push(child); child = child.sibling; }
-      for (var childIndex = children.length - 1; childIndex >= 0; childIndex--) {
-        stack.push({ fiber: children[childIndex], depth: depth + 1 });
-      }
-    }
     return null;
+  }
+
+  function metroNavigationStateFromFiber(fiber) {
+    var name = metroFiberName(fiber);
+    if (
+      name !== 'NavigationContainer' &&
+      name !== 'NavigationContainerInner' &&
+      name !== 'BaseNavigationContainer'
+    ) return null;
+
+    var found = null;
+    var hookState = fiber.memoizedState;
+    while (hookState && !found) {
+      if (hookState.memoizedState && hookState.memoizedState.routes) {
+        found = hookState.memoizedState;
+      } else if (
+        hookState.queue &&
+        hookState.queue.lastRenderedState &&
+        hookState.queue.lastRenderedState.routes
+      ) {
+        found = hookState.queue.lastRenderedState;
+      }
+      hookState = hookState.next;
+    }
+    if (
+      !found &&
+      fiber.memoizedProps &&
+      fiber.memoizedProps.state &&
+      fiber.memoizedProps.state.routes
+    ) {
+      found = fiber.memoizedProps.state;
+    }
+    return found;
   }
 
   function metroFocusedRoutes(state) {
@@ -243,12 +233,19 @@ export const FIBER_WALKER_JS = `
       return String(value).slice(0, 300);
     }
     if (!Array.isArray(value)) return null;
-    var text = value
-      .filter(function(item) {
-        return typeof item === 'string' || typeof item === 'number';
-      })
-      .join(' ');
-    return text ? text.slice(0, 300) : null;
+    var parts = [];
+    var length = 0;
+    for (var index = 0; index < value.length && index < 100 && length < 300; index++) {
+      var item = value[index];
+      if (typeof item !== 'string' && typeof item !== 'number') continue;
+      var separatorLength = parts.length ? 1 : 0;
+      var remaining = 300 - length - separatorLength;
+      if (remaining <= 0) break;
+      var part = String(item).slice(0, remaining);
+      parts.push(part);
+      length += separatorLength + part.length;
+    }
+    return parts.length ? parts.join(' ') : null;
   }
 
   function metroElementFromFiber(fiber) {
@@ -292,10 +289,8 @@ export const FIBER_WALKER_JS = `
       1,
       Number.isFinite(requestedNodes) ? requestedNodes : 1200
     ));
-    var focus = metroFocusedRoutes(metroNavigationState(roots));
-    var focused = focus.keys.length > 0 || focus.names.length > 0;
     var state = {
-      scope: focused ? 'focused-scene' : 'all-scenes',
+      scope: 'all-scenes',
       complete: roots.length > 0,
       depthReached: 0,
       scannedNodes: 0
@@ -306,12 +301,6 @@ export const FIBER_WALKER_JS = `
       return state;
     }
 
-    function inactiveScene(route) {
-      if (!focused || !route) return false;
-      if (typeof route.key === 'string') return focus.keys.indexOf(route.key) === -1;
-      return typeof route.name === 'string' && focus.names.indexOf(route.name) === -1;
-    }
-
     var stack = [];
     for (var rootIndex = roots.length - 1; rootIndex >= 0; rootIndex--) {
       stack.push({
@@ -320,10 +309,12 @@ export const FIBER_WALKER_JS = `
         rendererId: roots[rootIndex].rendererId,
         rootIndex: rootIndex,
         depth: 0,
-        parentContext: null
+        parentIndex: null
       });
     }
 
+    var entries = [];
+    var navigationState = metroNavigationState();
     while (stack.length) {
       if (state.scannedNodes >= maxNodes) {
         state.complete = false;
@@ -341,35 +332,81 @@ export const FIBER_WALKER_JS = `
 
       state.scannedNodes++;
       state.depthReached = Math.max(state.depthReached, entry.depth);
-      var name = metroFiberName(fiber);
-      var props = fiber.memoizedProps || {};
-      if (name === 'SceneView' && inactiveScene(props.route)) continue;
+      var entryIndex = entries.length;
+      entries.push(entry);
+      if (!navigationState) {
+        navigationState = metroNavigationStateFromFiber(fiber);
+      }
 
-      var visitResult = visitor(fiber, {
-        depth: entry.depth,
-        parentContext: entry.parentContext,
-        renderer: entry.renderer,
-        rendererId: entry.rendererId,
-        rootIndex: entry.rootIndex
+      var collectionFocus = metroFocusedRoutes(navigationState);
+      var entryName = metroFiberName(fiber);
+      var entryRoute = fiber.memoizedProps && fiber.memoizedProps.route;
+      var pruneInactiveScene = entryName === 'SceneView' && entryRoute && (
+        (typeof entryRoute.key === 'string' && collectionFocus.keys.length > 0 &&
+          collectionFocus.keys.indexOf(entryRoute.key) === -1) ||
+        (typeof entryRoute.key !== 'string' && typeof entryRoute.name === 'string' &&
+          collectionFocus.names.length > 0 &&
+          collectionFocus.names.indexOf(entryRoute.name) === -1)
+      );
+      if (!pruneInactiveScene) {
+        var children = [];
+        var child = fiber.child;
+        while (child) { children.push(child); child = child.sibling; }
+        for (var index = children.length - 1; index >= 0; index--) {
+          stack.push({
+            fiber: children[index],
+            renderer: entry.renderer,
+            rendererId: entry.rendererId,
+            rootIndex: entry.rootIndex,
+            depth: entry.depth + 1,
+            parentIndex: entryIndex
+          });
+        }
+      }
+    }
+
+    var focus = metroFocusedRoutes(navigationState);
+    var focused = focus.keys.length > 0 || focus.names.length > 0;
+    state.scope = focused ? 'focused-scene' : 'all-scenes';
+
+    function inactiveScene(route) {
+      if (!focused || !route) return false;
+      if (typeof route.key === 'string') return focus.keys.indexOf(route.key) === -1;
+      return typeof route.name === 'string' && focus.names.indexOf(route.name) === -1;
+    }
+
+    var visitStates = [];
+    for (var visitIndex = 0; visitIndex < entries.length; visitIndex++) {
+      var visitEntry = entries[visitIndex];
+      var parentState = visitEntry.parentIndex === null
+        ? null
+        : visitStates[visitEntry.parentIndex];
+      if (parentState && parentState.pruned) {
+        visitStates.push({ pruned: true, childContext: parentState.childContext });
+        continue;
+      }
+      var visitFiber = visitEntry.fiber;
+      var visitName = metroFiberName(visitFiber);
+      var visitProps = visitFiber.memoizedProps || {};
+      if (visitName === 'SceneView' && inactiveScene(visitProps.route)) {
+        visitStates.push({ pruned: true, childContext: parentState && parentState.childContext });
+        continue;
+      }
+      var parentContext = parentState ? parentState.childContext : null;
+      var visitResult = visitor(visitFiber, {
+        depth: visitEntry.depth,
+        parentContext: parentContext,
+        renderer: visitEntry.renderer,
+        rendererId: visitEntry.rendererId,
+        rootIndex: visitEntry.rootIndex
       });
       var childContext = visitResult && Object.prototype.hasOwnProperty.call(visitResult, 'childContext')
         ? visitResult.childContext
-        : entry.parentContext;
-      if (visitResult && visitResult.prune) continue;
-
-      var children = [];
-      var child = fiber.child;
-      while (child) { children.push(child); child = child.sibling; }
-      for (var index = children.length - 1; index >= 0; index--) {
-        stack.push({
-          fiber: children[index],
-          renderer: entry.renderer,
-          rendererId: entry.rendererId,
-          rootIndex: entry.rootIndex,
-          depth: entry.depth + 1,
-          parentContext: childContext
-        });
-      }
+        : parentContext;
+      visitStates.push({
+        pruned: !!(visitResult && visitResult.prune),
+        childContext: childContext
+      });
     }
     return state;
   }
@@ -406,7 +443,7 @@ export const FIBER_ROOT_JS = `
   var rootFiber = Array.from(fiberRoots)[0].current;
 `;
 
-export const COLLECT_ELEMENTS_JS = buildFiberReadExpression(`
+const COLLECT_ELEMENTS_BODY = `
   var elements = [];
   var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber) {
     var element = metroElementFromFiber(fiber);
@@ -415,7 +452,11 @@ export const COLLECT_ELEMENTS_JS = buildFiberReadExpression(`
     elements.push(element);
   });
   return { elements: elements, traversal: traversal };
-`);
+`;
+
+export const COLLECT_ELEMENTS_JS = buildFiberReadExpression(
+  COLLECT_ELEMENTS_BODY,
+);
 
 /**
  * Swipe coordinates [startX, startY, endX, endY] — assumes ~1080×1920 viewport.
@@ -478,9 +519,27 @@ type EvalFn = (
   opts?: { timeout?: number; awaitPromise?: boolean },
 ) => Promise<unknown>;
 
-export async function collectElements(evalInApp: EvalFn): Promise<TestableElement[]> {
-  const result = (await evalInApp(COLLECT_ELEMENTS_JS, {
+export interface CollectedElements {
+  elements: TestableElement[];
+  traversal: FiberTraversalMetadata;
+}
+
+export async function collectElements(
+  evalInApp: EvalFn,
+  options: FiberTraversalOptions = {},
+): Promise<CollectedElements> {
+  const expression = buildFiberReadExpression(COLLECT_ELEMENTS_BODY, options);
+  const result = (await evalInApp(expression, {
     timeout: 5000,
-  })) as { elements?: TestableElement[] } | null;
-  return result?.elements ?? [];
+  })) as CollectedElements | null;
+  return result ?? {
+    elements: [],
+    traversal: {
+      scope: 'all-scenes',
+      complete: false,
+      depthReached: 0,
+      scannedNodes: 0,
+      truncationReason: 'fiber-roots-unavailable',
+    },
+  };
 }


### PR DESCRIPTION
Closes #68

## Summary
- consolidate component reads, element listing, and point inspection on one iterative walker across renderer IDs 1-20 and all roots
- default to 200 levels / 1200 fibers, support 600 levels, and return explicit completeness, depth, scanned-node, truncation, and focus-scope metadata
- resolve React Navigation / Expo Router focus and prune inactive `SceneView` branches while retaining sibling overlays
- page flat component snapshots with stable parent IDs, opaque 60-second cursors, and an eight-snapshot retention bound
- update the Components MCP App to consume every page, rebuild the hierarchy, and warn on incomplete traversal
- await renderer/Fabric/Paper host measurement for `inspect_at_point`

## Validation
- `bun run typecheck`
- `bun test` (107 passing)
- `bun run build`
- `bun run docs:build`

## Integration follow-up

- Use an expiring, per-request in-app result mailbox for point measurements because Hermes can serialize JavaScript Promise objects despite CDP awaitPromise.
- Cover fulfilled/rejected/pending/concurrent reads and model returnByValue faithfully in the fiber harness. Keep its command stubs compatible with the independently shipped screenshot API.
- Independently validated this branch with typecheck, 107 passing tests, production build, and docs build.
- Live iOS integration smoke tests verified async point inspection and a complete 710-node focused tree across eight pages.
- Rebuilt and installed the Android development client (Expo clean Android prebuild). Earlier live Android integration checks passed: complete 190-node tree across two pages, 289 fibers scanned to depth 189, and 33 testable elements. A retained inactive FirstVisitScreen fiber is excluded after navigation to GuestBranchSelectionScreen.
- Android testing found lazy Fabric public instances on React Native 0.86. Added a native shadow-node measurement fallback with an asynchronous regression. Point inspection now resolves the visible RCTText heading at depth 179 with correct bounds in modern and legacy MCP; result mailboxes are cleaned up.
- Reviewed both follow-ups through reuse, quality, and efficiency passes. Applied a shared measurement-callback test type. Deferred shared-mailbox extraction, polling changes, and native measurement concurrency changes because they require separate behavior/latency validation.

## Release verification

Rebased onto main after #74–#76; typecheck, 107 tests, build, and docs build pass. The source tree matches the previously validated combined integration. A release-time Android retry could not be completed because the running target rejects even `1+1` with CDP `Runtime.evaluate` method-not-found (-32601); the unchanged earlier build reproduces the same runtime state.