### PR TITLE
[codex] Retry MCP Registry publication during npm propagation

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -29,6 +29,7 @@ jobs:
           mv server.tmp.json server.json
 
       - name: Publish to MCP Registry
+        timeout-minutes: 15
         run: |
           ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+          bash scripts/publish-mcp-registry.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Publish to MCP Registry
         if: startsWith(github.ref, 'refs/tags/')
+        timeout-minutes: 15
         run: |
           ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+          bash scripts/publish-mcp-registry.sh

--- a/scripts/publish-mcp-registry.sh
+++ b/scripts/publish-mcp-registry.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Retry registration only: npm may accept a publish before its version metadata
+# reaches the registry's cache. Never repeat npm publish or mask other failures.
+max_attempts=21
+retry_delay_seconds=30
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  printf 'Publishing to MCP Registry (attempt %s/%s)\n' "$attempt" "$max_attempts"
+  if output=$(./mcp-publisher publish 2>&1); then
+    printf '%s\n' "$output"
+    exit 0
+  else
+    status=$?
+  fi
+  printf '%s\n' "$output" >&2
+
+  # Match the specific registry validation error seen after publishing v0.14.0.
+  # Authentication, malformed metadata, conflicts, and other errors fail fast.
+  case "$output" in
+    *"NPM package '"*"' exists, but version '"*"' was not found (status: 404)"*) ;;
+    *) exit "$status" ;;
+  esac
+
+  if ((attempt == max_attempts)); then
+    printf '::error::npm version is still unavailable after %s registration attempts; giving up.\n' "$max_attempts" >&2
+    exit "$status"
+  fi
+
+  printf 'Waiting %s seconds for npm propagation before retrying registration.\n' "$retry_delay_seconds"
+  sleep "$retry_delay_seconds"
+done

--- a/tests/publish-mcp-registry.test.ts
+++ b/tests/publish-mcp-registry.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('../scripts/publish-mcp-registry.sh', import.meta.url));
+const propagationError = `Error: publish failed: server returned status 400: ${JSON.stringify({
+  title: 'Bad Request',
+  status: 400,
+  detail: 'Failed to publish server',
+  errors: [{
+    message: "registry validation failed for package 0 (metro-mcp): NPM package 'metro-mcp' exists, but version '0.14.0' was not found (status: 404). A newly published release can take a moment to appear on the registry. Wait and retry, or publish version '0.14.0' before registering it",
+  }],
+})}`;
+
+function runPublisher(options: { failures?: number; error?: string; exitCode?: number } = {}) {
+  const directory = mkdtempSync(join(tmpdir(), 'metro-mcp-publish-test-'));
+  try {
+    writeFileSync(join(directory, 'attempts'), '');
+    writeFileSync(join(directory, 'delays'), '');
+    writeFileSync(join(directory, 'error'), options.error ?? propagationError);
+    writeFileSync(join(directory, 'mcp-publisher'), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" != publish ]]; then exit 99; fi
+printf 'publish\\n' >> attempts
+attempts=$(wc -l < attempts)
+if ((attempts <= TEST_FAILURES)); then
+  cat error >&2
+  exit "$TEST_EXIT_CODE"
+fi
+printf 'Successfully published\\n'
+`, { mode: 0o700 });
+    // Record the real retry intervals without making the test wait ten minutes.
+    writeFileSync(join(directory, 'sleep'), `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> delays
+`, { mode: 0o700 });
+
+    const result = spawnSync('bash', [script], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH}`,
+        TEST_FAILURES: String(options.failures ?? 0),
+        TEST_EXIT_CODE: String(options.exitCode ?? 1),
+      },
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    if (result.error) throw result.error;
+    return {
+      ...result,
+      attempts: readFileSync(join(directory, 'attempts'), 'utf8').trim().split('\n'),
+      delays: readFileSync(join(directory, 'delays'), 'utf8').trim().split('\n').filter(Boolean),
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe('MCP Registry publication retries', () => {
+  test('publishes once without waiting when the npm version is already visible', () => {
+    const result = runPublisher();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Successfully published');
+    expect(result.attempts).toEqual(['publish']);
+    expect(result.delays).toEqual([]);
+  });
+
+  test('retries the actual npm propagation error and stops on success', () => {
+    const result = runPublisher({ failures: 2 });
+    expect(result.status).toBe(0);
+    expect(result.attempts).toEqual(['publish', 'publish', 'publish']);
+    expect(result.delays).toEqual(['30', '30']);
+    expect(result.stderr).toContain(propagationError);
+    expect(result.stdout).toContain('Successfully published');
+  });
+
+  test('allows propagation to finish on the final attempt', () => {
+    const result = runPublisher({ failures: 20 });
+    expect(result.status).toBe(0);
+    expect(result.attempts).toHaveLength(21);
+    expect(result.delays).toEqual(Array(20).fill('30'));
+  });
+
+  test('stops after ten minutes of retry delays and preserves the failing exit code', () => {
+    const result = runPublisher({ failures: 100, exitCode: 7 });
+    expect(result.status).toBe(7);
+    expect(result.attempts).toHaveLength(21);
+    expect(result.delays).toEqual(Array(20).fill('30'));
+    expect(result.stderr).toContain('still unavailable after 21 registration attempts; giving up.');
+  });
+
+  test.each([
+    'Error: authentication failed (status: 401)',
+    'Error: invalid server.json: missing required field',
+    'Error: server version already exists (status: 409)',
+    'Error: unrelated resource was not found (status: 404)',
+    'Error: registry unavailable (status: 503)',
+  ])('does not retry unrelated errors: %s', (error) => {
+    const result = runPublisher({ failures: 100, error, exitCode: 2 });
+    expect(result.status).toBe(2);
+    expect(result.attempts).toEqual(['publish']);
+    expect(result.delays).toEqual([]);
+    expect(result.stderr).toContain(error);
+  });
+
+  test.each(['publish.yml', 'publish-mcp-registry.yml'])('%s uses the bounded helper after authentication', (workflow) => {
+    const yaml = readFileSync(new URL(`../.github/workflows/${workflow}`, import.meta.url), 'utf8');
+    expect(yaml).toContain('timeout-minutes: 15');
+    expect(yaml).toContain('./mcp-publisher login github-oidc\n          bash scripts/publish-mcp-registry.sh');
+    expect(yaml).not.toContain('./mcp-publisher publish');
+  });
+});


### PR DESCRIPTION
## Summary

Make registry registration tolerate the npm propagation delay that left the v0.14.0 release workflow red, without hiding genuine publication errors or repeating `npm publish`.

- Share one Bash helper between the tag release workflow and the registry-only workflow.
- Retry only the specific MCP Registry validation error stating that the npm package exists but the requested version is not yet visible (404).
- Try immediately, then every 30 seconds for at most 21 attempts (ten minutes of retry delays). Both workflow steps also have a 15-minute overall timeout.
- Stop immediately on success or unrelated authentication, metadata, conflict, and registry errors. Preserve the failing exit code and print each attempt's output.
- Keep authentication outside the retry loop and leave npm publication unchanged.

## Background

In [the v0.14.0 release run](https://github.com/steve228uk/metro-mcp/actions/runs/33740906592), the build and npm publication succeeded, but immediate MCP Registry registration could not yet see the new npm version. [A later registry-only retry succeeded](https://github.com/steve228uk/metro-mcp/actions/runs/33741392627). This automates that narrowly scoped recovery for future releases.

## Validation

- 11 new regression tests execute the real Bash helper with an isolated fake publisher and recorded, non-blocking sleeps: immediate success, delayed visibility, final-attempt success, retry exhaustion, preserved exit codes, unrelated failures, and both workflow integrations.
- `bun test`: 118 passing tests.
- `bun run typecheck`
- `bun run build`
- `bun run docs:build`
- `bash -n scripts/publish-mcp-registry.sh`
- actionlint 1.7.12: both changed workflows pass.
- `git diff --check`

No version bump, dependency changes, or application-runtime changes. No live publication was performed to test this PR.