### PR TITLE
Fix accessibility audits that report incomplete trees as clean

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -149,7 +149,12 @@ All tools use the CDP fiber tree first, falling back to `simctl`/`adb`, then IDB
 
 > No app changes needed.
 
-- **`audit_accessibility`** — Full screen audit for missing labels, roles, testIDs, alt text.
+- **`audit_accessibility`** — Audit the current screen for missing labels, roles, testIDs, and alt
+  text. Always returns `{ issues, summary, traversal }`, including clean results. `maxDepth`
+  defaults to 200 (maximum 600); `maxNodes` defaults to 1200 (maximum 5000). Check
+  `traversal.complete` before treating an empty issue list as a clean audit. Incomplete results
+  report their truncation reason; increase the limits to inspect deeper or wider trees. Severity
+  filters affect `issues`, while the summary counts all findings in the inspected portion.
 - **`check_element_accessibility`** — Deep check on a specific component.
 - **`get_accessibility_summary`** — Counts overview of accessibility coverage.
 

--- a/src/plugins/accessibility.test.ts
+++ b/src/plugins/accessibility.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import type { z } from 'zod';
+import type { PluginContext, ToolHandlerContext } from '../plugin.js';
+import type { FiberTraversalMetadata } from '../utils/fiber.js';
+import { accessibilityPlugin } from './accessibility.js';
+
+interface Fiber {
+  type: { displayName: string };
+  memoizedProps: Record<string, unknown>;
+  child?: Fiber;
+  sibling?: Fiber;
+}
+
+function fiber(name: string, props: Record<string, unknown> = {}): Fiber {
+  return { type: { displayName: name }, memoizedProps: props };
+}
+
+interface Audit {
+  issues: Array<{ issue: string; severity: string; component: string }>;
+  summary: string;
+  traversal: FiberTraversalMetadata;
+}
+
+async function auditor(root?: Fiber) {
+  let audit!: {
+    parameters: z.ZodType;
+    handler(args: Record<string, unknown>, context: ToolHandlerContext): Promise<unknown>;
+  };
+  const runtime = {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: {
+      getFiberRoots: (id: number) => id === 12 && root ? new Set([{ current: root }]) : new Set(),
+    },
+  };
+  const registerTool: PluginContext['registerTool'] = (name, config) => {
+    if (name === 'audit_accessibility') audit = config as unknown as typeof audit;
+  };
+  const context: Pick<PluginContext, 'registerTool' | 'evalInApp'> = {
+    registerTool,
+    evalInApp: async (expression) => new Function('globalThis', `return ${expression};`)(runtime),
+  };
+  await accessibilityPlugin.setup(context as PluginContext);
+  return async (args: Record<string, unknown> = {}) =>
+    await audit.handler(audit.parameters.parse(args) as Record<string, unknown>, {}) as Audit;
+}
+
+function deepTree(depth: number): Fiber {
+  let root = fiber('Image');
+  for (let index = 0; index < depth; index++) root = { ...fiber('Provider'), child: root };
+  return root;
+}
+
+describe('bounded accessibility audits', () => {
+  test('finds violations past the former depth-50 cutoff by default', async () => {
+    const audit = await auditor(deepTree(150));
+    const result = await audit();
+    expect(result.issues).toMatchObject([{ component: 'Image', severity: 'error' }]);
+    expect(result.traversal).toMatchObject({ complete: true, depthReached: 150 });
+  });
+
+  test('reports insufficient depth and finds the deep violation with a larger budget', async () => {
+    const audit = await auditor(deepTree(263));
+    const partial = await audit();
+    expect(partial.issues).toEqual([]);
+    expect(partial.traversal).toMatchObject({ complete: false, truncationReason: 'max-depth' });
+    expect(partial.summary).toContain('Audit incomplete');
+    expect(partial.summary).not.toContain('No accessibility issues found!');
+    const complete = await audit({ maxDepth: 600 });
+    expect(complete.issues).toMatchObject([{ component: 'Image', severity: 'error' }]);
+    expect(complete.traversal.complete).toBe(true);
+  });
+
+  test('does not scan a wide child list outside the node budget or invent a missing label', async () => {
+    let reads = 0;
+    function sibling(index: number): Fiber {
+      const node = fiber(index === 99_999 ? 'Text' : 'View');
+      Object.defineProperty(node, 'sibling', { get() {
+        reads++;
+        return index < 99_999 ? sibling(index + 1) : undefined;
+      } });
+      return node;
+    }
+    const root = fiber('Pressable', { testID: 'submit', accessibilityRole: 'button' });
+    root.child = sibling(0);
+    const result = await (await auditor(root))({ maxNodes: 20 });
+    expect(result.traversal).toMatchObject({ complete: false, scannedNodes: 20, truncationReason: 'max-nodes' });
+    expect(reads).toBeLessThan(50);
+    expect(result.issues).toEqual([]);
+    expect(result.summary).toContain('Audit incomplete');
+  });
+
+  test('preserves the direct text-child label rule', async () => {
+    const root = fiber('Pressable', { testID: 'submit', accessibilityRole: 'button' });
+    root.child = fiber('View');
+    root.child.sibling = fiber('Text', { children: 'Submit' });
+    const result = await (await auditor(root))();
+    expect(result.issues).toEqual([]);
+    expect(result.traversal.complete).toBe(true);
+    expect(result.summary).toBe('No accessibility issues found!');
+  });
+
+  test('preserves audit rules and filters issues while keeping all-severity counts', async () => {
+    const root = fiber('Pressable');
+    root.sibling = fiber('Image');
+    // Root siblings are separate roots in React, so put all fixtures under a provider.
+    const provider = fiber('Provider');
+    provider.child = root;
+    root.sibling.sibling = fiber('TextInput');
+    root.sibling.sibling.sibling = fiber('Text', { accessibilityRole: 'header' });
+    const audit = await auditor(provider);
+    const all = await audit();
+    expect(all.summary).toBe('6 issues found: 3 errors, 2 warnings, 1 info');
+    const filtered = await audit({ severity: 'error' });
+    expect(filtered.issues).toHaveLength(3);
+    expect(filtered.issues.every((issue) => issue.severity === 'error')).toBe(true);
+    expect(filtered.summary).toBe(all.summary);
+  });
+
+  test('returns a complete envelope for a clean tree and incomplete coverage without roots', async () => {
+    const clean = await (await auditor(fiber('Pressable', {
+      accessibilityLabel: 'Submit', accessibilityRole: 'button', testID: 'submit',
+    })))();
+    expect(clean).toMatchObject({ issues: [], traversal: { complete: true } });
+    const missing = await (await auditor())();
+    expect(missing).toMatchObject({
+      issues: [], traversal: { complete: false, truncationReason: 'fiber-roots-unavailable' },
+    });
+    expect(missing.summary).toContain('Audit incomplete');
+  });
+});

--- a/src/plugins/accessibility.ts
+++ b/src/plugins/accessibility.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { escapeJsString } from '../utils/format.js';
+import {
+  buildFiberReadExpression,
+  DEFAULT_FIBER_MAX_DEPTH,
+  DEFAULT_FIBER_MAX_NODES,
+  MAX_FIBER_DEPTH,
+  MAX_FIBER_NODES,
+  type FiberTraversalMetadata,
+} from '../utils/fiber.js';
 
 interface AccessibilityIssue {
   component: string;
@@ -15,19 +23,7 @@ export const accessibilityPlugin = definePlugin({
   description: 'Accessibility auditing via fiber tree inspection',
 
   async setup(ctx) {
-    const AUDIT_EXPR = `
-      (function() {
-        var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-        if (!hook || !hook.getFiberRoots) return null;
-
-        var fiberRoots;
-        for (var i = 1; i <= 5; i++) {
-          fiberRoots = hook.getFiberRoots(i);
-          if (fiberRoots && fiberRoots.size > 0) break;
-        }
-        if (!fiberRoots || fiberRoots.size === 0) return null;
-
-        var rootFiber = Array.from(fiberRoots)[0].current;
+    const AUDIT_BODY = `
         var issues = [];
 
         var TOUCHABLE_TYPES = [
@@ -39,30 +35,35 @@ export const accessibilityPlugin = definePlugin({
 
         var INPUT_TYPES = ['TextInput', 'TextField'];
 
-        function auditFiber(fiber, depth) {
-          if (!fiber || depth > 50) return;
-
-          var name = fiber.type?.displayName || fiber.type?.name;
-          if (!name || typeof name !== 'string') {
-            auditFiber(fiber.child, depth + 1);
-            auditFiber(fiber.sibling, depth);
-            return;
+        var records = [];
+        var traversal = metroWalkFibers(FIBER_OPTIONS, function(fiber, context) {
+          var name = metroFiberName(fiber);
+          var record = {
+            name: name,
+            props: fiber.memoizedProps || {},
+            hasTextChild: false,
+            childrenComplete: !fiber.child
+          };
+          var parent = context.parentContext;
+          if (parent) {
+            if (name === 'Text' || name === 'RCTText') parent.hasTextChild = true;
+            if (!fiber.sibling) parent.childrenComplete = true;
           }
+          records.push(record);
+          return { childContext: record };
+        });
 
-          var props = fiber.memoizedProps || {};
+        for (var record of records) {
+          var name = record.name;
+          if (!name || typeof name !== 'string') continue;
+          var props = record.props;
 
           // Check touchable elements
           if (TOUCHABLE_TYPES.indexOf(name) >= 0 || props.onPress) {
             if (!props.accessibilityLabel && !props['aria-label']) {
-              // Check if it has text children
-              var hasTextChild = false;
-              var child = fiber.child;
-              while (child) {
-                var cn = child.type?.displayName || child.type?.name;
-                if (cn === 'Text' || cn === 'RCTText') { hasTextChild = true; break; }
-                child = child.sibling;
-              }
-              if (!hasTextChild) {
+              // Only report an absent text label when all immediate children
+              // were inspected by the bounded walker.
+              if (!record.hasTextChild && record.childrenComplete) {
                 issues.push({
                   component: name,
                   issue: 'Missing accessibilityLabel on interactive element',
@@ -129,37 +130,47 @@ export const accessibilityPlugin = definePlugin({
             }
           }
 
-          auditFiber(fiber.child, depth + 1);
-          auditFiber(fiber.sibling, depth);
         }
-
-        auditFiber(rootFiber, 0);
-        return issues;
-      })()
+        return { issues: issues, traversal: traversal };
     `;
 
     ctx.registerTool('audit_accessibility', {
       description:
-        'Run a full accessibility audit on the current screen. Checks for missing labels, roles, testIDs, alt text, and more.',
+        'Audit the current screen within bounded Fiber traversal limits. Checks labels, roles, testIDs, and alt text; returns issues, summary, and traversal coverage.',
       annotations: { readOnlyHint: true },
       parameters: z.object({
         severity: z.enum(['all', 'error', 'warning', 'info']).default('all').describe('Filter by severity level'),
+        maxDepth: z.number().int().min(0).max(MAX_FIBER_DEPTH).default(DEFAULT_FIBER_MAX_DEPTH)
+          .describe('Maximum Fiber depth to inspect'),
+        maxNodes: z.number().int().min(1).max(MAX_FIBER_NODES).default(DEFAULT_FIBER_MAX_NODES)
+          .describe('Maximum Fibers to inspect'),
       }),
-      handler: async ({ severity }) => {
-        const issues = (await ctx.evalInApp(AUDIT_EXPR)) as AccessibilityIssue[] | null;
-        if (!issues) return 'Could not access component tree for audit.';
-        if (issues.length === 0) return 'No accessibility issues found!';
-
-        const filtered = severity === 'all' ? issues : issues.filter((i) => i.severity === severity);
-
-        const errorCount = issues.filter((i) => i.severity === 'error').length;
-        const warnCount = issues.filter((i) => i.severity === 'warning').length;
-        const infoCount = issues.filter((i) => i.severity === 'info').length;
-
-        return {
-          summary: `${issues.length} issues found: ${errorCount} errors, ${warnCount} warnings, ${infoCount} info`,
-          issues: filtered,
+      handler: async ({ severity, maxDepth, maxNodes }) => {
+        const result = (await ctx.evalInApp(buildFiberReadExpression(
+          AUDIT_BODY, { maxDepth, maxNodes },
+        ))) as { issues: AccessibilityIssue[]; traversal: FiberTraversalMetadata } | null;
+        const issues = result?.issues ?? [];
+        const traversal: FiberTraversalMetadata = result?.traversal ?? {
+          scope: 'all-scenes',
+          complete: false,
+          scannedNodes: 0,
+          depthReached: 0,
+          truncationReason: 'fiber-roots-unavailable',
         };
+        const filtered: AccessibilityIssue[] = [];
+        const counts = { error: 0, warning: 0, info: 0 };
+        for (const issue of issues) {
+          counts[issue.severity]++;
+          if (severity === 'all' || issue.severity === severity) filtered.push(issue);
+        }
+
+        let summary = `${issues.length} issues found: ${counts.error} errors, ${counts.warning} warnings, ${counts.info} info`;
+        if (!traversal.complete) {
+          summary = `Audit incomplete (${traversal.truncationReason}). ${summary}. Results cover only inspected components.`;
+        } else if (issues.length === 0) {
+          summary = 'No accessibility issues found!';
+        }
+        return { summary, issues: filtered, traversal };
       },
     });
 


### PR DESCRIPTION
Closes #89.

The accessibility audit now uses the shared bounded Fiber walker and always returns `issues`, `summary`, and `traversal`, including clean results. A scan stopped by depth, node count, or missing roots explicitly reports incomplete coverage. Callers can raise `maxDepth` and `maxNodes` within the existing read-tool limits.

Direct text-child label checks use the same bounded scan, so wide child lists cannot bypass the node budget. Existing audit rules and severity filtering are retained; summary counts cover every finding in the inspected portion. The tool documentation describes the result contract and limits.

Validation with Bun 1.3.10: 113 tests pass, typecheck, package build, docs build, and `git diff --check` pass. Regression tests cover depth 150 and 263, a 100,000-sibling fixture, incomplete budgets, missing roots, severity filtering, and complete clean results. All three simplify passes and a separate local code review are complete, using AGENTS.md guidance.

This is one ticket in the 0.15.0 release. Hold merge until Codex and Graphify cover the final changes and the combined local integration/live iOS regression checks pass. PR #78 remains the first planned merge.