### PR TITLE
Fix navigation waits using shared focused-route discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "^0.2.9",
+        "metro-bridge": "^0.2.10",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },
@@ -349,7 +349,7 @@
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "metro-bridge": ["metro-bridge@0.2.9", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-YRxcbpXr95BZJljRvw9IFWoSybpipYag5922Js1AlnPn0LygK0ciCiNmth1wzyu3pAKDA5YH8NtMWc7DfOeFWw=="],
+    "metro-bridge": ["metro-bridge@0.2.10", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-4hhoQJvqDzNNkN8IKf712+YSfdTZtXQFeiXuaPpXdpbLooGP+8+Q0S6Zm25VzWY2gqCTLr6gaTN/jpd14QKBYA=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "metro-mcp",
       "dependencies": {
+        "@babel/parser": "^7.29.2",
         "@clack/prompts": "^1.2.0",
         "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/node": "^2.0.0",

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -142,6 +142,9 @@ All tools use the CDP fiber tree first, falling back to `simctl`/`adb`, then IDB
 
 - **`get_navigation_state`** — Full React Navigation / Expo Router state.
 - **`get_current_route`** — Currently focused route name and params.
+- **`wait_for_navigation`** — Wait for a focused route by name (up to the supplied timeout). Uses
+  the same SDK, navigation ref, Expo state, and bounded Fiber discovery as `get_current_route`,
+  including nested navigators. It also succeeds when the requested route is already focused.
 - **`get_route_history`** — Navigation back stack.
 - **`list_routes`** — All registered route names.
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "author": "Stephen Radford",
   "license": "MIT",
   "dependencies": {
+    "@babel/parser": "^7.29.2",
     "@clack/prompts": "^1.2.0",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.2.9",
+    "metro-bridge": "^0.2.10",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,10 +7,18 @@ import {
 import type { CircularBuffer } from './utils/buffer.js';
 import type { MetroTarget } from 'metro-bridge';
 
+interface CDPSendOptions {
+  timeoutMs?: number;
+}
+
 // ── CDP Connection Interface ──
 
 export interface CDPConnection {
-  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  send(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: CDPSendOptions,
+  ): Promise<unknown>;
   on(event: string, handler: (params: Record<string, unknown>) => void): void;
   off(event: string, handler: (params: Record<string, unknown>) => void): void;
   isConnected: boolean;
@@ -164,6 +172,8 @@ export interface EvalOptions {
   timeout?: number;
   /** Internal absolute deadline used to bound reconnect and transport waits. */
   deadline?: number;
+  /** Internal CDP object group used to release late remote completions. */
+  objectGroup?: string;
 }
 
 // ── Metro Events ──

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -162,6 +162,8 @@ export interface EvalOptions {
   awaitPromise?: boolean;
   /** CDP timeout in milliseconds (default: 10000) */
   timeout?: number;
+  /** Internal absolute deadline used to bound reconnect and transport waits. */
+  deadline?: number;
 }
 
 // ── Metro Events ──

--- a/src/plugins/automation.ts
+++ b/src/plugins/automation.ts
@@ -7,14 +7,7 @@ import {
   MAX_FIBER_DEPTH,
   MAX_FIBER_NODES,
 } from '../utils/fiber.js';
-
-const CURRENT_ROUTE_JS = `(function() {
-  try {
-    var n = globalThis.__METRO_MCP_NAV_REF__;
-    if (n && n.getCurrentRoute) { var r = n.getCurrentRoute(); return r ? r.name : null; }
-  } catch(e) {}
-  return null;
-})()`;
+import { readFocusedRoute } from '../utils/navigation.js';
 
 export const automationPlugin = definePlugin({
   name: 'automation',
@@ -137,15 +130,21 @@ export const automationPlugin = definePlugin({
         const pollInterval = 300;
         while (Date.now() - start < timeout) {
           try {
-            const current = await ctx.evalInApp(CURRENT_ROUTE_JS);
-            if (current === routeName) {
+            const current = await readFocusedRoute(
+              ctx.evalInApp,
+              Math.max(1, timeout - (Date.now() - start)),
+            );
+            if (current?.name === routeName) {
               return { route: routeName, elapsedMs: Date.now() - start };
             }
           } catch {
             // keep polling
           }
           await sendProgress?.(Date.now() - start, timeout, `Waiting for route "${routeName}"…`);
-          await new Promise<void>((r) => setTimeout(r, pollInterval));
+          const remaining = timeout - (Date.now() - start);
+          if (remaining > 0) {
+            await new Promise<void>((r) => setTimeout(r, Math.min(pollInterval, remaining)));
+          }
         }
         throw new Error(
           `Timed out after ${timeout}ms waiting for route "${routeName}". ` +

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -79,9 +79,9 @@ async function createHarness(
   plugins: PluginDefinition[],
 ) {
   // Runtime.evaluate executes against a persistent global object. A VM
-  // context exercises that behavior, including indirect eval used by the
-  // awaited mailbox path; wrapping snippets in new Function(globalThis) does
-  // not provide equivalent global declaration semantics.
+  // context exercises that behavior. Wrapping snippets in new
+  // Function(globalThis) does not provide equivalent global declaration
+  // semantics.
   const appGlobal = vm.createContext({
     ...runtime,
     setTimeout,
@@ -122,9 +122,13 @@ async function createHarness(
       truncate: (value: string) => value,
       structureOnly: (value: ComponentNode) => value,
     },
-    evalInApp: async (expression) => {
+    evalInApp: async (expression, options) => {
       // Mirror returnByValue without assuming CDP awaits an app's JS Promise.
       const result = new vm.Script(expression).runInContext(appGlobal);
+      if (options?.awaitPromise && result && typeof result === 'object' &&
+          typeof (result as Promise<unknown>).then === 'function') {
+        return result;
+      }
       return result === undefined
         ? undefined
         : JSON.parse(JSON.stringify(result));

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import vm from 'node:vm';
 import type { z } from 'zod';
 import type {
   ComponentNode,
@@ -77,6 +78,15 @@ async function createHarness(
   runtime: Record<string, unknown>,
   plugins: PluginDefinition[],
 ) {
+  // Runtime.evaluate executes against a persistent global object. A VM
+  // context exercises that behavior, including indirect eval used by the
+  // awaited mailbox path; wrapping snippets in new Function(globalThis) does
+  // not provide equivalent global declaration semantics.
+  const appGlobal = vm.createContext({
+    ...runtime,
+    setTimeout,
+    clearTimeout,
+  });
   const tools = new Map<string, RegisteredTool>();
   const registerTool: PluginContext['registerTool'] = (name, config) => {
     tools.set(name, {
@@ -113,12 +123,8 @@ async function createHarness(
       structureOnly: (value: ComponentNode) => value,
     },
     evalInApp: async (expression) => {
-      const evaluate = new Function(
-        'globalThis',
-        `return ${expression};`,
-      ) as (globalObject: Record<string, unknown>) => unknown;
       // Mirror returnByValue without assuming CDP awaits an app's JS Promise.
-      const result = evaluate(runtime);
+      const result = new vm.Script(expression).runInContext(appGlobal);
       return result === undefined
         ? undefined
         : JSON.parse(JSON.stringify(result));

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { awaitAppResult } from '../utils/await-app-result.js';
 import {
   DEFAULT_FIBER_MAX_DEPTH,
   DEFAULT_FIBER_MAX_NODES,
@@ -184,7 +183,7 @@ export const inspectPointPlugin = definePlugin({
           true,
         );
 
-        return awaitAppResult(ctx.evalInApp, expression);
+        return ctx.evalInApp(expression, { awaitPromise: true });
       },
     });
   },

--- a/src/plugins/navigation.test.ts
+++ b/src/plugins/navigation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from 'bun:test';
+import vm from 'node:vm';
+import type { z } from 'zod';
+import type { EvalOptions, PluginContext, ToolHandlerContext } from '../plugin.js';
+import { getFocusedRoute } from '../utils/navigation.js';
+import { createAppEvaluator } from '../utils/evaluate-app.js';
+import { automationPlugin } from './automation.js';
+import { navigationPlugin } from './navigation.js';
+
+interface RegisteredTool {
+  parameters: z.ZodType;
+  handler(args: Record<string, unknown>, ctx: ToolHandlerContext): Promise<unknown>;
+}
+
+async function harness(runtime: Record<string, unknown>) {
+  const tools = new Map<string, RegisteredTool>();
+  const timeouts: Array<number | undefined> = [];
+  const appGlobal = vm.createContext({ ...runtime, setTimeout, clearTimeout });
+  const evaluate = createAppEvaluator({
+    send: async (_method, params) => {
+      const result = new vm.Script(String(params?.expression)).runInContext(appGlobal);
+      // Hermes serializes promises instead of honoring CDP awaitPromise.
+      return { result: { value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)) } };
+    },
+  }, {
+    ensureConnected: async () => {},
+    waitForReconnect: async () => {},
+    reconnect: async () => {},
+    isReconnecting: () => false,
+  });
+  const registerTool: PluginContext['registerTool'] = (name, config) => {
+    tools.set(name, config as unknown as RegisteredTool);
+  };
+  const context = {
+    registerTool,
+    registerAppResource() {},
+    registerResource() {},
+    evalInApp: async (expression: string, options?: EvalOptions) => {
+      timeouts.push(options?.timeout);
+      // The shared evaluator owns promise resolution; the plugins must request it.
+      expect(options?.awaitPromise).toBe(true);
+      return evaluate(expression, options);
+    },
+    format: { compact: JSON.stringify },
+  } as unknown as PluginContext;
+  await navigationPlugin.setup(context);
+  await automationPlugin.setup(context);
+  return {
+    timeouts,
+    async call(name: string, args: Record<string, unknown> = {}) {
+      const tool = tools.get(name)!;
+      return tool.handler(tool.parameters.parse(args) as Record<string, unknown>, {});
+    },
+  };
+}
+
+function state(name: string) {
+  return { index: 0, routes: [{ name, key: `${name}-key`, params: { id: 1 } }] };
+}
+
+function fiberRuntime(navigation: unknown, depth = 255) {
+  let current: Record<string, unknown> = {
+    type: { displayName: 'NavigationContainerInner' },
+    memoizedState: { queue: { lastRenderedState: navigation } },
+  };
+  for (let index = 0; index < depth; index++) {
+    current = { type: { displayName: 'Provider' }, child: current };
+  }
+  return {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: {
+      getFiberRoots: (id: number) => id === 12 ? new Set([{ current }]) : new Set(),
+    },
+  };
+}
+
+describe('navigation inspection and waits', () => {
+  for (const bridgeName of ['__METRO_BRIDGE__', '__METRO_MCP__']) {
+    test(`an already focused SDK route works without a nav ref (${bridgeName})`, async () => {
+      const nav = state('Home');
+      const { call } = await harness({ [bridgeName]: { navigation: { getState: () => nav } } });
+      expect(await call('get_navigation_state')).toEqual(nav);
+      expect(await call('get_current_route')).toEqual(nav.routes[0]);
+      expect(await call('wait_for_navigation', { routeName: 'Home', timeout: 100 }))
+        .toMatchObject({ route: 'Home', elapsedMs: expect.any(Number) });
+    });
+  }
+
+  test('waits for a later nested transition from an asynchronous SDK', async () => {
+    let reads = 0;
+    const { call } = await harness({
+      __METRO_BRIDGE__: { navigation: { getState: async () => {
+        reads++;
+        return { routes: [{ name: 'Tabs', state: state(reads === 1 ? 'Home' : 'Profile') }] };
+      } } },
+    });
+    expect(await call('wait_for_navigation', { routeName: 'Profile', timeout: 1000 }))
+      .toMatchObject({ route: 'Profile' });
+    expect(reads).toBe(2);
+    expect(await call('get_current_route')).toEqual(state('Profile').routes[0]);
+  });
+
+  test('discovers deep Fiber state in renderer 12 for both tools', async () => {
+    const nav = { routes: [{ name: 'Root', state: state('Details') }] };
+    const { call } = await harness(fiberRuntime(nav));
+    expect(await call('get_navigation_state')).toEqual(nav);
+    expect(await call('get_current_route')).toEqual(state('Details').routes[0]);
+    expect(await call('wait_for_navigation', { routeName: 'Details', timeout: 100 }))
+      .toMatchObject({ route: 'Details' });
+  });
+
+  test('retains a current-route-only navigation ref', async () => {
+    const route = state('Home').routes[0];
+    const { call } = await harness({ __METRO_MCP_NAV_REF__: { getCurrentRoute: () => route } });
+    expect(await call('get_current_route')).toEqual(route);
+    expect(await call('wait_for_navigation', { routeName: 'Home', timeout: 100 }))
+      .toMatchObject({ route: 'Home' });
+  });
+
+  test('falls back from an unavailable SDK to Expo state', async () => {
+    const { call } = await harness({
+      __METRO_BRIDGE__: { navigation: { getState: async () => { throw new Error('not ready'); } } },
+      __EXPO_ROUTER_STATE__: () => state('ExpoHome'),
+    });
+    expect(await call('get_current_route')).toEqual(state('ExpoHome').routes[0]);
+  });
+
+  test('does not call an unavailable SDK again during Fiber fallback', async () => {
+    let reads = 0;
+    const { call } = await harness({
+      ...fiberRuntime(state('FiberHome')),
+      __METRO_BRIDGE__: { navigation: { getState: async () => {
+        reads++;
+        throw new Error('not ready');
+      } } },
+    });
+    expect(await call('get_current_route')).toEqual(state('FiberHome').routes[0]);
+    expect(reads).toBe(1);
+  });
+
+  test('times out when the route remains different, bounding each evaluation', async () => {
+    const { call, timeouts } = await harness({
+      __METRO_MCP_NAV_REF__: { getRootState: () => state('Home') },
+    });
+    await expect(call('wait_for_navigation', { routeName: 'Missing', timeout: 100 }))
+      .rejects.toThrow('Timed out after 100ms waiting for route "Missing"');
+    expect(timeouts.length).toBeGreaterThan(0);
+    expect(timeouts.every((timeout) => timeout! > 0 && timeout! <= 100)).toBe(true);
+  });
+
+  test('missing state preserves inspection messages and navigation timeout', async () => {
+    const { call } = await harness({});
+    expect(await call('get_current_route')).toBe('No focused route found.');
+    await expect(call('wait_for_navigation', { routeName: 'Home', timeout: 100 }))
+      .rejects.toThrow('Timed out');
+  });
+});
+
+test('focused route resolution handles empty, invalid, and cyclic states', () => {
+  for (const input of [null, {}, { routes: [] }, { index: 5, routes: [{ name: 'Home' }] }]) {
+    expect(getFocusedRoute(input)).toBeNull();
+  }
+  const cycle: { routes: Array<{ name: string; state?: unknown }> } = { routes: [{ name: 'Loop' }] };
+  cycle.routes[0].state = cycle;
+  expect(getFocusedRoute(cycle)).toBeNull();
+  expect(getFocusedRoute({ routes: [{ name: 'Home' }, { name: 'Details' }] }))
+    .toEqual({ name: 'Details', params: {}, key: undefined });
+});

--- a/src/plugins/navigation.test.ts
+++ b/src/plugins/navigation.test.ts
@@ -16,11 +16,63 @@ async function harness(runtime: Record<string, unknown>) {
   const tools = new Map<string, RegisteredTool>();
   const timeouts: Array<number | undefined> = [];
   const appGlobal = vm.createContext({ ...runtime, setTimeout, clearTimeout });
+  let nextObjectId = 0;
+  const remoteObjects = new Map<string, { value: unknown; group?: string }>();
   const evaluate = createAppEvaluator({
-    send: async (_method, params) => {
-      const result = new vm.Script(String(params?.expression)).runInContext(appGlobal);
-      // Hermes serializes promises instead of honoring CDP awaitPromise.
-      return { result: { value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)) } };
+    send: async (method, params) => {
+      const actualParams = params ?? {};
+      if (method === 'Runtime.evaluate') {
+        const result = new vm.Script(String(actualParams.expression)).runInContext(appGlobal);
+        // Model Hermes' Runtime.evaluate behavior: awaitPromise is ignored,
+        // and a non-by-value completion is retained as a remote object. The
+        // production evaluator then attaches settlement to that object with
+        // Runtime.callFunctionOn instead of replaying the user's expression.
+        if (actualParams.returnByValue === false && result !== null &&
+            (typeof result === 'object' || typeof result === 'function')) {
+          const objectId = `remote-${++nextObjectId}`;
+          remoteObjects.set(objectId, {
+            value: result,
+            group: typeof actualParams.objectGroup === 'string'
+              ? actualParams.objectGroup
+              : undefined,
+          });
+          return {
+            result: {
+              type: 'object',
+              ...(typeof (result as { then?: unknown }).then === 'function'
+                ? { subtype: 'promise' }
+                : {}),
+              objectId,
+            },
+          };
+        }
+        return {
+          result: {
+            value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)),
+          },
+        };
+      }
+      if (method === 'Runtime.callFunctionOn') {
+        const remote = remoteObjects.get(String(actualParams.objectId));
+        if (!remote) return { result: { value: false } };
+        const fn = new vm.Script(`(${String(actualParams.functionDeclaration)})`)
+          .runInContext(appGlobal) as (...args: unknown[]) => unknown;
+        const args = (actualParams.arguments as Array<{ value: unknown }> | undefined)
+          ?.map((argument) => argument.value) ?? [];
+        const result = fn.call(remote.value, ...args);
+        return { result: { value: result } };
+      }
+      if (method === 'Runtime.releaseObject') {
+        remoteObjects.delete(String(actualParams.objectId));
+        return {};
+      }
+      if (method === 'Runtime.releaseObjectGroup') {
+        for (const [objectId, remote] of remoteObjects) {
+          if (remote.group === actualParams.objectGroup) remoteObjects.delete(objectId);
+        }
+        return {};
+      }
+      throw new Error(`Unexpected CDP method ${method}`);
     },
   }, {
     ensureConnected: async () => {},

--- a/src/plugins/navigation.ts
+++ b/src/plugins/navigation.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import { buildNavigationHtml } from '../apps/navigation.js';
+import { readNavigationState, readFocusedRoute } from '../utils/navigation.js';
 
 export const navigationPlugin = definePlugin({
   name: 'navigation',
@@ -8,65 +9,6 @@ export const navigationPlugin = definePlugin({
   description: 'React Navigation / Expo Router state inspection',
 
   async setup(ctx) {
-    const GET_NAV_STATE_EXPR = `
-      (function() {
-        // Try client SDK first
-        var _b = globalThis.__METRO_BRIDGE__ || globalThis.__METRO_MCP__;
-        if (_b?.navigation?.getState) {
-          return _b.navigation.getState();
-        }
-
-        // Walk fiber tree to find NavigationContainer
-        var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-        if (!hook || !hook.getFiberRoots) return null;
-
-        var fiberRoots;
-        for (var i = 1; i <= 5; i++) {
-          fiberRoots = hook.getFiberRoots(i);
-          if (fiberRoots && fiberRoots.size > 0) break;
-        }
-        if (!fiberRoots || fiberRoots.size === 0) return null;
-
-        var rootFiber = Array.from(fiberRoots)[0].current;
-        var navState = null;
-
-        function findNavState(fiber) {
-          if (!fiber || navState) return;
-          var name = fiber.type?.displayName || fiber.type?.name || '';
-
-          // Look for NavigationContainer or its internals
-          if (name === 'NavigationContainer' || name === 'NavigationContainerInner' || name === 'BaseNavigationContainer') {
-            // The navigation state is stored in memoizedState
-            var state = fiber.memoizedState;
-            while (state) {
-              if (state.memoizedState && state.memoizedState.routes) {
-                navState = state.memoizedState;
-                return;
-              }
-              // Check queue for state updates
-              if (state.queue?.lastRenderedState?.routes) {
-                navState = state.queue.lastRenderedState;
-                return;
-              }
-              state = state.next;
-            }
-
-            // Also check props for state
-            if (fiber.memoizedProps?.state?.routes) {
-              navState = fiber.memoizedProps.state;
-              return;
-            }
-          }
-
-          findNavState(fiber.child);
-          if (!navState) findNavState(fiber.sibling);
-        }
-
-        findNavState(rootFiber);
-        return navState;
-      })()
-    `;
-
     ctx.registerAppResource('ui://metro/navigation', {
       name: 'Navigation Tree',
       description: 'Visual React Navigation / Expo Router route tree with active screen highlighted',
@@ -82,7 +24,7 @@ export const navigationPlugin = definePlugin({
         compact: z.boolean().default(false).describe('Return compact format'),
       }),
       handler: async ({ compact: isCompact }) => {
-        const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
+        const state = await readNavigationState(ctx.evalInApp);
         if (!state) {
           return 'Navigation state not found. Ensure your app uses React Navigation or Expo Router.';
         }
@@ -91,25 +33,12 @@ export const navigationPlugin = definePlugin({
       },
     });
 
-    function getFocusedRoute(s: Record<string, unknown>): Record<string, unknown> | null {
-      const routes = s.routes as Array<Record<string, unknown>>;
-      if (!routes) return null;
-      const idx = s.index !== undefined ? (s.index as number) : routes.length - 1;
-      const route = routes[idx];
-      if (route.state && typeof route.state === 'object') {
-        return getFocusedRoute(route.state as Record<string, unknown>);
-      }
-      return { name: route.name, params: route.params || {}, key: route.key };
-    }
-
     ctx.registerTool('get_current_route', {
       description: 'Get the currently focused route name and params.',
       annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
-        const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
-        if (!state || typeof state !== 'object') return 'No focused route found.';
-        const result = getFocusedRoute(state as Record<string, unknown>);
+        const result = await readFocusedRoute(ctx.evalInApp);
         if (!result) return 'No focused route found.';
         return result;
       },
@@ -120,7 +49,7 @@ export const navigationPlugin = definePlugin({
       annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
-        const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
+        const state = await readNavigationState(ctx.evalInApp);
         if (!state || typeof state !== 'object') return 'Navigation state not found.';
 
         const navState = state as Record<string, unknown>;
@@ -141,7 +70,7 @@ export const navigationPlugin = definePlugin({
       annotations: { readOnlyHint: true },
       parameters: z.object({}),
       handler: async () => {
-        const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
+        const state = await readNavigationState(ctx.evalInApp);
         if (!state || typeof state !== 'object') return 'Navigation state not found.';
 
         const routeNames = new Set<string>();
@@ -165,7 +94,7 @@ export const navigationPlugin = definePlugin({
       description: 'Current React Navigation / Expo Router state',
       handler: async () => {
         try {
-          const state = await ctx.evalInApp(GET_NAV_STATE_EXPR, { awaitPromise: true });
+          const state = await readNavigationState(ctx.evalInApp);
           return JSON.stringify(state, null, 2);
         } catch {
           return JSON.stringify({ error: 'Navigation state not available' });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -177,6 +177,44 @@ describe('scheduled reconnect takeover', () => {
     expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
   });
 
+  test('schedules a retry when the connection drops before a successful attempt settles', async () => {
+    type FakeTimer = { callback: () => void; delay: number; cancelled: boolean };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let resolveAttempt: ((connected: boolean) => void) | undefined;
+    let isConnected = true;
+    const controller = createReconnectController({
+      connect: () => new Promise<boolean>((resolve) => { resolveAttempt = resolve; }),
+      isConnected: () => isConnected,
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [500],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    const attempt = controller.connectNow();
+    await Promise.resolve();
+    // Model connectToTarget opening the socket, then CDP emitting
+    // `disconnected` before performConnectToMetro settles.
+    isConnected = false;
+    controller.schedule();
+    resolveAttempt?.(true);
+
+    await expect(attempt).resolves.toBe(false);
+    expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
+    expect(timers.find((timer) => !timer.cancelled)?.delay).toBe(500);
+  });
+
   test('keeps escalated backoff when a reconnect flaps before stability', async () => {
     type FakeTimer = {
       callback: () => void;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { createAppEvaluator } from './utils/evaluate-app.js';
+import { waitForConnectionUntil } from './server.js';
+
+describe('server connection deadlines', () => {
+  test('bounds an initial disconnected awaitPromise wait before source dispatch', async () => {
+    const methods: string[] = [];
+    let waits = 0;
+    const evaluate = createAppEvaluator({
+      send: async (method) => {
+        methods.push(method);
+        return { result: { value: undefined } };
+      },
+    }, {
+      ensureConnected: async (deadline) => {
+        const connected = await waitForConnectionUntil(
+          () => waits++ === 0
+            ? Promise.resolve(false)
+            : new Promise<boolean>(() => {}),
+          deadline,
+        );
+        if (!connected) {
+          await waitForConnectionUntil(
+            () => {
+              waits += 1;
+              return new Promise<boolean>(() => {});
+            },
+            deadline,
+          );
+        }
+      },
+      waitForReconnect: async () => {},
+      reconnect: async () => {},
+      isReconnecting: () => false,
+    });
+
+    const started = Date.now();
+    await expect(evaluate('globalThis.shouldNotRun = true;', {
+      awaitPromise: true,
+      timeout: 30,
+    })).rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(waits).toBe(2);
+    expect(methods.filter((method) => method === 'Runtime.evaluate')).toHaveLength(0);
+  });
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { createAppEvaluator } from './utils/evaluate-app.js';
-import { waitForConnectionUntil } from './server.js';
+import {
+  cancelScheduledReconnect,
+  createReconnectController,
+  waitForConnectionUntil,
+} from './server.js';
 
 describe('server connection deadlines', () => {
   test('bounds an initial disconnected awaitPromise wait before source dispatch', async () => {
@@ -42,5 +46,223 @@ describe('server connection deadlines', () => {
     expect(Date.now() - started).toBeLessThan(500);
     expect(waits).toBe(2);
     expect(methods.filter((method) => method === 'Runtime.evaluate')).toHaveLength(0);
+  });
+});
+
+describe('scheduled reconnect takeover', () => {
+  test('preempts a long backoff for a tool request and is idempotent', () => {
+    let scheduledCallback: (() => void) | undefined;
+    let scheduledDelay = 0;
+    let scheduledCancelled = false;
+    let attempts = 0;
+    const timers = {
+      clearTimeout() {
+        scheduledCancelled = true;
+      },
+    };
+    const state = { timer: null as ReturnType<typeof setTimeout> | null };
+    const timer = { callback: () => { attempts += 1; }, delay: 30_000 };
+    scheduledCallback = timer.callback;
+    scheduledDelay = timer.delay;
+    state.timer = timer as unknown as ReturnType<typeof setTimeout>;
+
+    expect(cancelScheduledReconnect(state, timers)).toBe(true);
+    expect(state.timer).toBeNull();
+    expect(scheduledCancelled).toBe(true);
+
+    // A concurrent tool request observes that the first request already
+    // claimed the scheduled retry and must not cancel or dispatch another one.
+    expect(cancelScheduledReconnect(state, timers)).toBe(false);
+    expect(scheduledDelay).toBe(30_000);
+
+    // Model a direct lifecycle.reconnect that starts immediately. The timer's
+    // callback is still present in the harness, but cancellation prevents it
+    // from starting a duplicate attempt after the on-demand one succeeds.
+    attempts += 1;
+    if (!scheduledCancelled) scheduledCallback?.();
+    expect(attempts).toBe(1);
+  });
+
+  test('retains one background retry when the tool deadline expires first', async () => {
+    type FakeTimer = {
+      callback: () => void;
+      delay: number;
+      cancelled: boolean;
+    };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let resolveAttempt: ((connected: boolean) => void) | undefined;
+    let attempts = 0;
+    const controller = createReconnectController({
+      connect: () => {
+        attempts += 1;
+        return new Promise<boolean>((resolve) => {
+          resolveAttempt = resolve;
+        });
+      },
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [30_000],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    controller.schedule();
+    const queued = timers[0]!;
+    expect(queued.delay).toBe(30_000);
+    const takeover = controller.connectNow();
+    expect(queued.cancelled).toBe(true);
+    // The caller can time out while the runtime-owned attempt continues.
+    const callerDeadline = Promise.race([
+      takeover,
+      Promise.resolve().then(() => {
+        throw new Error('App evaluation timed out');
+      }),
+    ]);
+    await expect(callerDeadline).rejects.toThrow('timed out');
+    resolveAttempt?.(false);
+    await expect(takeover).resolves.toBe(false);
+
+    expect(attempts).toBe(1);
+    expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
+    expect(timers.find((timer) => !timer.cancelled)?.delay).toBe(30_000);
+  });
+
+  test('shares a direct reconnect and schedules only one retry after failure', async () => {
+    type FakeTimer = { callback: () => void; delay: number; cancelled: boolean };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let resolveAttempt: ((connected: boolean) => void) | undefined;
+    let attempts = 0;
+    const controller = createReconnectController({
+      connect: () => {
+        attempts += 1;
+        return new Promise<boolean>((resolve) => {
+          resolveAttempt = resolve;
+        });
+      },
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [30_000],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    controller.schedule();
+    const first = controller.connectNow();
+    const second = controller.connectNow();
+    expect(first).toBe(second);
+    await Promise.resolve();
+    resolveAttempt?.(false);
+    await expect(first).resolves.toBe(false);
+    expect(attempts).toBe(1);
+    expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
+  });
+
+  test('keeps escalated backoff when a reconnect flaps before stability', async () => {
+    type FakeTimer = {
+      callback: () => void;
+      delay: number;
+      cancelled: boolean;
+    };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    const outcomes = [false, false, true];
+    const controller = createReconnectController({
+      connect: async () => outcomes.shift() ?? false,
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [500, 1000, 2000, 4000],
+      maxBurstAttempts: 4,
+      backgroundDelay: 30_000,
+    });
+
+    const fireNext = async (): Promise<void> => {
+      const timer = timers.find((candidate) => !candidate.cancelled);
+      expect(timer).toBeDefined();
+      timer!.cancelled = true;
+      timer!.callback();
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    };
+
+    controller.schedule();
+    expect(timers[0]?.delay).toBe(500);
+    await fireNext();
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(1000);
+    await fireNext();
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(2000);
+    await fireNext();
+
+    // The target reconnected, then flapped before the 5-second stability
+    // timer could reset the backoff. The next disconnect remains escalated.
+    controller.schedule();
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(4000);
+  });
+
+  test('does not reset escalated backoff for repeated foreground reconnects', async () => {
+    type FakeTimer = { callback: () => void; delay: number; cancelled: boolean };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let attempts = 0;
+    const controller = createReconnectController({
+      connect: async () => {
+        attempts += 1;
+        return false;
+      },
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [500],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    controller.schedule();
+    const firstTimer = timers[0]!;
+    firstTimer.cancelled = true;
+    firstTimer.callback();
+    for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    expect(attempts).toBe(1);
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(30_000);
+
+    await expect(controller.connectNow()).resolves.toBe(false);
+    await expect(controller.connectNow()).resolves.toBe(false);
+    expect(attempts).toBe(3);
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(30_000);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -243,6 +243,7 @@ export async function createMetroRuntime(
   const MAX_BURST_ATTEMPTS = 15; // fast retries; after this, switch to slow background probe
   let reconnectAttempts = 0;
   let isReconnecting = false;
+  let runtimeGeneration = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectStabilityTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -309,6 +310,7 @@ export async function createMetroRuntime(
 
   // Enable required CDP domains on every connection (initial and reconnect).
   cdpSession.on('reconnected', async () => {
+    runtimeGeneration++;
     isReconnecting = false;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
@@ -327,6 +329,7 @@ export async function createMetroRuntime(
 
   // Drive all reconnection through connectToMetro() so we always get a fresh target URL.
   cdpSession.on('disconnected', () => {
+    runtimeGeneration++;
     clearReconnectStabilityTimer();
     cleanProxyLock();
     scheduleReconnect();
@@ -338,6 +341,7 @@ export async function createMetroRuntime(
   // Metro fires 'bundle_build_done' once the new bundle is ready to run.
   eventsClient.on('bundle_build_done', async () => {
     if (!cdpSession.isConnected) return;
+    runtimeGeneration++;
     logger.info('Metro bundle rebuilt — re-enabling CDP domains');
     await enableCDPDomains();
   });
@@ -392,6 +396,7 @@ export async function createMetroRuntime(
       },
       waitForReconnect,
       isReconnecting: () => isReconnecting,
+      getGeneration: () => runtimeGeneration,
       reconnect: async () => {
         reconnectAttempts = 0;
         await connectToMetro();

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,12 +136,117 @@ export interface ReconnectWaitTimers {
   clearTimeout(handle: ReturnType<typeof setTimeout>): void;
 }
 
+export interface ReconnectTimerState {
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+export interface ReconnectController {
+  schedule(): void;
+  connectNow(): Promise<boolean>;
+  cancelScheduled(): boolean;
+  isReconnecting(): boolean;
+  resetBackoff(): void;
+}
+
+interface ReconnectControllerOptions {
+  connect: () => Promise<boolean>;
+  isClosed: () => boolean;
+  timers?: Pick<ReconnectWaitTimers, 'setTimeout' | 'clearTimeout'>;
+  delays?: readonly number[];
+  maxBurstAttempts?: number;
+  backgroundDelay?: number;
+  onSchedule?: (delay: number, attempt: number) => void;
+}
+
 const reconnectWaitTimers: ReconnectWaitTimers = {
   setInterval,
   clearInterval,
   setTimeout,
   clearTimeout,
 };
+
+/**
+ * Cancel a background reconnect that has not started connecting yet.
+ *
+ * Keeping the timer separate from the active-attempt state lets an on-demand
+ * tool request take over a long backoff immediately. The null check also makes
+ * concurrent callers idempotent: only the first caller can claim the timer.
+ */
+export function cancelScheduledReconnect(
+  state: ReconnectTimerState,
+  timers: Pick<ReconnectWaitTimers, 'clearTimeout'> = reconnectWaitTimers,
+): boolean {
+  if (state.timer === null) return false;
+  timers.clearTimeout(state.timer);
+  state.timer = null;
+  return true;
+}
+
+/**
+ * Own reconnect scheduling independently of any caller waiting on an attempt.
+ * A deadline-bounded caller may stop awaiting connectNow(), but the runtime
+ * still observes the result and keeps background recovery alive.
+ */
+export function createReconnectController(
+  options: ReconnectControllerOptions,
+): ReconnectController {
+  const timers = options.timers ?? reconnectWaitTimers;
+  const delays = options.delays ?? [500, 1000, 2000, 4000, 8000, 16000];
+  const maxBurstAttempts = options.maxBurstAttempts ?? 15;
+  const backgroundDelay = options.backgroundDelay ?? 30000;
+  const timerState: ReconnectTimerState = { timer: null };
+  let attempts = 0;
+  let activeAttempt: Promise<boolean> | null = null;
+
+  const cancelScheduled = (): boolean =>
+    cancelScheduledReconnect(timerState, timers);
+
+  const schedule = (): void => {
+    if (options.isClosed() || timerState.timer !== null || activeAttempt) return;
+    const delay = attempts < maxBurstAttempts
+      ? delays[Math.min(attempts, delays.length - 1)]!
+      : backgroundDelay;
+    attempts++;
+    options.onSchedule?.(delay, attempts);
+    timerState.timer = timers.setTimeout(() => {
+      timerState.timer = null;
+      void connectNow().catch(() => {});
+    }, delay);
+  };
+
+  const connectNow = (): Promise<boolean> => {
+    cancelScheduled();
+    if (activeAttempt) return activeAttempt;
+    const rawAttempt = Promise.resolve().then(options.connect);
+    let ownedAttempt!: Promise<boolean>;
+    ownedAttempt = rawAttempt.then(
+      (connected) => {
+        // Clear active ownership before scheduling the next background retry;
+        // schedule() must be able to claim the newly available slot.
+        if (activeAttempt === ownedAttempt) activeAttempt = null;
+        if (!connected) schedule();
+        return connected;
+      },
+      (error) => {
+        if (activeAttempt === ownedAttempt) activeAttempt = null;
+        schedule();
+        throw error;
+      },
+    );
+    activeAttempt = ownedAttempt;
+    return ownedAttempt;
+  };
+
+  return {
+    schedule,
+    connectNow,
+    cancelScheduled,
+    isReconnecting: () => activeAttempt !== null,
+    resetBackoff: () => {
+      attempts = 0;
+    },
+  };
+}
 
 export function waitForReconnect(
   isReconnecting: () => boolean,
@@ -332,20 +437,16 @@ export async function createMetroRuntime(
   let activeDeviceName: string | null = null;
   let targetPin: MetroTargetPin | null = null;
 
-  // Server-side reconnect state — single source of truth for all reconnect logic.
-  // Start with a very short delay (500ms) to recover quickly from brief disconnects
-  // like hot reloads, then ramp up for longer outages.
-  const RECONNECT_DELAYS = [500, 1000, 2000, 4000, 8000, 16000];
   const RECONNECT_STABLE_MS = 5000;
-  const MAX_BURST_ATTEMPTS = 15; // fast retries; after this, switch to slow background probe
-  let reconnectAttempts = 0;
-  let isReconnecting = false;
+  let reconnectController: ReconnectController | null = null;
   let runtimeGeneration = 0;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectStabilityTimer: ReturnType<typeof setTimeout> | null = null;
 
   const waitForCurrentReconnect = (deadline?: number): Promise<void> =>
-    waitForReconnect(() => isReconnecting, deadline);
+    waitForReconnect(
+      () => reconnectController?.isReconnecting() ?? false,
+      deadline,
+    );
 
   function clearReconnectStabilityTimer(): void {
     if (reconnectStabilityTimer) {
@@ -396,17 +497,13 @@ export async function createMetroRuntime(
   // Enable required CDP domains on every connection (initial and reconnect).
   cdpSession.on('reconnected', async () => {
     runtimeGeneration++;
-    isReconnecting = false;
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    reconnectController?.cancelScheduled();
     await enableCDPDomains();
     clearReconnectStabilityTimer();
     reconnectStabilityTimer = setTimeout(() => {
       reconnectStabilityTimer = null;
       if (!runtimeClosed && cdpSession.isConnected) {
-        reconnectAttempts = 0;
+        reconnectController?.resetBackoff();
         logger.debug('CDP connection stable; reset reconnect backoff');
       }
     }, RECONNECT_STABLE_MS);
@@ -461,14 +558,20 @@ export async function createMetroRuntime(
     const evalInApp = createAppEvaluator(cdpSession, {
       ensureConnected: async (deadline?: number) => {
         if (!cdpSession.isConnected) {
-          if (isReconnecting) {
+          if (reconnectController?.isReconnecting()) {
             // A reconnect is already in flight — wait for it rather than
             // starting another one.
             await waitForCurrentReconnect(deadline);
+          } else if (reconnectController?.cancelScheduled()) {
+            // A background retry may be waiting behind a long backoff. An
+            // on-demand tool request should claim that retry and connect now,
+            // rather than consuming its shorter deadline waiting for the timer.
+            const connected = await waitForConnectionUntil(
+              () => connectToMetro(),
+              deadline,
+            );
+            if (!connected) scheduleReconnect();
           } else {
-            // Reset the attempt counter so the background scheduler can resume
-            // after this tool-triggered reconnect, rather than staying capped.
-            reconnectAttempts = 0;
             const connected = await waitForConnectionUntil(
               () => cdpSession.waitForConnection(),
               deadline,
@@ -488,10 +591,9 @@ export async function createMetroRuntime(
         }
       },
       waitForReconnect: waitForCurrentReconnect,
-      isReconnecting: () => isReconnecting,
+      isReconnecting: () => reconnectController?.isReconnecting() ?? false,
       getGeneration: () => runtimeGeneration,
       reconnect: async () => {
-        reconnectAttempts = 0;
         await connectToMetro();
       },
     });
@@ -840,12 +942,7 @@ export async function createMetroRuntime(
 
   // Connect to Metro — always re-discovers targets to get a fresh webSocketDebuggerUrl.
   // Idempotent: concurrent callers wait for the in-flight attempt to finish.
-  async function connectToMetro(): Promise<boolean> {
-    if (isReconnecting) {
-      await waitForCurrentReconnect();
-      return cdpSession.isConnected;
-    }
-    isReconnecting = true;
+  async function performConnectToMetro(): Promise<boolean> {
     try {
       const proxyEnabled = config.proxy?.enabled !== false;
 
@@ -932,40 +1029,25 @@ export async function createMetroRuntime(
     } catch (err) {
       logger.warn('Could not connect to Metro:', err);
       return false;
-    } finally {
-      isReconnecting = false;
     }
+  }
+
+  reconnectController = createReconnectController({
+    connect: performConnectToMetro,
+    isClosed: () => runtimeClosed,
+    onSchedule: (delay, attempt) => {
+      logger.info(`Reconnecting to Metro in ${delay}ms (attempt ${attempt})`);
+    },
+  });
+
+  async function connectToMetro(): Promise<boolean> {
+    return reconnectController!.connectNow();
   }
 
   // Schedule a reconnect with exponential backoff, driven from server.ts so we always
   // re-fetch a fresh target URL from Metro's /json endpoint.
   function scheduleReconnect(): void {
-    if (runtimeClosed) return;
-    if (reconnectTimer !== null || isReconnecting) return; // already scheduled or in progress
-
-    // Use exponential backoff for the initial burst, then fall back to a slow
-    // background probe so the server keeps trying indefinitely (e.g. app started
-    // long after the MCP server).
-    const delay =
-      reconnectAttempts < MAX_BURST_ATTEMPTS
-        ? RECONNECT_DELAYS[
-            Math.min(reconnectAttempts, RECONNECT_DELAYS.length - 1)
-          ]
-        : 30000;
-    reconnectAttempts++;
-    logger.info(
-      `Reconnecting to Metro in ${delay}ms (attempt ${reconnectAttempts})`,
-    );
-
-    isReconnecting = true;
-    reconnectTimer = setTimeout(async () => {
-      reconnectTimer = null;
-      isReconnecting = false;
-      const success = await connectToMetro();
-      if (!success) {
-        scheduleReconnect();
-      }
-    }, delay);
+    reconnectController?.schedule();
   }
 
   // CDP proxy for Chrome DevTools coexistence — started lazily on first connect.
@@ -1094,10 +1176,7 @@ export async function createMetroRuntime(
   function closeRuntime(): Promise<void> {
     if (runtimeClosePromise) return runtimeClosePromise;
     runtimeClosed = true;
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    reconnectController?.cancelScheduled();
     clearReconnectStabilityTimer();
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);

--- a/src/server.ts
+++ b/src/server.ts
@@ -302,6 +302,9 @@ export async function createMetroRuntime(
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectStabilityTimer: ReturnType<typeof setTimeout> | null = null;
 
+  const waitForCurrentReconnect = (deadline?: number): Promise<void> =>
+    waitForReconnect(() => isReconnecting, deadline);
+
   function clearReconnectStabilityTimer(): void {
     if (reconnectStabilityTimer) {
       clearTimeout(reconnectStabilityTimer);
@@ -419,7 +422,7 @@ export async function createMetroRuntime(
           if (isReconnecting) {
             // A reconnect is already in flight — wait for it rather than
             // starting another one.
-            await waitForReconnect(() => isReconnecting, deadline);
+            await waitForCurrentReconnect(deadline);
           } else {
             // Reset the attempt counter so the background scheduler can resume
             // after this tool-triggered reconnect, rather than staying capped.
@@ -434,8 +437,7 @@ export async function createMetroRuntime(
           );
         }
       },
-      waitForReconnect: (deadline?: number) =>
-        waitForReconnect(() => isReconnecting, deadline),
+      waitForReconnect: waitForCurrentReconnect,
       isReconnecting: () => isReconnecting,
       getGeneration: () => runtimeGeneration,
       reconnect: async () => {
@@ -790,7 +792,7 @@ export async function createMetroRuntime(
   // Idempotent: concurrent callers wait for the in-flight attempt to finish.
   async function connectToMetro(): Promise<boolean> {
     if (isReconnecting) {
-      await waitForReconnect(() => isReconnecting);
+      await waitForCurrentReconnect();
       return cdpSession.isConnected;
     }
     isReconnecting = true;

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,6 @@ import type {
   ResourceConfig,
   AppResourceConfig,
   PromptConfig,
-  EvalOptions,
 } from './plugin.js';
 import {
   CDPSession,
@@ -47,7 +46,7 @@ import type { MetroTarget } from 'metro-bridge';
 import { MetroEventsClient } from './metro/events.js';
 import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
-import { extractCDPExceptionMessage } from './utils/cdp.js';
+import { createAppEvaluator } from './utils/evaluate-app.js';
 import { createPreferredFrameSizeMeta, withAppSizing } from './utils/apps.js';
 import { ResourceSubscriptionManager } from './utils/resource-subscriptions.js';
 import { createResourceUpdateScheduler } from './utils/resource-updates.js';
@@ -370,6 +369,34 @@ export async function createMetroRuntime(
     cfg: Required<MetroMCPConfig>,
   ): PluginContext {
     const pluginLogger = createLogger(plugin.name);
+    const evalInApp = createAppEvaluator(cdpSession, {
+      ensureConnected: async () => {
+        if (!cdpSession.isConnected) {
+          if (isReconnecting) {
+            // A reconnect is already in flight — wait for it rather than
+            // starting another one.
+            await waitForReconnect();
+          } else {
+            // Reset the attempt counter so the background scheduler can resume
+            // after this tool-triggered reconnect, rather than staying capped.
+            reconnectAttempts = 0;
+            const connected = await cdpSession.waitForConnection();
+            if (!connected) await connectToMetro();
+          }
+        }
+        if (!cdpSession.isConnected) {
+          throw new Error(
+            'Not connected to Metro. Use list_devices to check connection status.',
+          );
+        }
+      },
+      waitForReconnect,
+      isReconnecting: () => isReconnecting,
+      reconnect: async () => {
+        reconnectAttempts = 0;
+        await connectToMetro();
+      },
+    });
     return {
       cdp: cdpSession,
       events: eventsClient,
@@ -541,61 +568,7 @@ export async function createMetroRuntime(
           pluginLogger.error(`Failed to register prompt ${name}:`, err);
         }
       },
-      evalInApp: async (expression: string, options?: EvalOptions) => {
-        async function tryEval() {
-          if (!cdpSession.isConnected) {
-            if (isReconnecting) {
-              // A reconnect is already in flight — wait for it rather than starting another
-              await waitForReconnect();
-            } else {
-              // Reset the attempt counter so the background scheduler can resume
-              // after this tool-triggered reconnect, rather than staying capped out.
-              reconnectAttempts = 0;
-              const connected = await cdpSession.waitForConnection();
-              if (!connected) await connectToMetro();
-            }
-          }
-          if (!cdpSession.isConnected) {
-            throw new Error(
-              'Not connected to Metro. Use list_devices to check connection status.',
-            );
-          }
-          const result = (await cdpSession.send('Runtime.evaluate', {
-            expression,
-            returnByValue: true,
-            awaitPromise: options?.awaitPromise ?? false,
-            timeout: options?.timeout,
-          })) as Record<string, unknown>;
-          if (result.exceptionDetails) {
-            throw new Error(
-              extractCDPExceptionMessage(
-                result.exceptionDetails as Record<string, unknown>,
-              ),
-            );
-          }
-          return (result.result as Record<string, unknown>).value;
-        }
-        try {
-          return await tryEval();
-        } catch (err) {
-          if (
-            err instanceof Error &&
-            (err.message === 'WebSocket closed' ||
-              err.message === 'Not connected to CDP target' ||
-              err.message ===
-                'Not connected to Metro. Use list_devices to check connection status.')
-          ) {
-            if (isReconnecting) {
-              await waitForReconnect();
-            } else {
-              reconnectAttempts = 0;
-              await connectToMetro();
-            }
-            return await tryEval();
-          }
-          throw err;
-        }
-      },
+      evalInApp,
       config: cfg as unknown as Record<string, unknown>,
       logger: pluginLogger,
       metro: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -184,6 +184,48 @@ export function waitForReconnect(
   });
 }
 
+/**
+ * Wait for an in-flight CDP connection without allowing it to outlive the
+ * caller's evaluation deadline. The underlying connection attempt cannot be
+ * cancelled, so consume its eventual result while clearing the only timer we
+ * own when either side settles.
+ */
+export function waitForConnectionUntil(
+  waitForConnection: () => Promise<boolean>,
+  deadline?: number,
+  timers: ReconnectWaitTimers = reconnectWaitTimers,
+): Promise<boolean> {
+  if (deadline === undefined) return waitForConnection();
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return Promise.reject(new Error('App evaluation timed out'));
+
+  return new Promise<boolean>((resolve, reject) => {
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = timers.setTimeout(
+      () => {
+        deadlineTimer = null;
+        reject(new Error('App evaluation timed out'));
+      },
+      remaining,
+    );
+    void waitForConnection().then(
+      (connected) => {
+        if (deadlineTimer) {
+          timers.clearTimeout(deadlineTimer);
+          deadlineTimer = null;
+        }
+        resolve(connected);
+      },
+      (error) => {
+        if (deadlineTimer) {
+          timers.clearTimeout(deadlineTimer);
+          deadlineTimer = null;
+        }
+        reject(error);
+      },
+    );
+  });
+}
+
 type RuntimeRegistration = (server: McpServer) => { remove: () => void };
 
 interface McpSession {
@@ -427,8 +469,16 @@ export async function createMetroRuntime(
             // Reset the attempt counter so the background scheduler can resume
             // after this tool-triggered reconnect, rather than staying capped.
             reconnectAttempts = 0;
-            const connected = await cdpSession.waitForConnection();
-            if (!connected) await connectToMetro();
+            const connected = await waitForConnectionUntil(
+              () => cdpSession.waitForConnection(),
+              deadline,
+            );
+            if (!connected) {
+              await waitForConnectionUntil(() => connectToMetro(), deadline);
+            }
+          }
+          if (deadline !== undefined && Date.now() >= deadline) {
+            throw new Error('App evaluation timed out');
           }
         }
         if (!cdpSession.isConnected) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -150,6 +150,8 @@ export interface ReconnectController {
 
 interface ReconnectControllerOptions {
   connect: () => Promise<boolean>;
+  /** Verify that a successful attempt is still connected when it settles. */
+  isConnected?: () => boolean;
   isClosed: () => boolean;
   timers?: Pick<ReconnectWaitTimers, 'setTimeout' | 'clearTimeout'>;
   delays?: readonly number[];
@@ -221,11 +223,17 @@ export function createReconnectController(
     let ownedAttempt!: Promise<boolean>;
     ownedAttempt = rawAttempt.then(
       (connected) => {
+        // A CDP connection can open and emit `reconnected`, then close again
+        // before the owning connect operation settles. Treat that attempt as
+        // failed so its disconnected event cannot be lost behind
+        // activeAttempt ownership.
+        const settledConnected = connected &&
+          (options.isConnected?.() ?? true);
         // Clear active ownership before scheduling the next background retry;
         // schedule() must be able to claim the newly available slot.
         if (activeAttempt === ownedAttempt) activeAttempt = null;
-        if (!connected) schedule();
-        return connected;
+        if (!settledConnected) schedule();
+        return settledConnected;
       },
       (error) => {
         if (activeAttempt === ownedAttempt) activeAttempt = null;
@@ -1034,6 +1042,7 @@ export async function createMetroRuntime(
 
   reconnectController = createReconnectController({
     connect: performConnectToMetro,
+    isConnected: () => cdpSession.isConnected,
     isClosed: () => runtimeClosed,
     onSchedule: (delay, attempt) => {
       logger.info(`Reconnecting to Metro in ${delay}ms (attempt ${attempt})`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,6 +129,61 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   environmentPlugin,
 ];
 
+export interface ReconnectWaitTimers {
+  setInterval(callback: () => void, delay: number): ReturnType<typeof setInterval>;
+  clearInterval(handle: ReturnType<typeof setInterval>): void;
+  setTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout>;
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void;
+}
+
+const reconnectWaitTimers: ReconnectWaitTimers = {
+  setInterval,
+  clearInterval,
+  setTimeout,
+  clearTimeout,
+};
+
+export function waitForReconnect(
+  isReconnecting: () => boolean,
+  deadline?: number,
+  timers: ReconnectWaitTimers = reconnectWaitTimers,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (!isReconnecting()) {
+      resolve();
+      return;
+    }
+    let check: ReturnType<typeof setInterval> | null = null;
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    const finish = (error?: Error): void => {
+      if (check) {
+        timers.clearInterval(check);
+        check = null;
+      }
+      if (deadlineTimer) {
+        timers.clearTimeout(deadlineTimer);
+        deadlineTimer = null;
+      }
+      if (error) reject(error);
+      else resolve();
+    };
+    check = timers.setInterval(() => {
+      if (!isReconnecting()) finish();
+    }, 100);
+    if (deadline !== undefined) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        finish(new Error('App evaluation timed out'));
+        return;
+      }
+      deadlineTimer = timers.setTimeout(
+        () => finish(new Error('App evaluation timed out')),
+        remaining,
+      );
+    }
+  });
+}
+
 type RuntimeRegistration = (server: McpServer) => { remove: () => void };
 
 interface McpSession {
@@ -254,21 +309,6 @@ export async function createMetroRuntime(
     }
   }
 
-  function waitForReconnect(): Promise<void> {
-    return new Promise<void>((resolve) => {
-      if (!isReconnecting) {
-        resolve();
-        return;
-      }
-      const check = setInterval(() => {
-        if (!isReconnecting) {
-          clearInterval(check);
-          resolve();
-        }
-      }, 100);
-    });
-  }
-
   // Enable required CDP domains. Called on every CDP connection and after Metro
   // bundle rebuilds (fast refresh / hot reload resets Hermes domain registration).
   async function enableCDPDomains(): Promise<void> {
@@ -374,12 +414,12 @@ export async function createMetroRuntime(
   ): PluginContext {
     const pluginLogger = createLogger(plugin.name);
     const evalInApp = createAppEvaluator(cdpSession, {
-      ensureConnected: async () => {
+      ensureConnected: async (deadline?: number) => {
         if (!cdpSession.isConnected) {
           if (isReconnecting) {
             // A reconnect is already in flight — wait for it rather than
             // starting another one.
-            await waitForReconnect();
+            await waitForReconnect(() => isReconnecting, deadline);
           } else {
             // Reset the attempt counter so the background scheduler can resume
             // after this tool-triggered reconnect, rather than staying capped.
@@ -394,7 +434,8 @@ export async function createMetroRuntime(
           );
         }
       },
-      waitForReconnect,
+      waitForReconnect: (deadline?: number) =>
+        waitForReconnect(() => isReconnecting, deadline),
       isReconnecting: () => isReconnecting,
       getGeneration: () => runtimeGeneration,
       reconnect: async () => {
@@ -749,7 +790,7 @@ export async function createMetroRuntime(
   // Idempotent: concurrent callers wait for the in-flight attempt to finish.
   async function connectToMetro(): Promise<boolean> {
     if (isReconnecting) {
-      await waitForReconnect();
+      await waitForReconnect(() => isReconnecting);
       return cdpSession.isConnected;
     }
     isReconnecting = true;

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -257,7 +257,7 @@ describe('async app read results', () => {
     let mailboxWriteAttempts = 0;
     let reconnects = 0;
     const evaluateWithDisconnect: PluginContext['evalInApp'] = async (expression, options) => {
-      if (expression.includes('state.value =')) {
+      if (expression.includes('state.unserializableValue = void 0;')) {
         mailboxWriteAttempts += 1;
         if (mailboxWriteAttempts === 1) throw new Error('transport disconnected');
       }
@@ -267,7 +267,7 @@ describe('async app read results', () => {
       try {
         return await evaluateWithDisconnect(expression, options);
       } catch (error) {
-        if (!expression.includes('state.value =')) throw error;
+        if (!expression.includes('state.unserializableValue = void 0;')) throw error;
         reconnects += 1;
         return evaluateWithDisconnect(expression, options);
       }

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import vm from 'node:vm';
 import type { PluginContext } from '../plugin.js';
-import { awaitAppResult } from './await-app-result.js';
+import {
+  awaitAppResult,
+  type AppEvaluationCompletion,
+  type AwaitAppResultOptions,
+} from './await-app-result.js';
 
 function hermesHarness() {
   // A VM context gives eval its own global object, so global var/function
@@ -12,7 +16,55 @@ function hermesHarness() {
     // Simulate CDP returnByValue ignoring awaitPromise, not JS-level awaiting.
     return result === undefined ? undefined : JSON.parse(JSON.stringify(result));
   };
-  return { runtime, evaluate };
+  const remoteObjects = new Map<string, unknown>();
+  const releasedGroups: string[] = [];
+  let nextObjectId = 0;
+  const evaluateScript = async (expression: string): Promise<AppEvaluationCompletion> => {
+    const result = new vm.Script(expression).runInContext(runtime);
+    if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
+      const objectId = `remote-${++nextObjectId}`;
+      remoteObjects.set(objectId, result);
+      return { objectId };
+    }
+    return { value: result };
+  };
+  const settleRemote = async (objectId: string, mailboxName: string) => {
+    const state = (runtime as Record<string, unknown>)[mailboxName] as Record<string, unknown>;
+    const result = remoteObjects.get(objectId);
+    if (result && typeof (result as Promise<unknown>).then === 'function') {
+      void Promise.resolve(result).then(
+        (value) => {
+          if (state) { state.value = value; state.status = 'fulfilled'; }
+        },
+        (error) => {
+          if (state) {
+            state.error = String(error && (error as Error).message || error);
+            state.status = 'rejected';
+          }
+        },
+      );
+    } else if (state) {
+      state.value = result;
+      state.status = 'fulfilled';
+    }
+    return true;
+  };
+  const awaitResult = (
+    expression: string,
+    timeout?: number,
+    options?: AwaitAppResultOptions,
+  ) => awaitAppResult(
+    evaluate,
+    expression,
+    timeout,
+    {
+      ...options,
+      evaluateScript,
+      settleRemote,
+      releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
+    },
+  );
+  return { runtime, evaluate, awaitResult, releasedGroups };
 }
 
 function userRuntimeKeys(runtime: vm.Context): string[] {
@@ -23,64 +75,73 @@ function userRuntimeKeys(runtime: vm.Context): string[] {
 
 describe('async app read results', () => {
   test('awaits a promise when CDP serializes the promise object', async () => {
-    const { runtime, evaluate } = hermesHarness();
+    const { runtime, evaluate, awaitResult } = hermesHarness();
     expect(await evaluate('Promise.resolve(42)', { awaitPromise: true })).toEqual(
       {},
     );
-    expect(await awaitAppResult(
-      evaluate,
+    expect(await awaitResult(
       'new Promise(resolve => setTimeout(() => resolve({ found: true }), 10))',
     )).toEqual({ found: true });
     expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('propagates rejected and synchronously thrown errors and cleans up', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    await expect(awaitAppResult(
-      evaluate,
+    const { runtime, awaitResult } = hermesHarness();
+    await expect(awaitResult(
       'Promise.reject(new Error("measurement failed"))',
     )).rejects.toThrow('measurement failed');
-    await expect(awaitAppResult(
-      evaluate,
+    await expect(awaitResult(
       '(() => { throw new Error("sync failure"); })()',
     )).rejects.toThrow('sync failure');
     expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('bounds pending reads and leaves expiry to the app after host deadline', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    await expect(awaitAppResult(
-      evaluate,
+    const { runtime, awaitResult, releasedGroups } = hermesHarness();
+    await expect(awaitResult(
       'new Promise(() => {})',
       30,
     )).rejects.toThrow('timed out');
     expect(userRuntimeKeys(runtime)).toHaveLength(1);
     expect(userRuntimeKeys(runtime)[0]).toStartWith('__METRO_MCP_ASYNC_');
+    expect(releasedGroups).toHaveLength(0); // Runtime.releaseObject handled the Promise
   });
 
   test('isolates concurrent reads and preserves undefined and null', async () => {
-    const { runtime, evaluate } = hermesHarness();
+    const { runtime, awaitResult } = hermesHarness();
     expect(await Promise.all([
-      awaitAppResult(evaluate, 'Promise.resolve(undefined)'),
-      awaitAppResult(evaluate, 'Promise.resolve(null)'),
-      awaitAppResult(evaluate, 'Promise.resolve(42)'),
+      awaitResult('Promise.resolve(undefined)'),
+      awaitResult('Promise.resolve(null)'),
+      awaitResult('Promise.resolve(42)'),
     ])).toEqual([undefined, null, 42]);
     expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('preserves script completion values and executes the source once', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    expect(await awaitAppResult(
-      evaluate,
+    const { runtime, awaitResult, releasedGroups } = hermesHarness();
+    expect(await awaitResult(
       `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
        Promise.resolve({ count: globalThis.evaluationCount, value: 7 });`,
     )).toEqual({ count: 1, value: 7 });
     expect(runtime).toMatchObject({ evaluationCount: 1 });
     expect(userRuntimeKeys(runtime)).toEqual(['evaluationCount']);
+    expect(releasedGroups).toHaveLength(0);
+  });
+
+  test('assimilates nested thenables and ignores repeated resolution', async () => {
+    const { awaitResult } = hermesHarness();
+    await expect(awaitResult(`({
+      then: function(resolve) {
+        resolve({ then: function(resolveNested) {
+          resolveNested('nested value');
+        }});
+        resolve('second value');
+      }
+    })`)).resolves.toBe('nested value');
   });
 
   test('can reconnect mailbox reads without replaying the source', async () => {
-    const { runtime, evaluate } = hermesHarness();
+    const { runtime, awaitResult, evaluate } = hermesHarness();
     let pollReads = 0;
     let transportRecovered = false;
     const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
@@ -94,8 +155,7 @@ describe('async app read results', () => {
 
     // The helper leaves retry policy to its polling evaluator. This models a
     // server reconnect that retries only a mailbox read after a lost transport.
-    await expect(awaitAppResult(
-      evaluate,
+    await expect(awaitResult(
       `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
        new Promise(resolve => setTimeout(() => resolve(globalThis.evaluationCount), 10));`,
       1000,
@@ -107,15 +167,12 @@ describe('async app read results', () => {
   });
 
   test('keeps global script declarations across awaited evaluations', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    await expect(awaitAppResult(
-      evaluate,
-      'var persistedValue = 41; Promise.resolve(persistedValue);',
+    const { runtime, awaitResult } = hermesHarness();
+    await expect(awaitResult(
+      'let persistedValue = 41; class PersistedClass {} Promise.resolve(persistedValue);',
     )).resolves.toBe(41);
-    await expect(awaitAppResult(
-      evaluate,
-      'Promise.resolve(persistedValue + 1);',
+    await expect(awaitResult(
+      'Promise.resolve(persistedValue + (typeof PersistedClass === "function" ? 1 : 0));',
     )).resolves.toBe(42);
-    expect(runtime).toHaveProperty('persistedValue', 41);
   });
 });

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -34,7 +34,19 @@ function hermesHarness() {
     if (result && typeof (result as Promise<unknown>).then === 'function') {
       void Promise.resolve(result).then(
         (value) => {
-          if (state) { state.value = value; state.status = 'fulfilled'; }
+          if (state) {
+            state.unserializableValue = undefined;
+            if (typeof value === 'number') {
+              if (Number.isNaN(value)) state.unserializableValue = 'NaN';
+              else if (value === Infinity) state.unserializableValue = 'Infinity';
+              else if (value === -Infinity) state.unserializableValue = '-Infinity';
+              else if (Object.is(value, -0)) state.unserializableValue = '-0';
+            } else if (typeof value === 'bigint') {
+              state.unserializableValue = String(value) + 'n';
+            }
+            state.value = state.unserializableValue === undefined ? value : undefined;
+            state.status = 'fulfilled';
+          }
         },
         (error) => {
           if (state) {
@@ -122,6 +134,48 @@ describe('async app read results', () => {
       awaitResult('Promise.resolve(42)'),
     ])).toEqual([undefined, null, 42]);
     expect(userRuntimeKeys(runtime)).toEqual([]);
+  });
+
+  test('preserves unserializable values from remote Promise settlement', async () => {
+    const { awaitResult } = hermesHarness();
+    const cases: Array<[string, unknown]> = [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['-0', -0],
+      ['123456789012345678901234567890n', 123456789012345678901234567890n],
+    ];
+    for (const [source, expected] of cases) {
+      const actual = await awaitResult(`Promise.resolve(${source})`);
+      if (typeof expected === 'number' && Object.is(expected, -0)) {
+        expect(Object.is(actual, -0)).toBe(true);
+      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+        expect(Number.isNaN(actual)).toBe(true);
+      } else {
+        expect(actual).toBe(expected);
+      }
+    }
+  });
+
+  test('preserves unserializable synchronous awaited completions', async () => {
+    const { awaitResult } = hermesHarness();
+    const cases: Array<[string, unknown]> = [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['-0', -0],
+      ['123456789012345678901234567890n', 123456789012345678901234567890n],
+    ];
+    for (const [source, expected] of cases) {
+      const actual = await awaitResult(source);
+      if (typeof expected === 'number' && Object.is(expected, -0)) {
+        expect(Object.is(actual, -0)).toBe(true);
+      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+        expect(Number.isNaN(actual)).toBe(true);
+      } else {
+        expect(actual).toBe(expected);
+      }
+    }
   });
 
   test('preserves script completion values and executes the source once', async () => {

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, test } from 'bun:test';
+import vm from 'node:vm';
 import type { PluginContext } from '../plugin.js';
 import { awaitAppResult } from './await-app-result.js';
 
 function hermesHarness() {
-  const runtime = {};
+  // A VM context gives eval its own global object, so global var/function
+  // declarations behave like Runtime.evaluate across separate calls.
+  const runtime = vm.createContext({ setTimeout, clearTimeout });
   const evaluate: PluginContext['evalInApp'] = async (expression) => {
-    const result = new Function('globalThis', `return ${expression};`)(runtime);
+    const result = new vm.Script(expression).runInContext(runtime);
     // Simulate CDP returnByValue ignoring awaitPromise, not JS-level awaiting.
     return result === undefined ? undefined : JSON.parse(JSON.stringify(result));
   };
   return { runtime, evaluate };
+}
+
+function userRuntimeKeys(runtime: vm.Context): string[] {
+  return Object.getOwnPropertyNames(runtime).filter(
+    (name) => name !== 'setTimeout' && name !== 'clearTimeout',
+  );
 }
 
 describe('async app read results', () => {
@@ -22,7 +31,7 @@ describe('async app read results', () => {
       evaluate,
       'new Promise(resolve => setTimeout(() => resolve({ found: true }), 10))',
     )).toEqual({ found: true });
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('propagates rejected and synchronously thrown errors and cleans up', async () => {
@@ -35,17 +44,18 @@ describe('async app read results', () => {
       evaluate,
       '(() => { throw new Error("sync failure"); })()',
     )).rejects.toThrow('sync failure');
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
-  test('bounds pending reads and deletes their mailbox', async () => {
+  test('bounds pending reads and leaves expiry to the app after host deadline', async () => {
     const { runtime, evaluate } = hermesHarness();
     await expect(awaitAppResult(
       evaluate,
       'new Promise(() => {})',
       30,
     )).rejects.toThrow('timed out');
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toHaveLength(1);
+    expect(userRuntimeKeys(runtime)[0]).toStartWith('__METRO_MCP_ASYNC_');
   });
 
   test('isolates concurrent reads and preserves undefined and null', async () => {
@@ -55,6 +65,57 @@ describe('async app read results', () => {
       awaitAppResult(evaluate, 'Promise.resolve(null)'),
       awaitAppResult(evaluate, 'Promise.resolve(42)'),
     ])).toEqual([undefined, null, 42]);
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toEqual([]);
+  });
+
+  test('preserves script completion values and executes the source once', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    expect(await awaitAppResult(
+      evaluate,
+      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
+       Promise.resolve({ count: globalThis.evaluationCount, value: 7 });`,
+    )).toEqual({ count: 1, value: 7 });
+    expect(runtime).toMatchObject({ evaluationCount: 1 });
+    expect(userRuntimeKeys(runtime)).toEqual(['evaluationCount']);
+  });
+
+  test('can reconnect mailbox reads without replaying the source', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    let pollReads = 0;
+    let transportRecovered = false;
+    const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
+      pollReads += 1;
+      if (pollReads === 1) {
+        // A server-side poll wrapper reconnects, then retries this read.
+        transportRecovered = true;
+      }
+      return evaluate(expression, options);
+    };
+
+    // The helper leaves retry policy to its polling evaluator. This models a
+    // server reconnect that retries only a mailbox read after a lost transport.
+    await expect(awaitAppResult(
+      evaluate,
+      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
+       new Promise(resolve => setTimeout(() => resolve(globalThis.evaluationCount), 10));`,
+      1000,
+      { pollEvaluate },
+    )).resolves.toBe(1);
+    expect(runtime).toMatchObject({ evaluationCount: 1 });
+    expect(pollReads).toBeGreaterThan(1);
+    expect(transportRecovered).toBe(true);
+  });
+
+  test('keeps global script declarations across awaited evaluations', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    await expect(awaitAppResult(
+      evaluate,
+      'var persistedValue = 41; Promise.resolve(persistedValue);',
+    )).resolves.toBe(41);
+    await expect(awaitAppResult(
+      evaluate,
+      'Promise.resolve(persistedValue + 1);',
+    )).resolves.toBe(42);
+    expect(runtime).toHaveProperty('persistedValue', 41);
   });
 });

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -170,6 +170,34 @@ describe('async app read results', () => {
     }
   });
 
+  test('returns a by-value primitive without a mailbox write or poll', async () => {
+    const { evaluate, evaluateScript } = hermesHarness();
+    const evaluatedExpressions: string[] = [];
+    const trackingEvaluate: PluginContext['evalInApp'] = async (source, options) => {
+      evaluatedExpressions.push(source);
+      return evaluate(source, options);
+    };
+
+    await expect(awaitAppResult(
+      trackingEvaluate,
+      '42',
+      1000,
+      {
+        evaluateScript: async (source) => {
+          expect(source).toBe('42');
+          return evaluateScript(source);
+        },
+      },
+    )).resolves.toBe(42);
+
+    expect(evaluatedExpressions).toHaveLength(2);
+    expect(evaluatedExpressions[0]).toContain("status: 'pending'");
+    expect(evaluatedExpressions[1]).toContain('delete root[');
+    expect(
+      evaluatedExpressions.some((source) => source.includes('status: state.status')),
+    ).toBe(false);
+  });
+
   test('preserves script completion values and executes the source once', async () => {
     const { runtime, awaitResult, releasedGroups } = hermesHarness();
     expect(await awaitResult(
@@ -244,51 +272,6 @@ describe('async app read results', () => {
     expect(runtime).toMatchObject({ evaluationCount: 1 });
     expect(pollReads).toBeGreaterThan(1);
     expect(transportRecovered).toBe(true);
-  });
-
-  test('retries a mailbox completion write without replaying the source', async () => {
-    const {
-      runtime,
-      evaluate,
-      evaluateScript,
-      settleRemote,
-      releasedGroups,
-    } = hermesHarness();
-    let mailboxWriteAttempts = 0;
-    let reconnects = 0;
-    const evaluateWithDisconnect: PluginContext['evalInApp'] = async (expression, options) => {
-      if (expression.includes('state.unserializableValue = void 0;')) {
-        mailboxWriteAttempts += 1;
-        if (mailboxWriteAttempts === 1) throw new Error('transport disconnected');
-      }
-      return evaluate(expression, options);
-    };
-    const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
-      try {
-        return await evaluateWithDisconnect(expression, options);
-      } catch (error) {
-        if (!expression.includes('state.unserializableValue = void 0;')) throw error;
-        reconnects += 1;
-        return evaluateWithDisconnect(expression, options);
-      }
-    };
-
-    await expect(awaitAppResult(
-      evaluateWithDisconnect,
-      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
-       globalThis.evaluationCount;`,
-      1000,
-      {
-        pollEvaluate,
-        evaluateScript,
-        settleRemote,
-        releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
-      },
-    )).resolves.toBe(1);
-    expect(runtime).toMatchObject({ evaluationCount: 1 });
-    expect(mailboxWriteAttempts).toBe(2);
-    expect(reconnects).toBe(1);
-    expect(releasedGroups).toHaveLength(0);
   });
 
   test('keeps global script declarations across awaited evaluations', async () => {

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -92,6 +92,24 @@ function userRuntimeKeys(runtime: vm.Context): string[] {
   );
 }
 
+const UNSERIALIZABLE_CASES: Array<[string, unknown]> = [
+  ['NaN', Number.NaN],
+  ['Infinity', Number.POSITIVE_INFINITY],
+  ['-Infinity', Number.NEGATIVE_INFINITY],
+  ['-0', -0],
+  ['123456789012345678901234567890n', 123456789012345678901234567890n],
+];
+
+function expectUnserializableValue(actual: unknown, expected: unknown): void {
+  if (typeof expected === 'number' && Object.is(expected, -0)) {
+    expect(Object.is(actual, -0)).toBe(true);
+  } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+    expect(Number.isNaN(actual)).toBe(true);
+  } else {
+    expect(actual).toBe(expected);
+  }
+}
+
 describe('async app read results', () => {
   test('awaits a promise when CDP serializes the promise object', async () => {
     const { runtime, evaluate, awaitResult } = hermesHarness();
@@ -138,43 +156,17 @@ describe('async app read results', () => {
 
   test('preserves unserializable values from remote Promise settlement', async () => {
     const { awaitResult } = hermesHarness();
-    const cases: Array<[string, unknown]> = [
-      ['NaN', Number.NaN],
-      ['Infinity', Number.POSITIVE_INFINITY],
-      ['-Infinity', Number.NEGATIVE_INFINITY],
-      ['-0', -0],
-      ['123456789012345678901234567890n', 123456789012345678901234567890n],
-    ];
-    for (const [source, expected] of cases) {
+    for (const [source, expected] of UNSERIALIZABLE_CASES) {
       const actual = await awaitResult(`Promise.resolve(${source})`);
-      if (typeof expected === 'number' && Object.is(expected, -0)) {
-        expect(Object.is(actual, -0)).toBe(true);
-      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
-        expect(Number.isNaN(actual)).toBe(true);
-      } else {
-        expect(actual).toBe(expected);
-      }
+      expectUnserializableValue(actual, expected);
     }
   });
 
   test('preserves unserializable synchronous awaited completions', async () => {
     const { awaitResult } = hermesHarness();
-    const cases: Array<[string, unknown]> = [
-      ['NaN', Number.NaN],
-      ['Infinity', Number.POSITIVE_INFINITY],
-      ['-Infinity', Number.NEGATIVE_INFINITY],
-      ['-0', -0],
-      ['123456789012345678901234567890n', 123456789012345678901234567890n],
-    ];
-    for (const [source, expected] of cases) {
+    for (const [source, expected] of UNSERIALIZABLE_CASES) {
       const actual = await awaitResult(source);
-      if (typeof expected === 'number' && Object.is(expected, -0)) {
-        expect(Object.is(actual, -0)).toBe(true);
-      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
-        expect(Number.isNaN(actual)).toBe(true);
-      } else {
-        expect(actual).toBe(expected);
-      }
+      expectUnserializableValue(actual, expected);
     }
   });
 

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -181,6 +181,33 @@ describe('async app read results', () => {
     expect(releasedGroups).toHaveLength(0);
   });
 
+  test('does not delay a settled result for stalled mailbox cleanup', async () => {
+    const { runtime, evaluate, awaitResult } = hermesHarness();
+    let cleanupStarted = false;
+    let finishCleanup: (() => void) | undefined;
+    const cleanupEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
+      cleanupStarted = true;
+      await new Promise<void>((resolve) => { finishCleanup = resolve; });
+      return evaluate(expression, options);
+    };
+    let resultSettled = false;
+    const result = awaitResult('Promise.resolve(42)', 1000, { cleanupEvaluate })
+      .then((value) => {
+        resultSettled = true;
+        return value;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    try {
+      expect(cleanupStarted).toBe(true);
+      expect(resultSettled).toBe(true);
+      await expect(result).resolves.toBe(42);
+    } finally {
+      finishCleanup?.();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(userRuntimeKeys(runtime)).toEqual([]);
+  });
+
   test('assimilates nested thenables and ignores repeated resolution', async () => {
     const { awaitResult } = hermesHarness();
     await expect(awaitResult(`({

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -64,7 +64,14 @@ function hermesHarness() {
       releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
     },
   );
-  return { runtime, evaluate, awaitResult, releasedGroups };
+  return {
+    runtime,
+    evaluate,
+    evaluateScript,
+    settleRemote,
+    awaitResult,
+    releasedGroups,
+  };
 }
 
 function userRuntimeKeys(runtime: vm.Context): string[] {
@@ -164,6 +171,51 @@ describe('async app read results', () => {
     expect(runtime).toMatchObject({ evaluationCount: 1 });
     expect(pollReads).toBeGreaterThan(1);
     expect(transportRecovered).toBe(true);
+  });
+
+  test('retries a mailbox completion write without replaying the source', async () => {
+    const {
+      runtime,
+      evaluate,
+      evaluateScript,
+      settleRemote,
+      releasedGroups,
+    } = hermesHarness();
+    let mailboxWriteAttempts = 0;
+    let reconnects = 0;
+    const evaluateWithDisconnect: PluginContext['evalInApp'] = async (expression, options) => {
+      if (expression.includes('state.value =')) {
+        mailboxWriteAttempts += 1;
+        if (mailboxWriteAttempts === 1) throw new Error('transport disconnected');
+      }
+      return evaluate(expression, options);
+    };
+    const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
+      try {
+        return await evaluateWithDisconnect(expression, options);
+      } catch (error) {
+        if (!expression.includes('state.value =')) throw error;
+        reconnects += 1;
+        return evaluateWithDisconnect(expression, options);
+      }
+    };
+
+    await expect(awaitAppResult(
+      evaluateWithDisconnect,
+      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
+       globalThis.evaluationCount;`,
+      1000,
+      {
+        pollEvaluate,
+        evaluateScript,
+        settleRemote,
+        releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
+      },
+    )).resolves.toBe(1);
+    expect(runtime).toMatchObject({ evaluationCount: 1 });
+    expect(mailboxWriteAttempts).toBe(2);
+    expect(reconnects).toBe(1);
+    expect(releasedGroups).toHaveLength(0);
   });
 
   test('keeps global script declarations across awaited evaluations', async () => {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -102,6 +102,8 @@ export async function awaitPromiseBeforeDeadline<T>(
 }
 
 export interface AwaitAppResultOptions {
+  /** Absolute caller deadline shared by every awaited stage. */
+  deadline?: number;
   /**
    * Evaluation used for mailbox reads. This may reconnect before a read, but
    * must never replay the expression that created the mailbox.
@@ -186,7 +188,10 @@ export async function awaitAppResult(
   const mailboxName = `__METRO_MCP_ASYNC_${randomUUID()}`;
   const objectGroup = `__METRO_MCP_ASYNC_GROUP_${randomUUID()}`;
   const key = JSON.stringify(mailboxName);
-  const deadline = Date.now() + timeout;
+  const timeoutDeadline = Date.now() + timeout;
+  const deadline = options?.deadline === undefined
+    ? timeoutDeadline
+    : Math.min(timeoutDeadline, options.deadline);
   let sourceCompletedByValue = false;
   let remoteHandleReleased = false;
   let sourceEvaluation: Promise<AppEvaluationCompletion> | undefined;
@@ -194,15 +199,22 @@ export async function awaitAppResult(
 
   const releaseGroup = async (): Promise<void> => {
     if (!options?.releaseObjectGroup) return;
-    const releaseDeadline = Date.now() + 100;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return;
+    const releaseTimeout = Math.min(100, remaining);
+    const releaseDeadline = Date.now() + releaseTimeout;
     await awaitPromiseBeforeDeadline(
-      options.releaseObjectGroup(objectGroup, { timeout: 100 }),
+      options.releaseObjectGroup(objectGroup, { timeout: releaseTimeout }),
       releaseDeadline,
-      100,
+      releaseTimeout,
     ).catch(() => {});
   };
 
   try {
+    const mailboxLifetime = Math.max(
+      0,
+      Math.min(timeout, deadline - Date.now()),
+    ) + 1000;
     const mailboxSetup = `(function() {
       var state = { status: 'pending' };
       Object.defineProperty(globalThis, ${key}, {
@@ -210,7 +222,7 @@ export async function awaitAppResult(
       });
       state.timer = setTimeout(function() {
         if (globalThis[${key}] === state) delete globalThis[${key}];
-      }, ${timeout + 1000});
+      }, ${mailboxLifetime});
       return true;
     })()`;
     const mailboxGeneration = options?.setupMailbox

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -227,12 +227,41 @@ export async function awaitAppResult(
     ) + 1000;
     const mailboxSetup = `(function() {
       var root = this;
-      var PromiseCtor = root.Promise;
-      var state = {
-        status: 'pending',
-        promiseConstructor: PromiseCtor,
-        promiseResolve: PromiseCtor && PromiseCtor.resolve,
-        promiseThen: PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then
+      var state = { status: 'pending', observing: false };
+      function rejectionMessage(error) {
+        var message;
+        try {
+          if (error !== null && error !== undefined) message = error.message;
+        } catch (_) {}
+        if (message !== undefined && message !== null) {
+          try { return String(message); } catch (_) {}
+        }
+        try { return String(error); } catch (_) {}
+        return 'Promise rejected with an unstringifiable reason';
+      }
+      function fulfill(value) {
+        if (root[${key}] !== state) return;
+        state.unserializableValue = undefined;
+        if (typeof value === 'number') {
+          if (value !== value) state.unserializableValue = 'NaN';
+          else if (value === Infinity) state.unserializableValue = 'Infinity';
+          else if (value === -Infinity) state.unserializableValue = '-Infinity';
+          else if (value === 0 && 1 / value === -Infinity) state.unserializableValue = '-0';
+        } else if (typeof value === 'bigint') {
+          state.unserializableValue = String(value) + 'n';
+        }
+        state.value = state.unserializableValue === undefined ? value : undefined;
+        state.status = 'fulfilled';
+      }
+      function reject(error) {
+        if (root[${key}] !== state) return;
+        state.error = rejectionMessage(error);
+        state.status = 'rejected';
+      }
+      state.observe = async function(value) {
+        if (state.observing) return;
+        state.observing = true;
+        try { fulfill(await value); } catch (error) { reject(error); }
       };
       root.Object.defineProperty(root, ${key}, {
         value: state, configurable: true

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -213,9 +213,18 @@ export async function awaitAppResult(
         state.observing = true;
         try { fulfill(await value); } catch (error) { reject(error); }
       };
-      root.Object.defineProperty(root, ${key}, {
-        value: state, configurable: true
-      });
+      // Keep setup viable after the app replaces Object or defineProperty.
+      // With normal intrinsics, hide and protect the temporary mailbox as before.
+      var descriptor = {
+        value: state, configurable: true, enumerable: false, writable: false
+      };
+      try {
+        root.Reflect.defineProperty(root, ${key}, descriptor);
+      } catch (_) {}
+      if (root[${key}] !== state) {
+        try { root.Object.defineProperty(root, ${key}, descriptor); } catch (_) {}
+      }
+      if (root[${key}] !== state) root[${key}] = state;
       state.timer = root.setTimeout(function() {
         if (root[${key}] === state) delete root[${key}];
       }, ${mailboxLifetime});

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -18,8 +18,18 @@ export type AppEvaluationCompletion =
 
 type EvaluateScript = (
   expression: string,
-  options?: { timeout?: number; deadline?: number; objectGroup?: string },
+  options?: {
+    timeout?: number;
+    deadline?: number;
+    objectGroup?: string;
+    generation?: number;
+  },
 ) => Promise<AppEvaluationCompletion>;
+
+type SetupMailbox = (
+  expression: string,
+  options: { timeout?: number; deadline: number },
+) => Promise<number | undefined>;
 
 type SettleRemote = (
   objectId: string,
@@ -98,6 +108,45 @@ export interface AwaitAppResultOptions {
   settleRemote?: SettleRemote;
   /** Release handles if source evaluation completes after the host deadline. */
   releaseObjectGroup?: ReleaseObjectGroup;
+  /** Runtime generation captured after mailbox creation. */
+  getRuntimeGeneration?: () => number;
+  /** Create the mailbox while bracketing the dispatch with generation checks. */
+  setupMailbox?: SetupMailbox;
+}
+
+function decodeUnserializableValue(value: unknown): unknown {
+  if (value === 'NaN') return Number.NaN;
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
+  if (value === '-0') return -0;
+  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
+    return BigInt(value.slice(0, -1));
+  }
+  throw new Error('Unsupported CDP unserializable value');
+}
+
+function serializeCompletionValue(value: unknown): {
+  expression: string;
+  unserializableValue?: string;
+} {
+  if (value === undefined) return { expression: 'void 0' };
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) return { expression: 'void 0', unserializableValue: 'NaN' };
+    if (value === Number.POSITIVE_INFINITY) return { expression: 'void 0', unserializableValue: 'Infinity' };
+    if (value === Number.NEGATIVE_INFINITY) return { expression: 'void 0', unserializableValue: '-Infinity' };
+    if (Object.is(value, -0)) return { expression: 'void 0', unserializableValue: '-0' };
+  }
+  if (typeof value === 'bigint') {
+    return {
+      expression: 'void 0',
+      unserializableValue: `${value.toString()}n`,
+    };
+  }
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error('App evaluation result could not be serialized');
+  }
+  return { expression: serialized };
 }
 
 async function completeByValue(
@@ -106,16 +155,17 @@ async function completeByValue(
   value: unknown,
   options: { deadline: number; timeout: number },
 ): Promise<void> {
-  const serialized = value === undefined ? 'void 0' : JSON.stringify(value);
-  if (serialized === undefined) {
-    throw new Error('App evaluation result could not be serialized');
-  }
+  const serialized = serializeCompletionValue(value);
+  const unserializableValue = serialized.unserializableValue === undefined
+    ? 'void 0'
+    : JSON.stringify(serialized.unserializableValue);
   await evaluateBeforeDeadline(
     evaluate,
     `(function() {
       var state = globalThis[${key}];
       if (state) {
-        state.value = ${serialized};
+        state.unserializableValue = ${unserializableValue};
+        state.value = ${serialized.expression};
         state.status = 'fulfilled';
       }
     })()`,
@@ -157,7 +207,7 @@ export async function awaitAppResult(
   };
 
   try {
-    await evaluateBeforeDeadline(evaluate, `(function() {
+    const mailboxSetup = `(function() {
       var state = { status: 'pending' };
       Object.defineProperty(globalThis, ${key}, {
         value: state, configurable: true
@@ -166,7 +216,20 @@ export async function awaitAppResult(
         if (globalThis[${key}] === state) delete globalThis[${key}];
       }, ${timeout + 1000});
       return true;
-    })()`, { timeout, deadline }, timeout);
+    })()`;
+    const mailboxGeneration = options?.setupMailbox
+      ? await evaluateBeforeDeadline(
+        options.setupMailbox,
+        mailboxSetup,
+        { timeout, deadline },
+        timeout,
+      )
+      : await evaluateBeforeDeadline(
+        evaluate,
+        mailboxSetup,
+        { timeout, deadline },
+        timeout,
+      ).then(() => options?.getRuntimeGeneration?.());
 
     // Runtime.evaluate must receive the user's source itself. Indirect eval
     // runs in a separate variable environment and silently loses top-level
@@ -176,7 +239,12 @@ export async function awaitAppResult(
     let completion: AppEvaluationCompletion;
     if (options?.evaluateScript) {
       if (Date.now() >= deadline) throw timeoutError(timeout);
-      sourceEvaluation = options.evaluateScript(expression, { timeout, deadline, objectGroup });
+      sourceEvaluation = options.evaluateScript(expression, {
+        timeout,
+        deadline,
+        objectGroup,
+        generation: mailboxGeneration,
+      });
       sourceEvaluation.then(
         () => { sourceEvaluationSettled = true; },
         () => { sourceEvaluationSettled = true; },
@@ -213,14 +281,22 @@ export async function awaitAppResult(
         var state = globalThis[${key}];
         if (!state) return { status: 'missing' };
         return {
-          status: state.status, value: state.value, error: state.error
+          status: state.status,
+          value: state.value,
+          unserializableValue: state.unserializableValue,
+          error: state.error
         };
       })()`, { timeout: Math.max(1, deadline - Date.now()), deadline }, timeout) as {
         status: string;
         value?: unknown;
+        unserializableValue?: unknown;
         error?: string;
       };
-      if (result?.status === 'fulfilled') return result.value;
+      if (result?.status === 'fulfilled') {
+        return result.unserializableValue === undefined
+          ? result.value
+          : decodeUnserializableValue(result.unserializableValue);
+      }
       if (result?.status === 'rejected') throw new Error(result.error);
       if (!result || result.status !== 'pending') {
         throw new Error('App evaluation context was lost before measurement completed');

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -2,6 +2,46 @@ import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { PluginContext } from '../plugin.js';
 
+type Evaluate = PluginContext['evalInApp'];
+
+function timeoutError(timeout: number): Error {
+  return new Error(`App evaluation timed out after ${timeout}ms`);
+}
+
+async function evaluateBeforeDeadline(
+  evaluate: Evaluate,
+  expression: string,
+  options: { timeout?: number; deadline: number },
+  timeout: number,
+): Promise<unknown> {
+  const remaining = options.deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(timeout);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const operation = evaluate(expression, {
+    timeout: Math.max(1, Math.min(options.timeout ?? remaining, remaining)),
+    deadline: options.deadline,
+  });
+  const deadlineReached = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
+  });
+  try {
+    return await Promise.race([operation, deadlineReached]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface AwaitAppResultOptions {
+  /**
+   * Evaluation used for mailbox reads. This may reconnect before a read, but
+   * must never replay the expression that created the mailbox.
+   */
+  pollEvaluate?: Evaluate;
+  /** Evaluation used to remove the mailbox during cleanup. */
+  cleanupEvaluate?: Evaluate;
+}
+
 /**
  * Await a read expression without relying on CDP's awaitPromise support.
  * Hermes can return a serialized JS Promise instead of its resolved value.
@@ -11,11 +51,14 @@ export async function awaitAppResult(
   evaluate: PluginContext['evalInApp'],
   expression: string,
   timeout = 10_000,
+  options?: AwaitAppResultOptions,
 ): Promise<unknown> {
+  const pollEvaluate = options?.pollEvaluate ?? evaluate;
+  const cleanupEvaluate = options?.cleanupEvaluate ?? evaluate;
   const key = JSON.stringify(`__METRO_MCP_ASYNC_${randomUUID()}`);
   const deadline = Date.now() + timeout;
   try {
-    await evaluate(`(function() {
+    await evaluateBeforeDeadline(evaluate, `(function() {
       var state = { status: 'pending' };
       Object.defineProperty(globalThis, ${key}, {
         value: state, configurable: true
@@ -28,22 +71,26 @@ export async function awaitAppResult(
         state.error = String(error && error.message || error);
       }
       try {
-        Promise.resolve(${expression}).then(function(value) {
+        // Evaluate the caller's source as a script so awaitPromise works for
+        // the same completion values as Runtime.evaluate (including multiple
+        // statements and declarations), rather than interpolating it into an
+        // expression. The source is evaluated exactly once before polling.
+        Promise.resolve((0, eval)(${JSON.stringify(expression)})).then(function(value) {
           state.value = value;
           state.status = 'fulfilled';
         }, reject);
       } catch (error) { reject(error); }
       return true;
-    })()`, { timeout });
+    })()`, { timeout, deadline }, timeout);
 
     while (Date.now() < deadline) {
-      const result = await evaluate(`(function() {
+      const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {
         var state = globalThis[${key}];
         if (!state) return { status: 'missing' };
         return {
           status: state.status, value: state.value, error: state.error
         };
-      })()`, { timeout: Math.max(1, deadline - Date.now()) }) as {
+      })()`, { timeout: Math.max(1, deadline - Date.now()), deadline }, timeout) as {
         status: string;
         value?: unknown;
         error?: string;
@@ -55,13 +102,16 @@ export async function awaitAppResult(
       }
       await delay(Math.min(25, Math.max(0, deadline - Date.now())));
     }
-    throw new Error(`App evaluation timed out after ${timeout}ms`);
+    throw timeoutError(timeout);
   } finally {
     // Also expires inside the app if the MCP process or CDP connection is lost.
-    await evaluate(`(function() {
-      var state = globalThis[${key}];
-      if (state) clearTimeout(state.timer);
-      delete globalThis[${key}];
-    })()`, { timeout: 1000 }).catch(() => {});
+    const remaining = deadline - Date.now();
+    if (remaining > 0) {
+      await evaluateBeforeDeadline(cleanupEvaluate, `(function() {
+        var state = globalThis[${key}];
+        if (state) clearTimeout(state.timer);
+        delete globalThis[${key}];
+      })()`, { timeout: Math.min(1000, remaining), deadline }, timeout).catch(() => {});
+    }
   }
 }

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -127,56 +127,6 @@ export interface AwaitAppResultOptions {
   setupMailbox?: SetupMailbox;
 }
 
-function serializeCompletionValue(value: unknown): {
-  expression: string;
-  unserializableValue?: string;
-} {
-  if (value === undefined) return { expression: 'void 0' };
-  if (typeof value === 'number') {
-    if (Number.isNaN(value)) return { expression: 'void 0', unserializableValue: 'NaN' };
-    if (value === Number.POSITIVE_INFINITY) return { expression: 'void 0', unserializableValue: 'Infinity' };
-    if (value === Number.NEGATIVE_INFINITY) return { expression: 'void 0', unserializableValue: '-Infinity' };
-    if (Object.is(value, -0)) return { expression: 'void 0', unserializableValue: '-0' };
-  }
-  if (typeof value === 'bigint') {
-    return {
-      expression: 'void 0',
-      unserializableValue: `${value.toString()}n`,
-    };
-  }
-  const serialized = JSON.stringify(value);
-  if (serialized === undefined) {
-    throw new Error('App evaluation result could not be serialized');
-  }
-  return { expression: serialized };
-}
-
-async function completeByValue(
-  evaluate: Evaluate,
-  key: string,
-  value: unknown,
-  options: { deadline: number; timeout: number },
-): Promise<void> {
-  const serialized = serializeCompletionValue(value);
-  const unserializableValue = serialized.unserializableValue === undefined
-    ? 'void 0'
-    : JSON.stringify(serialized.unserializableValue);
-  await evaluateBeforeDeadline(
-    evaluate,
-    `(function() {
-      var root = this;
-      var state = root[${key}];
-      if (state) {
-        state.unserializableValue = ${unserializableValue};
-        state.value = ${serialized.expression};
-        state.status = 'fulfilled';
-      }
-    })()`,
-    options,
-    options.timeout,
-  );
-}
-
 /**
  * Await a read expression without relying on CDP's awaitPromise support.
  * Hermes can return a serialized JS Promise instead of its resolved value.
@@ -328,11 +278,12 @@ export async function awaitAppResult(
         timeout,
       );
     } else {
+      // Runtime.evaluate returns primitives by value when the source has no
+      // remote object completion. They are already complete, so writing them
+      // back through the mailbox would add an unnecessary request and poll.
+      // The finally block still performs best-effort mailbox cleanup.
       sourceCompletedByValue = true;
-      // The source has already executed. A transport failure while writing its
-      // completion is safe to retry through the mailbox evaluator, which owns
-      // reconnect policy and never replays the caller's source.
-      await completeByValue(pollEvaluate, key, completion.value, { deadline, timeout });
+      return completion.value;
     }
 
     while (Date.now() < deadline) {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -4,24 +4,76 @@ import type { PluginContext } from '../plugin.js';
 
 type Evaluate = PluginContext['evalInApp'];
 
+export type AppEvaluationCompletion =
+  | {
+      /** Remote object handle for object and Promise completions. */
+      objectId: string;
+      value?: unknown;
+    }
+  | {
+      /** By-value completion, including an explicit undefined value. */
+      objectId?: undefined;
+      value: unknown;
+    };
+
+type EvaluateScript = (
+  expression: string,
+  options?: { timeout?: number; deadline?: number; objectGroup?: string },
+) => Promise<AppEvaluationCompletion>;
+
+type SettleRemote = (
+  objectId: string,
+  mailboxKey: string,
+  options: { timeout?: number; deadline: number },
+) => Promise<boolean>;
+
+type ReleaseObjectGroup = (
+  objectGroup: string,
+  options: { timeout?: number },
+) => Promise<void>;
+
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
 
-async function evaluateBeforeDeadline(
-  evaluate: Evaluate,
+type DeadlineEvaluate<T> = (
   expression: string,
-  options: { timeout?: number; deadline: number },
+  options: { timeout?: number; deadline: number; objectGroup?: string },
+) => Promise<T>;
+
+async function evaluateBeforeDeadline<T>(
+  evaluate: DeadlineEvaluate<T>,
+  expression: string,
+  options: { timeout?: number; deadline: number; objectGroup?: string },
   timeout: number,
-): Promise<unknown> {
+): Promise<T> {
   const remaining = options.deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(timeout);
+  return awaitPromiseBeforeDeadline(
+    evaluate(expression, {
+      timeout: Math.max(
+        1,
+        Math.min(
+          options.timeout ?? remaining,
+          remaining,
+        ),
+      ),
+      deadline: options.deadline,
+    }),
+    options.deadline,
+    timeout,
+  );
+}
+
+async function awaitPromiseBeforeDeadline<T>(
+  operation: Promise<T>,
+  deadline: number,
+  timeout: number,
+): Promise<T> {
+  const remaining = deadline - Date.now();
   if (remaining <= 0) throw timeoutError(timeout);
 
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const operation = evaluate(expression, {
-    timeout: Math.max(1, Math.min(options.timeout ?? remaining, remaining)),
-    deadline: options.deadline,
-  });
   const deadlineReached = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
   });
@@ -40,6 +92,36 @@ export interface AwaitAppResultOptions {
   pollEvaluate?: Evaluate;
   /** Evaluation used to remove the mailbox during cleanup. */
   cleanupEvaluate?: Evaluate;
+  /** Execute the caller's source as a Runtime.evaluate script exactly once. */
+  evaluateScript?: EvaluateScript;
+  /** Attach mailbox settlement to a remote Promise/object completion. */
+  settleRemote?: SettleRemote;
+  /** Release handles if source evaluation completes after the host deadline. */
+  releaseObjectGroup?: ReleaseObjectGroup;
+}
+
+async function completeByValue(
+  evaluate: Evaluate,
+  key: string,
+  value: unknown,
+  options: { deadline: number; timeout: number },
+): Promise<void> {
+  const serialized = value === undefined ? 'void 0' : JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error('App evaluation result could not be serialized');
+  }
+  await evaluateBeforeDeadline(
+    evaluate,
+    `(function() {
+      var state = globalThis[${key}];
+      if (state) {
+        state.value = ${serialized};
+        state.status = 'fulfilled';
+      }
+    })()`,
+    options,
+    options.timeout,
+  );
 }
 
 /**
@@ -55,8 +137,25 @@ export async function awaitAppResult(
 ): Promise<unknown> {
   const pollEvaluate = options?.pollEvaluate ?? evaluate;
   const cleanupEvaluate = options?.cleanupEvaluate ?? evaluate;
-  const key = JSON.stringify(`__METRO_MCP_ASYNC_${randomUUID()}`);
+  const mailboxName = `__METRO_MCP_ASYNC_${randomUUID()}`;
+  const objectGroup = `__METRO_MCP_ASYNC_GROUP_${randomUUID()}`;
+  const key = JSON.stringify(mailboxName);
   const deadline = Date.now() + timeout;
+  let sourceCompletedByValue = false;
+  let remoteHandleReleased = false;
+  let sourceEvaluation: Promise<AppEvaluationCompletion> | undefined;
+  let sourceEvaluationSettled = false;
+
+  const releaseGroup = async (): Promise<void> => {
+    if (!options?.releaseObjectGroup) return;
+    const releaseDeadline = Date.now() + 100;
+    await awaitPromiseBeforeDeadline(
+      options.releaseObjectGroup(objectGroup, { timeout: 100 }),
+      releaseDeadline,
+      100,
+    ).catch(() => {});
+  };
+
   try {
     await evaluateBeforeDeadline(evaluate, `(function() {
       var state = { status: 'pending' };
@@ -66,22 +165,45 @@ export async function awaitAppResult(
       state.timer = setTimeout(function() {
         if (globalThis[${key}] === state) delete globalThis[${key}];
       }, ${timeout + 1000});
-      function reject(error) {
-        state.status = 'rejected';
-        state.error = String(error && error.message || error);
-      }
-      try {
-        // Evaluate the caller's source as a script so awaitPromise works for
-        // the same completion values as Runtime.evaluate (including multiple
-        // statements and declarations), rather than interpolating it into an
-        // expression. The source is evaluated exactly once before polling.
-        Promise.resolve((0, eval)(${JSON.stringify(expression)})).then(function(value) {
-          state.value = value;
-          state.status = 'fulfilled';
-        }, reject);
-      } catch (error) { reject(error); }
       return true;
     })()`, { timeout, deadline }, timeout);
+
+    // Runtime.evaluate must receive the user's source itself. Indirect eval
+    // runs in a separate variable environment and silently loses top-level
+    // let/const/class declarations. The evaluator supplied by the server
+    // requests a remote completion object so Hermes' Promise can settle the
+    // mailbox without replaying the source during a reconnect.
+    let completion: AppEvaluationCompletion;
+    if (options?.evaluateScript) {
+      if (Date.now() >= deadline) throw timeoutError(timeout);
+      sourceEvaluation = options.evaluateScript(expression, { timeout, deadline, objectGroup });
+      sourceEvaluation.then(
+        () => { sourceEvaluationSettled = true; },
+        () => { sourceEvaluationSettled = true; },
+      );
+      completion = await awaitPromiseBeforeDeadline(sourceEvaluation, deadline, timeout);
+    } else {
+      completion = { value: await evaluateBeforeDeadline(evaluate, expression, { timeout, deadline }, timeout) };
+      sourceCompletedByValue = true;
+    }
+
+    if (completion.objectId) {
+      if (!options?.settleRemote) {
+        throw new Error('App evaluation returned a remote object without settlement support');
+      }
+      if (Date.now() >= deadline) throw timeoutError(timeout);
+      remoteHandleReleased = await awaitPromiseBeforeDeadline(
+        options.settleRemote(completion.objectId, mailboxName, {
+          timeout,
+          deadline,
+        }),
+        deadline,
+        timeout,
+      );
+    } else {
+      sourceCompletedByValue = true;
+      await completeByValue(evaluate, key, completion.value, { deadline, timeout });
+    }
 
     while (Date.now() < deadline) {
       const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {
@@ -104,6 +226,18 @@ export async function awaitAppResult(
     }
     throw timeoutError(timeout);
   } finally {
+    // Runtime.evaluate may still complete after the host-side deadline and
+    // return an object handle that never reaches settleRemote. Release the
+    // whole group best effort so late completions cannot accumulate handles.
+    if (!sourceCompletedByValue && !remoteHandleReleased) {
+      await releaseGroup();
+      if (sourceEvaluation && !sourceEvaluationSettled) {
+        // A transport timeout can race the engine's eventual response. Keep
+        // this continuation bounded and release the same unique group after
+        // that response arrives, without leaving a polling timer alive.
+        void sourceEvaluation.then(() => releaseGroup(), () => releaseGroup());
+      }
+    }
     // Also expires inside the app if the MCP process or CDP connection is lost.
     const remaining = deadline - Date.now();
     if (remaining > 0) {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -5,6 +5,15 @@ import { decodeCDPUnserializableValue } from './cdp.js';
 
 type Evaluate = PluginContext['evalInApp'];
 
+type SetupMailbox = (
+  expression: string,
+  options: { timeout?: number; deadline: number },
+) => Promise<number | undefined>;
+
+type RetryMailboxSetup = (
+  options: { timeout?: number; deadline: number },
+) => Promise<number | undefined>;
+
 export type AppEvaluationCompletion =
   | {
       /** Remote object handle for object and Promise completions. */
@@ -24,13 +33,10 @@ type EvaluateScript = (
     deadline?: number;
     objectGroup?: string;
     generation?: number;
+    /** Recreate the mailbox after a safe pre-dispatch source retry. */
+    retryMailboxSetup?: RetryMailboxSetup;
   },
 ) => Promise<AppEvaluationCompletion>;
-
-type SetupMailbox = (
-  expression: string,
-  options: { timeout?: number; deadline: number },
-) => Promise<number | undefined>;
 
 type SettleRemote = (
   objectId: string,
@@ -234,6 +240,9 @@ export async function awaitAppResult(
         deadline,
         objectGroup,
         generation: mailboxGeneration,
+        retryMailboxSetup: options.setupMailbox
+          ? (retryOptions) => options.setupMailbox!(mailboxSetup, retryOptions)
+          : undefined,
       });
       sourceEvaluation.then(
         () => { sourceEvaluationSettled = true; },

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -58,6 +58,9 @@ type DeadlineEvaluate<T> = (
   options: { timeout?: number; deadline: number; objectGroup?: string },
 ) => Promise<T>;
 
+const RELEASE_GROUP_TIMEOUT_MS = 100;
+const RELEASE_GROUP_AFTER_DEADLINE_MS = 250;
+
 async function evaluateBeforeDeadline<T>(
   evaluate: DeadlineEvaluate<T>,
   expression: string,
@@ -194,14 +197,19 @@ export async function awaitAppResult(
     : Math.min(timeoutDeadline, options.deadline);
   let sourceCompletedByValue = false;
   let remoteHandleReleased = false;
+  let sourceEvaluationStarted = false;
   let sourceEvaluation: Promise<AppEvaluationCompletion> | undefined;
   let sourceEvaluationSettled = false;
 
   const releaseGroup = async (): Promise<void> => {
     if (!options?.releaseObjectGroup) return;
     const remaining = deadline - Date.now();
-    if (remaining <= 0) return;
-    const releaseTimeout = Math.min(100, remaining);
+    // Cleanup is detached from the caller, so it may use a small independent
+    // budget after the caller deadline to release a handle whose evaluate
+    // response arrived late. Before the deadline, retain the caller bound.
+    const releaseTimeout = remaining > 0
+      ? Math.min(RELEASE_GROUP_TIMEOUT_MS, remaining)
+      : RELEASE_GROUP_AFTER_DEADLINE_MS;
     const releaseDeadline = Date.now() + releaseTimeout;
     await awaitPromiseBeforeDeadline(
       options.releaseObjectGroup(objectGroup, { timeout: releaseTimeout }),
@@ -247,6 +255,7 @@ export async function awaitAppResult(
     let completion: AppEvaluationCompletion;
     if (options?.evaluateScript) {
       if (Date.now() >= deadline) throw timeoutError(timeout);
+      sourceEvaluationStarted = true;
       sourceEvaluation = options.evaluateScript(expression, {
         timeout,
         deadline,
@@ -319,7 +328,7 @@ export async function awaitAppResult(
     // Runtime.evaluate may still complete after the host-side deadline and
     // return an object handle that never reaches settleRemote. Release the
     // whole group best effort so late completions cannot accumulate handles.
-    if (!sourceCompletedByValue && !remoteHandleReleased) {
+    if (sourceEvaluationStarted && !sourceCompletedByValue && !remoteHandleReleased) {
       // Cleanup has its own transport and host deadline. Keep it detached so
       // a result found within the caller's deadline is never delayed past it.
       void releaseGroup();

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -230,7 +230,9 @@ export async function awaitAppResult(
     // return an object handle that never reaches settleRemote. Release the
     // whole group best effort so late completions cannot accumulate handles.
     if (!sourceCompletedByValue && !remoteHandleReleased) {
-      await releaseGroup();
+      // Cleanup has its own transport and host deadline. Keep it detached so
+      // a result found within the caller's deadline is never delayed past it.
+      void releaseGroup();
       if (sourceEvaluation && !sourceEvaluationSettled) {
         // A transport timeout can race the engine's eventual response. Keep
         // this continuation bounded and release the same unique group after

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -65,7 +65,7 @@ async function evaluateBeforeDeadline<T>(
   );
 }
 
-async function awaitPromiseBeforeDeadline<T>(
+export async function awaitPromiseBeforeDeadline<T>(
   operation: Promise<T>,
   deadline: number,
   timeout: number,

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -202,7 +202,10 @@ export async function awaitAppResult(
       );
     } else {
       sourceCompletedByValue = true;
-      await completeByValue(evaluate, key, completion.value, { deadline, timeout });
+      // The source has already executed. A transport failure while writing its
+      // completion is safe to retry through the mailbox evaluator, which owns
+      // reconnect policy and never replays the caller's source.
+      await completeByValue(pollEvaluate, key, completion.value, { deadline, timeout });
     }
 
     while (Date.now() < deadline) {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -226,8 +226,14 @@ export async function awaitAppResult(
       Math.min(timeout, deadline - Date.now()),
     ) + 1000;
     const mailboxSetup = `(function() {
-      var state = { status: 'pending' };
       var root = this;
+      var PromiseCtor = root.Promise;
+      var state = {
+        status: 'pending',
+        promiseConstructor: PromiseCtor,
+        promiseResolve: PromiseCtor && PromiseCtor.resolve,
+        promiseThen: PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then
+      };
       root.Object.defineProperty(root, ${key}, {
         value: state, configurable: true
       });

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -264,7 +264,10 @@ export async function awaitAppResult(
       sourceCompletedByValue = true;
     }
 
-    if (completion.objectId) {
+    const runtimeGenerationChanged = mailboxGeneration !== undefined &&
+      options?.getRuntimeGeneration !== undefined &&
+      options.getRuntimeGeneration() !== mailboxGeneration;
+    if (completion.objectId && !runtimeGenerationChanged) {
       if (!options?.settleRemote) {
         throw new Error('App evaluation returned a remote object without settlement support');
       }
@@ -277,7 +280,7 @@ export async function awaitAppResult(
         deadline,
         timeout,
       );
-    } else {
+    } else if (!completion.objectId) {
       // Runtime.evaluate returns primitives by value when the source has no
       // remote object completion. They are already complete, so writing them
       // back through the mailbox would add an unnecessary request and poll.
@@ -285,6 +288,10 @@ export async function awaitAppResult(
       sourceCompletedByValue = true;
       return completion.value;
     }
+
+    // The source may have completed just before a reconnect changed the
+    // runtime generation. Its completion handle is now stale, but the
+    // source's mailbox observation is still the safe one-shot result.
 
     while (Date.now() < deadline) {
       const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { PluginContext } from '../plugin.js';
+import { decodeCDPUnserializableValue } from './cdp.js';
 
 type Evaluate = PluginContext['evalInApp'];
 
@@ -112,17 +113,6 @@ export interface AwaitAppResultOptions {
   getRuntimeGeneration?: () => number;
   /** Create the mailbox while bracketing the dispatch with generation checks. */
   setupMailbox?: SetupMailbox;
-}
-
-function decodeUnserializableValue(value: unknown): unknown {
-  if (value === 'NaN') return Number.NaN;
-  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
-  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
-  if (value === '-0') return -0;
-  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
-    return BigInt(value.slice(0, -1));
-  }
-  throw new Error('Unsupported CDP unserializable value');
 }
 
 function serializeCompletionValue(value: unknown): {
@@ -295,7 +285,7 @@ export async function awaitAppResult(
       if (result?.status === 'fulfilled') {
         return result.unserializableValue === undefined
           ? result.value
-          : decodeUnserializableValue(result.unserializableValue);
+          : decodeCDPUnserializableValue(result.unserializableValue);
       }
       if (result?.status === 'rejected') throw new Error(result.error);
       if (!result || result.status !== 'pending') {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -312,7 +312,10 @@ export async function awaitAppResult(
     // Also expires inside the app if the MCP process or CDP connection is lost.
     const remaining = deadline - Date.now();
     if (remaining > 0) {
-      await evaluateBeforeDeadline(cleanupEvaluate, `(function() {
+      // Cleanup is best effort and must not delay delivery of a value that has
+      // already settled. The mailbox also has an in-app expiry for a lost
+      // host, so leave this bounded operation detached from the caller.
+      void evaluateBeforeDeadline(cleanupEvaluate, `(function() {
         var state = globalThis[${key}];
         if (state) clearTimeout(state.timer);
         delete globalThis[${key}];

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -32,6 +32,7 @@ type EvaluateScript = (
     timeout?: number;
     deadline?: number;
     objectGroup?: string;
+    completionKey?: string;
     generation?: number;
     /** Recreate the mailbox after a safe pre-dispatch source retry. */
     retryMailboxSetup?: RetryMailboxSetup;
@@ -163,7 +164,8 @@ async function completeByValue(
   await evaluateBeforeDeadline(
     evaluate,
     `(function() {
-      var state = globalThis[${key}];
+      var root = this;
+      var state = root[${key}];
       if (state) {
         state.unserializableValue = ${unserializableValue};
         state.value = ${serialized.expression};
@@ -225,11 +227,12 @@ export async function awaitAppResult(
     ) + 1000;
     const mailboxSetup = `(function() {
       var state = { status: 'pending' };
-      Object.defineProperty(globalThis, ${key}, {
+      var root = this;
+      root.Object.defineProperty(root, ${key}, {
         value: state, configurable: true
       });
-      state.timer = setTimeout(function() {
-        if (globalThis[${key}] === state) delete globalThis[${key}];
+      state.timer = root.setTimeout(function() {
+        if (root[${key}] === state) delete root[${key}];
       }, ${mailboxLifetime});
       return true;
     })()`;
@@ -260,6 +263,7 @@ export async function awaitAppResult(
         timeout,
         deadline,
         objectGroup,
+        completionKey: mailboxName,
         generation: mailboxGeneration,
         retryMailboxSetup: options.setupMailbox
           ? (retryOptions) => options.setupMailbox!(mailboxSetup, retryOptions)
@@ -298,7 +302,8 @@ export async function awaitAppResult(
 
     while (Date.now() < deadline) {
       const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {
-        var state = globalThis[${key}];
+        var root = this;
+        var state = root[${key}];
         if (!state) return { status: 'missing' };
         return {
           status: state.status,
@@ -346,9 +351,10 @@ export async function awaitAppResult(
       // already settled. The mailbox also has an in-app expiry for a lost
       // host, so leave this bounded operation detached from the caller.
       void evaluateBeforeDeadline(cleanupEvaluate, `(function() {
-        var state = globalThis[${key}];
-        if (state) clearTimeout(state.timer);
-        delete globalThis[${key}];
+        var root = this;
+        var state = root[${key}];
+        if (state) root.clearTimeout(state.timer);
+        delete root[${key}];
       })()`, { timeout: Math.min(1000, remaining), deadline }, timeout).catch(() => {});
     }
   }

--- a/src/utils/cdp.ts
+++ b/src/utils/cdp.ts
@@ -14,3 +14,15 @@ export function extractCDPExceptionMessage(
     fallback
   );
 }
+
+/** Decode the primitive formats CDP cannot carry in JSON's value field. */
+export function decodeCDPUnserializableValue(value: unknown): unknown {
+  if (value === 'NaN') return Number.NaN;
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
+  if (value === '-0') return -0;
+  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
+    return BigInt(value.slice(0, -1));
+  }
+  throw new Error('Unsupported CDP unserializable value');
+}

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -77,6 +77,29 @@ describe('raw app evaluation', () => {
     await expect(evaluateAppScript(cdp, 'increment();')).rejects.toThrow('WebSocket closed');
     expect(calls).toHaveLength(1);
   });
+
+  test('preserves CDP unserializable primitive completions', async () => {
+    const values: Array<[string, unknown]> = [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['-0', -0],
+      ['123456789012345678901234567890n', 123456789012345678901234567890n],
+    ];
+    for (const [unserializableValue, expected] of values) {
+      const { cdp } = cdpHarness({
+        result: { type: 'number', unserializableValue },
+      });
+      const actual = await evaluateAppScript(cdp, 'completion');
+      if (typeof expected === 'number' && Object.is(expected, -0)) {
+        expect(Object.is(actual, -0)).toBe(true);
+      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+        expect(Number.isNaN(actual)).toBe(true);
+      } else {
+        expect(actual).toBe(expected);
+      }
+    }
+  });
 });
 
 function vmTransport() {
@@ -126,6 +149,9 @@ function vmTransport() {
     },
     replaceContext() {
       appGlobal = vm.createContext({ setTimeout, clearTimeout });
+      remoteObjects = new Map();
+    },
+    invalidateHandles() {
       remoteObjects = new Map();
     },
     get context() {
@@ -223,7 +249,7 @@ describe('shared app evaluation policy', () => {
     expect(calls.length).toBeGreaterThan(2);
   });
 
-  test('reconnects a remote settlement attachment lost before dispatch', async () => {
+  test('leaves a pre-dispatch settlement loss pending without replay', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let settlementAttempts = 0;
@@ -239,35 +265,91 @@ describe('shared app evaluation policy', () => {
 
     await expect(evalInApp(
       'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
-      { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe(1);
+      { awaitPromise: true, timeout: 40 },
+    )).rejects.toThrow('timed out');
     expect(transport.context).toHaveProperty('executionCount', 1);
     expect(state.state().reconnectCount).toBe(1);
-    expect(settlementAttempts).toBe(2);
+    expect(settlementAttempts).toBe(1);
   });
 
-  test('reconnects a remote settlement attachment after a lost response', async () => {
+  test('recovers a lost settlement response without replaying a side-effecting thenable', async () => {
     const { transport } = vmTransport();
     const originalSend = transport.send;
     let settlementAttempts = 0;
     transport.send = async (method, params) => {
-      const result = await originalSend(method, params);
       if (method === 'Runtime.callFunctionOn') {
         settlementAttempts += 1;
+        const result = await originalSend(method, params);
         if (settlementAttempts === 1) throw new Error('WebSocket closed');
+        return result;
       }
-      return result;
+      return originalSend(method, params);
     };
-    const state = lifecycle();
+    let reconnects = 0;
+    const state = lifecycle({ reconnect: async () => {
+      reconnects += 1;
+      transport.invalidateHandles();
+    } });
     const evalInApp = createAppEvaluator(transport, state);
 
     await expect(evalInApp(
-      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      `globalThis.thenCalls = 0;
+       ({ then: function(resolve) { globalThis.thenCalls += 1; resolve(7); } });`,
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe(1);
-    expect(transport.context).toHaveProperty('executionCount', 1);
-    expect(state.state().reconnectCount).toBe(1);
-    expect(settlementAttempts).toBe(2);
+    )).resolves.toBe(7);
+    expect(transport.context).toHaveProperty('thenCalls', 1);
+    expect(reconnects).toBe(1);
+    expect(settlementAttempts).toBe(1);
+  });
+
+  test('does not dispatch source when runtime generation changes after mailbox setup', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 0;
+    const base = lifecycle();
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+      ensureConnected: async () => {
+        if (calls.filter((call) => call.method === 'Runtime.evaluate').length === 1) {
+          generation += 1;
+        }
+      },
+    });
+
+    await expect(evalInApp(
+      'globalThis.sourceMutation = true; Promise.resolve(1);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('context changed before source dispatch');
+    expect(transport.context).not.toHaveProperty('sourceMutation');
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
+  });
+
+  test('rejects a generation change immediately after mailbox setup response', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 0;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        generation += 1;
+      }
+      return result;
+    };
+    const base = lifecycle();
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+    });
+
+    await expect(evalInApp(
+      'globalThis.sourceMutation = true; Promise.resolve(1);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('context changed during mailbox setup');
+    expect(transport.context).not.toHaveProperty('sourceMutation');
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
   });
 
   test('does not retry remote settlement after a deadline-bounded reconnect', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -770,6 +770,18 @@ describe('shared app evaluation policy', () => {
       'globalThis.flag = false; let i = 0; L: while (i < 1) { i += 1; Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { continue L; } }',
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('before');
+
+    const retainsFinalizerCompletionWhenCaught = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(retainsFinalizerCompletionWhenCaught(
+      'globalThis.flag = false; L: { Promise.resolve("before"); try { try {} finally { Promise.resolve("leak"); if (flag) break L; throw 0; } } catch {} }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('leak');
+
+    const inheritsGuardedCompletionThroughReplacedExit = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(inheritsGuardedCompletionThroughReplacedExit(
+      'if (true) { A: { B: try { Promise.resolve("guarded"); break A; } finally { break B; } } } else Promise.resolve("other")',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
   });
 
   test('observes a completion expression before trailing declarations', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -279,6 +279,57 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('serverLevelRetryCount'))).toHaveLength(1);
   });
 
+  test('does not retry a dispatched mutation that reports the server guidance string', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    const cdp = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>): Promise<unknown> => {
+        const result = await originalSend(method, params, options);
+        if (method === 'Runtime.evaluate' && String(params?.expression).includes('__dispatchedServerError')) {
+          return {
+            exceptionDetails: {
+              text: 'Not connected to Metro. Use list_devices to check connection status.',
+            },
+          };
+        }
+        return result;
+      },
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(cdp, state);
+
+    await expect(evalInApp(
+      'globalThis.__dispatchedServerError = (globalThis.__dispatchedServerError || 0) + 1; __dispatchedServerError;',
+      { awaitPromise: false, timeout: 1000 },
+    )).rejects.toThrow('Not connected to Metro. Use list_devices to check connection status.');
+    expect(transport.context).toHaveProperty('__dispatchedServerError', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('__dispatchedServerError'))).toHaveLength(1);
+  });
+
+  test('does not dispatch after server-level recovery reaches the deadline', async () => {
+    const { transport, calls } = vmTransport();
+    let ensureAttempts = 0;
+    const evalInApp = createAppEvaluator(transport, lifecycle({
+      ensureConnected: async () => {
+        ensureAttempts += 1;
+        throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+      },
+      reconnect: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40));
+      },
+    }));
+
+    await expect(evalInApp('globalThis.mustNotDispatch = true;', {
+      awaitPromise: false,
+      timeout: 10,
+      deadline: Date.now() + 10,
+    })).rejects.toThrow('timed out');
+    expect(ensureAttempts).toBe(1);
+    expect(calls).toHaveLength(0);
+  });
+
   test('does not retry a duration-bearing evaluation timeout after dispatch', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -257,6 +257,28 @@ describe('shared app evaluation policy', () => {
     expect(state.state().reconnectCount).toBe(1);
   });
 
+  test('retries the server-level disconnected error before raw source dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    let ensureAttempts = 0;
+    const state = lifecycle({
+      ensureConnected: async () => {
+        ensureAttempts += 1;
+        if (ensureAttempts === 1) {
+          throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+        }
+      },
+    });
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.serverLevelRetryCount = (globalThis.serverLevelRetryCount || 0) + 1; serverLevelRetryCount;',
+      { awaitPromise: false, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(ensureAttempts).toBe(2);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('serverLevelRetryCount'))).toHaveLength(1);
+  });
+
   test('does not retry a duration-bearing evaluation timeout after dispatch', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -1212,6 +1212,57 @@ describe('shared app evaluation policy', () => {
     expect(settlementAttempts).toBe(1);
   });
 
+  test('polls the mailbox when the runtime generation changes after source dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 1;
+    const originalSend = transport.send;
+    transport.send = async (method, params, options) => {
+      const result = await originalSend(method, params, options);
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('generationAfterSource')) {
+        generation += 1;
+      }
+      return result;
+    };
+    const base = lifecycle();
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+    });
+
+    await expect(evalInApp(
+      'globalThis.generationAfterSourceExecutions = (globalThis.generationAfterSourceExecutions || 0) + 1; globalThis.generationAfterSource = new Promise(resolve => setTimeout(() => resolve(7), 10)); generationAfterSource;',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(7);
+    expect(transport.context).toHaveProperty('generationAfterSourceExecutions', 1);
+    expect(calls.filter((call) => call.method === 'Runtime.callFunctionOn')).toHaveLength(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('generationAfterSource'))).toHaveLength(1);
+  });
+
+  test('polls the mailbox after a stale completion handle error', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params, options) => {
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        await originalSend(method, params, options);
+        throw new Error('Could not find object with given id');
+      }
+      return originalSend(method, params, options);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'globalThis.staleSettlementExecutions = (globalThis.staleSettlementExecutions || 0) + 1; new Promise(resolve => setTimeout(() => resolve(8), 10));',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(8);
+    expect(transport.context).toHaveProperty('staleSettlementExecutions', 1);
+    expect(settlementAttempts).toBe(1);
+    expect(calls.filter((call) => call.method === 'Runtime.callFunctionOn')).toHaveLength(1);
+  });
+
   test('recreates the mailbox when generation changes after mailbox setup', async () => {
     const { transport, calls } = vmTransport();
     let generation = 0;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -335,4 +335,27 @@ describe('shared app evaluation policy', () => {
       .resolves.toBe(1);
     expect(Date.now() - started).toBeLessThan(500);
   });
+
+  test('does not delay a settled remote result for bounded group cleanup', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let groupReleaseStarted = false;
+    transport.send = async (method, params, options) => {
+      if (method === 'Runtime.releaseObjectGroup') {
+        groupReleaseStarted = true;
+        return new Promise(() => {});
+      }
+      return originalSend(method, params, options);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const started = Date.now();
+
+    await expect(evalInApp(
+      'new Promise(resolve => setTimeout(() => resolve(42), 10));',
+      { awaitPromise: true, timeout: 40 },
+    )).resolves.toBe(42);
+    expect(Date.now() - started).toBeLessThan(100);
+    expect(groupReleaseStarted).toBe(true);
+    expect(calls.some((call) => call.method === 'Runtime.releaseObject')).toBe(false);
+  });
 });

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from 'bun:test';
+import vm from 'node:vm';
+import { createAppEvaluator, evaluateAppScript } from './evaluate-app.js';
+
+function cdpHarness(response: unknown) {
+  const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const cdp = {
+    send: async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (response instanceof Error) throw response;
+      return response;
+    },
+  };
+  return { cdp, calls };
+}
+
+describe('raw app evaluation', () => {
+  test('uses synchronous CDP completion semantics and forwards timeout', async () => {
+    const { cdp, calls } = cdpHarness({ result: { value: 42 } });
+    await expect(evaluateAppScript(cdp, 'var answer = 42; answer;', { timeout: 1234 }))
+      .resolves.toBe(42);
+    expect(calls).toEqual([{
+      method: 'Runtime.evaluate',
+      params: {
+        expression: 'var answer = 42; answer;',
+        returnByValue: true,
+        awaitPromise: false,
+        timeout: 1234,
+      },
+    }]);
+  });
+
+  test('reports CDP exceptions without replaying the script', async () => {
+    const { cdp, calls } = cdpHarness({
+      exceptionDetails: { text: 'script failed' },
+    });
+    await expect(evaluateAppScript(cdp, 'mutateOnce();')).rejects.toThrow('script failed');
+    expect(calls).toHaveLength(1);
+  });
+
+  test('propagates an ambiguous transport failure after one dispatch', async () => {
+    const { cdp, calls } = cdpHarness(new Error('WebSocket closed'));
+    await expect(evaluateAppScript(cdp, 'increment();')).rejects.toThrow('WebSocket closed');
+    expect(calls).toHaveLength(1);
+  });
+});
+
+function vmTransport() {
+  let appGlobal = vm.createContext({ setTimeout, clearTimeout });
+  const calls: Array<Record<string, unknown>> = [];
+  const transport = {
+    send: async (_method: string, params?: Record<string, unknown>) => {
+      calls.push(params ?? {});
+      const result = new vm.Script(String(params?.expression)).runInContext(appGlobal);
+      return {
+        result: {
+          value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)),
+        },
+      };
+    },
+    replaceContext() {
+      appGlobal = vm.createContext({ setTimeout, clearTimeout });
+    },
+    get context() {
+      return appGlobal;
+    },
+  };
+  return { transport, calls };
+}
+
+function lifecycle(overrides: Partial<{
+  ensureConnected: () => Promise<void>;
+  waitForReconnect: () => Promise<void>;
+  reconnect: () => Promise<void>;
+  isReconnecting: () => boolean;
+}> = {}) {
+  let reconnecting = false;
+  let reconnectCount = 0;
+  return {
+    state: () => ({ reconnectCount }),
+    ensureConnected: overrides.ensureConnected ?? (async () => {}),
+    waitForReconnect: overrides.waitForReconnect ?? (async () => {}),
+    reconnect: overrides.reconnect ?? (async () => { reconnectCount += 1; }),
+    isReconnecting: overrides.isReconnecting ?? (() => reconnecting),
+  };
+}
+
+describe('shared app evaluation policy', () => {
+  test('does not replay a script after an ambiguous initial dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const initialContext = transport.context;
+    let first = true;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (first) {
+        first = false;
+        throw new Error('WebSocket closed');
+      }
+      return result;
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('WebSocket closed');
+    expect(initialContext).toHaveProperty('executionCount', 1);
+    expect(calls).toHaveLength(2); // initial dispatch plus mailbox cleanup
+  });
+
+  test('reconnects mailbox reads without replaying the original source', async () => {
+    const { transport, calls } = vmTransport();
+    let firstPoll = true;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (firstPoll && calls.length === 1) {
+        firstPoll = false;
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; new Promise(resolve => setTimeout(() => resolve(executionCount), 10));',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(calls.length).toBeGreaterThan(2);
+  });
+
+  test('keeps unawaited evaluation one-shot after an ambiguous dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const initialContext = transport.context;
+    let first = true;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (first) {
+        first = false;
+        await originalSend(method, params);
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; executionCount;',
+      { awaitPromise: false },
+    )).rejects.toThrow('WebSocket closed');
+    expect(initialContext).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.awaitPromise).toBe(false);
+  });
+
+  test('reports a lost mailbox when reconnect lands in a new app context', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 1) transport.replaceContext();
+      return originalSend(method, params);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'new Promise(resolve => setTimeout(() => resolve(1), 20));',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('context was lost');
+  });
+
+  test('bounds a stalled initial CDP request by the caller deadline', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const transport = {
+      send: async (_method: string, params?: Record<string, unknown>) => {
+        calls.push(params ?? {});
+        return new Promise(() => {});
+      },
+    };
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
+      .rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 1) return new Promise(() => {});
+      return originalSend(method, params);
+    };
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
+      .rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('bounds reconnect recovery after a dropped mailbox read', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 0) return originalSend(method, params);
+      throw new Error('WebSocket closed');
+    };
+    const state = lifecycle({ reconnect: async () => new Promise(() => {}) });
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
+      .rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test('keeps stalled cleanup best effort within the absolute deadline', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 2) return new Promise(() => {});
+      return originalSend(method, params);
+    };
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
+      .resolves.toBe(1);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+});

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -223,6 +223,83 @@ describe('shared app evaluation policy', () => {
     expect(calls.length).toBeGreaterThan(2);
   });
 
+  test('reconnects a remote settlement attachment lost before dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        if (settlementAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(settlementAttempts).toBe(2);
+  });
+
+  test('reconnects a remote settlement attachment after a lost response', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        if (settlementAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return result;
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(settlementAttempts).toBe(2);
+  });
+
+  test('does not retry remote settlement after a deadline-bounded reconnect', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        if (settlementAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    let reconnects = 0;
+    const state = lifecycle({
+      reconnect: async () => {
+        reconnects += 1;
+        await new Promise((resolve) => setTimeout(resolve, 60));
+      },
+    });
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; new Promise(resolve => setTimeout(() => resolve(executionCount), 100));',
+      { awaitPromise: true, timeout: 30 },
+    )).rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(settlementAttempts).toBe(1);
+    expect(reconnects).toBe(1);
+  });
+
   test('keeps unawaited evaluation one-shot after an ambiguous dispatch', async () => {
     const { transport, calls } = vmTransport();
     const initialContext = transport.context;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -226,6 +226,20 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('executionCount'))).toHaveLength(1);
   });
 
+  test('settles hostile Promise rejection reasons instead of timing out', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'Promise.reject(Object.create(null))',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('unstringifiable reason');
+    await expect(evalInApp(
+      'Promise.reject({ get message() { throw new Error("message unavailable"); } })',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('[object Object]');
+  });
+
   test('reconnects mailbox reads without replaying the original source', async () => {
     const { transport, calls } = vmTransport();
     let firstPoll = true;
@@ -458,6 +472,30 @@ describe('shared app evaluation policy', () => {
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
     expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded cleanup
+  });
+
+  test('does not reconnect after a mailbox poll rejects after the deadline', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    let reconnects = 0;
+    transport.send = async (method, params, options) => {
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params, options);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle({
+      reconnect: async () => { reconnects += 1; },
+    }));
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 30 },
+    )).rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(reconnects).toBe(0);
   });
 
   test('bounds reconnect recovery after a dropped mailbox read', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -226,6 +226,120 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('executionCount'))).toHaveLength(1);
   });
 
+  test('retries an exact pre-dispatch disconnect without replaying a raw script', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let first = true;
+    let sourceAttempts = 0;
+    transport.send = async (method, params) => {
+      if (first && method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
+        first = false;
+        sourceAttempts += 1;
+        throw new Error('Not connected to CDP target');
+      }
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) sourceAttempts += 1;
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; executionCount;',
+      { awaitPromise: false },
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(sourceAttempts).toBe(2);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+    expect(state.state().reconnectCount).toBe(1);
+  });
+
+  test('does not retry a duration-bearing evaluation timeout after dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
+        throw new Error('App evaluation timed out after 30ms');
+      }
+      return result;
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; executionCount;',
+      { awaitPromise: false },
+    )).rejects.toThrow('App evaluation timed out after 30ms');
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
+  test('retries an exact pre-dispatch disconnect before awaited source execution', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let sourceAttempts = 0;
+    let setupAttempts = 0;
+    let generation = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        setupAttempts += 1;
+      }
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
+        sourceAttempts += 1;
+        if (sourceAttempts === 1) throw new Error('Not connected to CDP target');
+      }
+      return originalSend(method, params);
+    };
+    const base = lifecycle({ reconnect: async () => { generation += 1; } });
+    const state = { ...base, getGeneration: () => generation };
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(sourceAttempts).toBe(2);
+    expect(setupAttempts).toBe(2);
+    expect(generation).toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
+  test('retries mailbox setup after transport loss before source dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let setupAttempts = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        setupAttempts += 1;
+        if (setupAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(setupAttempts).toBe(2);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
   test('settles hostile Promise rejection reasons instead of timing out', async () => {
     const { transport } = vmTransport();
     const evalInApp = createAppEvaluator(transport, lifecycle());

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -966,6 +966,43 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
   });
 
+  test('recreates the mailbox after server-level recovery changes the runtime generation', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 1;
+    let ensureAttempts = 0;
+    let mailboxSetups = 0;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        mailboxSetups += 1;
+      }
+      return originalSend(method, params);
+    };
+    const base = lifecycle({
+      ensureConnected: async () => {
+        ensureAttempts += 1;
+        if (ensureAttempts === 2) {
+          throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+        }
+      },
+      reconnect: async () => { generation = 2; },
+    });
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+    });
+
+    await expect(evalInApp(
+      'globalThis.generationRecoverySource = (globalThis.generationRecoverySource || 0) + 1; Promise.resolve(generationRecoverySource);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(generation).toBe(2);
+    expect(mailboxSetups).toBe(2);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('generationRecoverySource'))).toHaveLength(1);
+  });
+
   test('does not retry remote settlement after a deadline-bounded reconnect', async () => {
     const { transport } = vmTransport();
     const originalSend = transport.send;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -198,7 +198,7 @@ describe('shared app evaluation policy', () => {
     await expect(evaluate('mutate()', { awaitPromise: true, timeout: 10 })).rejects.toThrow('timed out');
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(calls.filter((call) => call.method === 'Runtime.evaluate')).toHaveLength(0);
-    expect(calls).toHaveLength(1); // bounded late-completion group cleanup
+    expect(calls).toHaveLength(0); // no cleanup request remains within the deadline
   });
 
   test('does not replay a script after an ambiguous initial dispatch', async () => {
@@ -278,6 +278,81 @@ describe('shared app evaluation policy', () => {
     expect(state.state().reconnectCount).toBe(0);
     expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
+  test('does not retry an app exception that uses the Bridge disconnect message', async () => {
+    const { transport, calls } = vmTransport();
+    const cdp = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>): Promise<unknown> => {
+        const result = await transport.send(method, params, options);
+        if (method === 'Runtime.evaluate' &&
+            String(params?.expression).includes('__appExceptionMarker')) {
+          return { exceptionDetails: { text: 'Not connected to CDP target' } };
+        }
+        return result;
+      },
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(cdp, state);
+
+    await expect(evalInApp(
+      `globalThis.executionCount = (globalThis.executionCount || 0) + 1;
+       globalThis.__appExceptionMarker = true;
+       Promise.resolve(executionCount);`,
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('Not connected to CDP target');
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('__appExceptionMarker'))).toHaveLength(1);
+  });
+
+  test('does not retry a remote settlement app exception that uses the Bridge disconnect message', async () => {
+    const { transport, calls } = vmTransport();
+    const cdp = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>): Promise<unknown> => {
+        const result = await transport.send(method, params, options);
+        if (method === 'Runtime.callFunctionOn') {
+          return { exceptionDetails: { text: 'Not connected to CDP target' } };
+        }
+        return result;
+      },
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(cdp, state);
+
+    await expect(evalInApp(
+      'Promise.resolve(42)',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('Not connected to CDP target');
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.callFunctionOn')).toHaveLength(1);
+  });
+
+  test('honors an explicit absolute deadline across awaited stages', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const deadline = Date.now() + 40;
+    const started = Date.now();
+
+    await expect(evalInApp(
+      'new Promise(() => {})',
+      { awaitPromise: true, timeout: 1000, deadline },
+    )).rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test('keeps the requested timeout when an explicit deadline is later', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const deadline = Date.now() + 200;
+    const started = Date.now();
+
+    await expect(evalInApp(
+      'new Promise(() => {})',
+      { awaitPromise: true, timeout: 40, deadline },
+    )).rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(150);
   });
 
   test('retries an exact pre-dispatch disconnect before awaited source execution', async () => {
@@ -567,7 +642,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(2); // stalled setup plus bounded group cleanup
+    expect(calls).toHaveLength(1); // stalled setup; cleanup has no remaining budget
   });
 
   test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
@@ -585,7 +660,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded cleanup
+    expect(calls).toHaveLength(3); // setup, source, and stalled poll
   });
 
   test('does not reconnect after a mailbox poll rejects after the deadline', async () => {
@@ -651,9 +726,13 @@ describe('shared app evaluation policy', () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let groupReleaseStarted = false;
+    const deadline = Date.now() + 100;
     transport.send = async (method, params, options) => {
       if (method === 'Runtime.releaseObjectGroup') {
         groupReleaseStarted = true;
+        const timeoutMs = Number(options?.timeoutMs);
+        expect(timeoutMs).toBeLessThan(100);
+        expect(timeoutMs).toBeLessThanOrEqual(deadline - Date.now() + 2);
         return new Promise(() => {});
       }
       return originalSend(method, params, options);
@@ -662,8 +741,8 @@ describe('shared app evaluation policy', () => {
     const started = Date.now();
 
     await expect(evalInApp(
-      'new Promise(resolve => setTimeout(() => resolve(42), 10));',
-      { awaitPromise: true, timeout: 40 },
+      'new Promise(resolve => setTimeout(() => resolve(42), 70));',
+      { awaitPromise: true, timeout: 1000, deadline },
     )).resolves.toBe(42);
     expect(Date.now() - started).toBeLessThan(100);
     expect(groupReleaseStarted).toBe(true);

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -463,6 +463,20 @@ describe('shared app evaluation policy', () => {
     )).resolves.toBe('final loop completion');
     expect(transport.context.observedPromises).toContain('final');
     expect(transport.context.observedPromises).not.toContain('discarded');
+    await expect(evalInApp(
+      `marked(Promise.resolve('discarded branch value'), 'discarded-branch');
+       if (false) Promise.resolve('untaken');`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      `while (true) {
+         marked(Promise.resolve('discarded break value'), 'discarded-break');
+         if (true) break;
+       }`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    expect(transport.context.observedPromises).not.toContain('discarded-branch');
+    expect(transport.context.observedPromises).not.toContain('discarded-break');
     await expect(evalInApp('Promise.prototype.then = globalThis.originalThen; void 0;', {
       awaitPromise: false,
     })).resolves.toBeUndefined();
@@ -498,7 +512,11 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('"use strict"; if (false) Promise.resolve(9)', {
       awaitPromise: true,
       timeout: 1000,
-    })).resolves.toBe('use strict');
+    })).resolves.toBeUndefined();
+    await expect(evalInApp('"use strict"; while (false) Promise.resolve(9)', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBeUndefined();
     await expect(evalInApp('Promise.resolve(9) // trailing line comment', {
       awaitPromise: true,
       timeout: 1000,
@@ -513,9 +531,6 @@ describe('shared app evaluation policy', () => {
       'try { Promise.reject(new Error("try completion rejection")); } finally {}',
       'try { Promise.reject(new Error("try/finally completion rejection")); } finally { Promise.resolve(1); }',
       'switch (1) { case 1: Promise.resolve(1); case 2: Promise.reject(new Error("switch completion rejection")); break; }',
-      'switch (1) { case 1: Promise.reject(new Error("conditional break completion rejection")); if (true) break; Promise.resolve(2); }',
-      'for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("conditional continue completion rejection")); if (true) continue; Promise.resolve(2); }',
-      'const flag = true; L: for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("labeled continue completion rejection")); if (flag) continue L; Promise.resolve(2); }',
     ];
     let unhandledRejections = 0;
     const onUnhandledRejection = () => { unhandledRejections += 1; };
@@ -549,7 +564,6 @@ describe('shared app evaluation policy', () => {
   test('retains labeled break paths through finalizers and nested switches', async () => {
     const sources = [
       'const flag = true; L: { try { throw 1; } finally { if (flag) break L; } } Promise.reject(new Error("outer labeled completion rejection"));',
-      'const flag = true; L: { switch (1) { case 1: Promise.reject(new Error("nested switch labeled break rejection")); if (flag) break L; Promise.resolve(2); } }',
     ];
     let unhandledRejections = 0;
     const onUnhandledRejection = () => { unhandledRejections += 1; };
@@ -569,24 +583,60 @@ describe('shared app evaluation policy', () => {
         timeout: 1000,
       })).rejects.toThrow('outer labeled completion rejection');
 
-      const second = vmTransport();
-      const secondSend = second.transport.send;
-      second.transport.send = async (method, params, options) => {
-        const result = await secondSend(method, params, options);
-        if (method === 'Runtime.evaluate' && String(params?.expression).includes('nested switch labeled break rejection')) {
-          await new Promise((resolve) => setTimeout(resolve, 30));
-        }
-        return result;
-      };
-      await expect(createAppEvaluator(second.transport, lifecycle())(sources[1]!, {
-        awaitPromise: true,
-        timeout: 1000,
-      })).rejects.toThrow('nested switch labeled break rejection');
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(unhandledRejections).toBe(0);
     } finally {
       process.off('unhandledRejection', onUnhandledRejection);
     }
+  });
+
+  test('matches native empty completions across untaken branches and exits', async () => {
+    const evaluate = (source: string) => createAppEvaluator(vmTransport().transport, lifecycle())(
+      source,
+      { awaitPromise: true, timeout: 1000 },
+    );
+
+    await expect(evaluate('Promise.resolve("discarded"); if (false) 2')).resolves.toBeUndefined();
+    await expect(evaluate('while (false) Promise.resolve("discarded")')).resolves.toBeUndefined();
+    await expect(evaluate('for (let i = 0; i < 0; i += 1) Promise.resolve("discarded")'))
+      .resolves.toBeUndefined();
+    await expect(evaluate('while (true) { Promise.resolve("direct"); break; }'))
+      .resolves.toBe('direct');
+    await expect(evaluate('while (true) { Promise.resolve("conditional"); if (true) break; }'))
+      .resolves.toBeUndefined();
+    await expect(evaluate(
+      'let i = 0; while (i < 2) { i += 1; if (i === 1) { Promise.resolve("discarded"); continue; } Promise.resolve("final"); }',
+    )).resolves.toBe('final');
+    await expect(evaluate('switch (1) { case 1: Promise.resolve("direct"); break; }'))
+      .resolves.toBe('direct');
+    await expect(evaluate('switch (1) { case 1: Promise.resolve("conditional"); if (true) break; }'))
+      .resolves.toBeUndefined();
+    await expect(evaluate(
+      'while (true) { if (true) break; Promise.resolve("unreachable after break"); }',
+    )).resolves.toBeUndefined();
+    await expect(evaluate(
+      'let i = 0; while (i < 1) { i += 1; if (true) continue; Promise.resolve("unreachable after continue"); }',
+    )).resolves.toBeUndefined();
+  });
+
+  test('keeps guarded values only when a finally exit is not taken', async () => {
+    const taken = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(taken(
+      'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+
+    const skipped = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(skipped(
+      'globalThis.flag = false; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const continued = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(continued(
+      'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { if (i === 1) continue outer; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
   });
 
   test('observes a completion expression before trailing declarations', async () => {
@@ -978,7 +1028,7 @@ describe('shared app evaluation policy', () => {
     expect(settlementAttempts).toBe(1);
   });
 
-  test('does not dispatch source when runtime generation changes after mailbox setup', async () => {
+  test('recreates the mailbox when generation changes after mailbox setup', async () => {
     const { transport, calls } = vmTransport();
     let generation = 0;
     const base = lifecycle();
@@ -995,10 +1045,10 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp(
       'globalThis.sourceMutation = true; Promise.resolve(1);',
       { awaitPromise: true, timeout: 1000 },
-    )).rejects.toThrow('context changed before source dispatch');
-    expect(transport.context).not.toHaveProperty('sourceMutation');
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('sourceMutation', true);
     expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
+      String(call.params.expression).includes('sourceMutation'))).toHaveLength(1);
   });
 
   test('rejects a generation change immediately after mailbox setup response', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -125,10 +125,11 @@ function vmTransport() {
             (typeof result === 'object' || typeof result === 'function')) {
           const objectId = `remote-${++nextObjectId}`;
           remoteObjects.set(objectId, result);
+          const isPromise = Object.prototype.toString.call(result) === '[object Promise]';
           return {
             result: {
               type: 'object',
-              subtype: result instanceof Promise ? 'promise' : undefined,
+              subtype: isPromise ? 'promise' : undefined,
               objectId,
             },
           };
@@ -305,6 +306,343 @@ describe('shared app evaluation policy', () => {
     expect(state.state().reconnectCount).toBe(0);
     expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('__appExceptionMarker'))).toHaveLength(1);
+  });
+
+  test('observes an immediately rejected Promise during source evaluation', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'Promise.reject(new Error("immediate rejection"));',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('immediate rejection');
+
+    const sourceCall = calls.find((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('immediate rejection'));
+    expect(sourceCall?.params.awaitPromise).toBe(false);
+    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+    expect(calls.filter((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('immediate rejection'))).toHaveLength(1);
+
+    await expect(evalInApp(
+      'Promise.reject(new Error("line comment rejection")); // trailing comment',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('line comment rejection');
+    await expect(evalInApp(
+      'Promise.reject(new Error("block comment rejection")); /* trailing comment */',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('block comment rejection');
+    await expect(evalInApp(
+      'Promise.reject(new Error("repeated terminator rejection"));; /* trailing comment */',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('repeated terminator rejection');
+    await expect(evalInApp(
+      'Promise.reject(new Error("mixed terminator rejection")); /* c */ ; // d',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('mixed terminator rejection');
+  });
+
+  test('observes a rejected Promise before a delayed Runtime.evaluate response', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params, options) => {
+      const result = await originalSend(method, params, options);
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('delayed rejection')) {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+      }
+      return result;
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    let unhandledRejections = 0;
+    const onUnhandledRejection = () => { unhandledRejections += 1; };
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      await expect(evalInApp(
+        'const delayedPromise = Promise.reject(new Error("delayed rejection")); delayedPromise;',
+        { awaitPromise: true, timeout: 1000 },
+      )).rejects.toThrow('delayed rejection');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toBe(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('observes completion Promises through control-flow statements before a delayed response', async () => {
+    const sources = [
+      '{ Promise.reject(new Error("block completion rejection")); }',
+      'if (true) Promise.reject(new Error("if completion rejection"));',
+      'if (false) {} else Promise.reject(new Error("else completion rejection"));',
+      'try { Promise.reject(new Error("try completion rejection")); } finally {}',
+      'try { Promise.reject(new Error("try/finally completion rejection")); } finally { Promise.resolve(1); }',
+      'switch (1) { case 1: Promise.resolve(1); case 2: Promise.reject(new Error("switch completion rejection")); break; }',
+      'switch (1) { case 1: Promise.reject(new Error("conditional break completion rejection")); if (true) break; Promise.resolve(2); }',
+      'for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("conditional continue completion rejection")); if (true) continue; Promise.resolve(2); }',
+      'const flag = true; L: for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("labeled continue completion rejection")); if (flag) continue L; Promise.resolve(2); }',
+    ];
+    let unhandledRejections = 0;
+    const onUnhandledRejection = () => { unhandledRejections += 1; };
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      for (const source of sources) {
+        const { transport } = vmTransport();
+        const originalSend = transport.send;
+        transport.send = async (method, params, options) => {
+          const result = await originalSend(method, params, options);
+          if (method === 'Runtime.evaluate' && String(params?.expression).includes('completion rejection')) {
+            await new Promise((resolve) => setTimeout(resolve, 30));
+          }
+          return result;
+        };
+        const evalInApp = createAppEvaluator(transport, lifecycle());
+        try {
+          await expect(evalInApp(source, { awaitPromise: true, timeout: 1000 }))
+            .rejects.toThrow('completion rejection');
+        } catch (error) {
+          throw new Error(`${source}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toBe(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('retains labeled break paths through finalizers and nested switches', async () => {
+    const sources = [
+      'const flag = true; L: { try { throw 1; } finally { if (flag) break L; } } Promise.reject(new Error("outer labeled completion rejection"));',
+      'const flag = true; L: { switch (1) { case 1: Promise.reject(new Error("nested switch labeled break rejection")); if (flag) break L; Promise.resolve(2); } }',
+    ];
+    let unhandledRejections = 0;
+    const onUnhandledRejection = () => { unhandledRejections += 1; };
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      const first = vmTransport();
+      const firstSend = first.transport.send;
+      first.transport.send = async (method, params, options) => {
+        const result = await firstSend(method, params, options);
+        if (method === 'Runtime.evaluate' && String(params?.expression).includes('outer labeled completion rejection')) {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+        }
+        return result;
+      };
+      await expect(createAppEvaluator(first.transport, lifecycle())(sources[0]!, {
+        awaitPromise: true,
+        timeout: 1000,
+      })).rejects.toThrow('outer labeled completion rejection');
+
+      const second = vmTransport();
+      const secondSend = second.transport.send;
+      second.transport.send = async (method, params, options) => {
+        const result = await secondSend(method, params, options);
+        if (method === 'Runtime.evaluate' && String(params?.expression).includes('nested switch labeled break rejection')) {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+        }
+        return result;
+      };
+      await expect(createAppEvaluator(second.transport, lifecycle())(sources[1]!, {
+        awaitPromise: true,
+        timeout: 1000,
+      })).rejects.toThrow('nested switch labeled break rejection');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toBe(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('observes a completion expression before trailing declarations', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'const trailingPromise = Promise.reject(new Error("trailing declaration rejection")); trailingPromise; var afterCompletion = true;',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('trailing declaration rejection');
+    const sourceCall = calls.find((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('trailing declaration rejection'));
+    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+  });
+
+  test('does not invoke a native Promise subclass then override during observation', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      `(() => {
+        class TrackedPromise extends Promise {
+          then(...args) {
+            globalThis.thenOverrideCalls = (globalThis.thenOverrideCalls || 0) + 1;
+            return super.then(...args);
+          }
+        }
+        globalThis.thenOverrideCalls = 0;
+        return new TrackedPromise(resolve => resolve(7));
+      })()`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(7);
+    // The wrapper uses the intrinsic method; only SETTLE_REMOTE's single
+    // assimilation invokes the subclass override.
+    expect(transport.context).toHaveProperty('thenOverrideCalls', 1);
+  });
+
+  test('keeps declaration-form scripts in the direct evaluation scope', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('/* leading */ function /* interstitial */ persistedFunction() {}', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBeUndefined();
+    await expect(evalInApp('/* leading */ class /* interstitial */ PersistedClass {}', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBeUndefined();
+    await expect(evalInApp('typeof persistedFunction', {
+      awaitPromise: false,
+    })).resolves.toBe('function');
+    await expect(evalInApp('typeof PersistedClass', {
+      awaitPromise: false,
+    })).resolves.toBe('function');
+  });
+
+  test('observes sequence and parenthesized Promise expressions', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      '(Promise.resolve(1), Promise.resolve(2)); // sequence',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(2);
+    await expect(evalInApp(
+      '((Promise.resolve(3))); /* parenthesized */',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(3);
+    await expect(evalInApp(
+      'Promise.resolve("string // marker ;"); // trailing',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('string // marker ;');
+    await expect(evalInApp(
+      'Promise.resolve("no semicolon") // trailing without terminator',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('no semicolon');
+    await expect(evalInApp(
+      'Promise.resolve(`/template ; // marker`); /* trailing */',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('/template ; // marker');
+    await expect(evalInApp(
+      'Promise.resolve(/[//;]/.test("//;")); /* trailing */',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(true);
+    await expect(evalInApp(
+      'Promise.resolve(1); // first statement\n Promise.resolve(2)',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(2);
+  });
+
+  test('preserves direct eval bindings when observing a Promise expression', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'eval("var persistedByDirectEval = 41"), Promise.resolve(1);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    await expect(evalInApp('persistedByDirectEval', {
+      awaitPromise: false,
+    })).resolves.toBe(41);
+  });
+
+  test('preserves top-level arguments errors while observing Promise expressions', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'Promise.resolve(arguments.length);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('arguments is not defined');
+  });
+
+  test('preserves brace-leading direct script completion semantics', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('{ foo: 1 }', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(1);
+  });
+
+  test('leaves Proxy thenables to the single later assimilation path', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      `(() => {
+        globalThis.proxyPrototypeChecks = 0;
+        globalThis.proxyThenCalls = 0;
+        return new Proxy({
+        then(resolve) {
+          globalThis.proxyThenCalls = (globalThis.proxyThenCalls || 0) + 1;
+          resolve(9);
+        }
+      }, {
+        getPrototypeOf() {
+          globalThis.proxyPrototypeChecks = (globalThis.proxyPrototypeChecks || 0) + 1;
+          throw new Error('proxy prototype trap');
+        }
+        });
+      })()`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(9);
+    expect(transport.context).toMatchObject({
+      proxyPrototypeChecks: 0,
+      proxyThenCalls: 1,
+    });
+  });
+
+  test('does not mistake a Unicode identifier prefix for a declaration', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp('globalThis.functioné = Promise.resolve(6)', {
+      awaitPromise: false,
+    })).resolves.toBeDefined();
+    await expect(evalInApp('functioné;', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(6);
+    expect(calls.some((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('observePromise'))).toBe(true);
+  });
+
+  test('keeps anonymous and async/generator declarations direct', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const invalidDeclarations = [
+      'function() {}',
+      'class {}',
+      'async function() {}',
+      'function*() {}',
+      'async function*() {}',
+    ];
+
+    for (const source of invalidDeclarations) {
+      await expect(evalInApp(source, {
+        awaitPromise: true,
+        timeout: 1000,
+      })).rejects.toThrow();
+    }
+    const sourceExpressions = calls
+      .filter((call) => call.method === 'Runtime.evaluate')
+      .map((call) => String(call.params.expression));
+    for (const source of invalidDeclarations) {
+      expect(sourceExpressions).toContain(source);
+    }
   });
 
   test('does not retry a remote settlement app exception that uses the Bridge disconnect message', async () => {
@@ -645,6 +983,38 @@ describe('shared app evaluation policy', () => {
     expect(calls).toHaveLength(1); // stalled setup; cleanup has no remaining budget
   });
 
+  test('releases a late completion with a bounded post-deadline cleanup budget', async () => {
+    let resolveSource: ((result: unknown) => void) | undefined;
+    const calls: Array<{ method: string; options?: Record<string, unknown> }> = [];
+    const transport = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>) => {
+        calls.push({ method, options });
+        if (method === 'Runtime.evaluate' &&
+            String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          return { result: { value: true } };
+        }
+        if (method === 'Runtime.evaluate') {
+          return new Promise((resolve) => { resolveSource = resolve; });
+        }
+        if (method === 'Runtime.releaseObjectGroup') return { result: { value: true } };
+        return { result: { value: true } };
+      },
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('Promise.resolve(42)', { awaitPromise: true, timeout: 30 }))
+      .rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const release = calls.find((call) => call.method === 'Runtime.releaseObjectGroup');
+    expect(release?.options?.timeoutMs).toBe(250);
+
+    // A late source result gets the same best-effort cleanup path and never
+    // replays the source evaluation.
+    resolveSource?.({ result: { type: 'object', objectId: 'late-promise' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate')).toHaveLength(2);
+  });
+
   test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
@@ -660,7 +1030,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(3); // setup, source, and stalled poll
+    expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded group cleanup
   });
 
   test('does not reconnect after a mailbox poll rejects after the deadline', async () => {
@@ -726,12 +1096,12 @@ describe('shared app evaluation policy', () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let groupReleaseStarted = false;
-    const deadline = Date.now() + 100;
+    const deadline = Date.now() + 300;
     transport.send = async (method, params, options) => {
       if (method === 'Runtime.releaseObjectGroup') {
         groupReleaseStarted = true;
         const timeoutMs = Number(options?.timeoutMs);
-        expect(timeoutMs).toBeLessThan(100);
+        expect(timeoutMs).toBeLessThanOrEqual(100);
         expect(timeoutMs).toBeLessThanOrEqual(deadline - Date.now() + 2);
         return new Promise(() => {});
       }
@@ -744,7 +1114,9 @@ describe('shared app evaluation policy', () => {
       'new Promise(resolve => setTimeout(() => resolve(42), 70));',
       { awaitPromise: true, timeout: 1000, deadline },
     )).resolves.toBe(42);
-    expect(Date.now() - started).toBeLessThan(100);
+    // Keep this separate from the cleanup budget: a stalled release must not
+    // delay delivery of a result that already settled.
+    expect(Date.now() - started).toBeLessThan(250);
     expect(groupReleaseStarted).toBe(true);
     expect(calls.some((call) => call.method === 'Runtime.releaseObject')).toBe(false);
   });

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -443,6 +443,68 @@ describe('shared app evaluation policy', () => {
     }
   });
 
+  test('observes only the final loop completion without touching discarded values', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      `globalThis.observedPromises = [];
+       const originalThen = Promise.prototype.then;
+       globalThis.originalThen = originalThen;
+       Promise.prototype.then = function(...args) {
+         if (this.marker) globalThis.observedPromises.push(this.marker);
+         return originalThen.apply(this, args);
+       };
+       function marked(value, marker) { value.marker = marker; return value; }
+       for (let index = 0; index < 2; index += 1) {
+         if (index === 0) marked(Promise.resolve('discarded loop value'), 'discarded');
+         else marked(Promise.resolve('final loop completion'), 'final');
+       }`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('final loop completion');
+    expect(transport.context.observedPromises).toContain('final');
+    expect(transport.context.observedPromises).not.toContain('discarded');
+    await expect(evalInApp('Promise.prototype.then = globalThis.originalThen; void 0;', {
+      awaitPromise: false,
+    })).resolves.toBeUndefined();
+  });
+
+  test('uses the intrinsic global when the source shadows globalThis', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      'let globalThis = { shadowed: true }; Promise.resolve(7);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(7);
+
+    const byValue = vmTransport();
+    const evaluateByValue = createAppEvaluator(byValue.transport, lifecycle());
+    await expect(evaluateByValue('let globalThis = null; 42;', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(42);
+  });
+
+  test('preserves directive prologues while observing the final completion', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp('"use strict"; Promise.resolve(8);', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(8);
+    const sourceCall = calls.find((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('"use strict"'));
+    expect(String(sourceCall?.params.expression).startsWith('"use strict";')).toBe(true);
+    await expect(evalInApp('"use strict"; if (false) Promise.resolve(9)', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe('use strict');
+    await expect(evalInApp('Promise.resolve(9) // trailing line comment', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(9);
+  });
+
   test('observes completion Promises through control-flow statements before a delayed response', async () => {
     const sources = [
       '{ Promise.reject(new Error("block completion rejection")); }',
@@ -690,7 +752,7 @@ describe('shared app evaluation policy', () => {
     })).resolves.toBe(6);
     expect(calls.some((call) =>
       call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('observePromise'))).toBe(true);
+      String(call.params.expression).includes('PromiseCtor.prototype.then.call'))).toBe(true);
   });
 
   test('keeps anonymous and async/generator declarations direct', async () => {
@@ -774,7 +836,7 @@ describe('shared app evaluation policy', () => {
     let generation = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         setupAttempts += 1;
       }
       if (method === 'Runtime.evaluate' &&
@@ -806,7 +868,7 @@ describe('shared app evaluation policy', () => {
     let setupAttempts = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         setupAttempts += 1;
         if (setupAttempts === 1) throw new Error('WebSocket closed');
       }
@@ -946,7 +1008,7 @@ describe('shared app evaluation policy', () => {
     transport.send = async (method, params) => {
       const result = await originalSend(method, params);
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         generation += 1;
       }
       return result;
@@ -974,7 +1036,7 @@ describe('shared app evaluation policy', () => {
     const originalSend = transport.send;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         mailboxSetups += 1;
       }
       return originalSend(method, params);
@@ -1100,7 +1162,7 @@ describe('shared app evaluation policy', () => {
       send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>) => {
         calls.push({ method, options });
         if (method === 'Runtime.evaluate' &&
-            String(params?.expression).includes('Object.defineProperty(globalThis')) {
+            String(params?.expression).includes('Object.defineProperty(root')) {
           return { result: { value: true } };
         }
         if (method === 'Runtime.evaluate') {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -394,7 +394,7 @@ describe('shared app evaluation policy', () => {
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'));
     expect(sourceCall?.params.awaitPromise).toBe(false);
-    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
     expect(calls.filter((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'))).toHaveLength(1);
@@ -447,39 +447,49 @@ describe('shared app evaluation policy', () => {
     const { transport } = vmTransport();
     const evalInApp = createAppEvaluator(transport, lifecycle());
     await expect(evalInApp(
-      `globalThis.observedPromises = [];
-       const originalThen = Promise.prototype.then;
-       globalThis.originalThen = originalThen;
-       Promise.prototype.then = function(...args) {
-         if (this.marker) globalThis.observedPromises.push(this.marker);
-         return originalThen.apply(this, args);
+      `globalThis.observedThenables = [];
+       globalThis.markedThenable = function(value, marker) {
+         return { then: function(resolve) {
+           globalThis.observedThenables.push(marker);
+           resolve(value);
+         }};
        };
-       function marked(value, marker) { value.marker = marker; return value; }
        for (let index = 0; index < 2; index += 1) {
-         if (index === 0) marked(Promise.resolve('discarded loop value'), 'discarded');
-         else marked(Promise.resolve('final loop completion'), 'final');
+         if (index === 0) markedThenable('discarded loop value', 'discarded-loop');
+         else markedThenable('final loop completion', 'final');
        }`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('final loop completion');
-    expect(transport.context.observedPromises).toContain('final');
-    expect(transport.context.observedPromises).not.toContain('discarded');
+    expect(transport.context.observedThenables).toEqual(['final']);
     await expect(evalInApp(
-      `marked(Promise.resolve('discarded branch value'), 'discarded-branch');
-       if (false) Promise.resolve('untaken');`,
+      `markedThenable('discarded branch value', 'discarded-branch');
+       if (false) markedThenable('untaken', 'untaken');`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBeUndefined();
     await expect(evalInApp(
       `while (true) {
-         marked(Promise.resolve('discarded break value'), 'discarded-break');
+         markedThenable('discarded break value', 'discarded-break');
          if (true) break;
        }`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBeUndefined();
-    expect(transport.context.observedPromises).not.toContain('discarded-branch');
-    expect(transport.context.observedPromises).not.toContain('discarded-break');
-    await expect(evalInApp('Promise.prototype.then = globalThis.originalThen; void 0;', {
-      awaitPromise: false,
-    })).resolves.toBeUndefined();
+    expect(transport.context.observedThenables).toEqual(['final']);
+    await expect(evalInApp(
+      'let index = 0; while (index < 2) { index += 1; if (index === 1) Promise.resolve("first"); }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      "let switchIndex = 0; while (switchIndex++ < 2) { switch (switchIndex) { case 1: Promise.resolve('kept'); break; default: continue; } }",
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      "let mixedIndex = 0; while (mixedIndex++ < 2) { if (mixedIndex === 1) Promise.resolve('first'); if (false) Promise.resolve('never'); continue; }",
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      "let continueIndex = 0; while (continueIndex++ < 2) { Promise.resolve('kept'); continue; }",
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('kept');
   });
 
   test('uses the intrinsic global when the source shadows globalThis', async () => {
@@ -561,6 +571,21 @@ describe('shared app evaluation policy', () => {
     }
   });
 
+  test('leaves discarded prior values untransformed before empty catch or finally statements', async () => {
+    for (const source of [
+      "Promise.resolve('discarded'); try {} finally {}",
+      "Promise.resolve('discarded'); try {} catch {}",
+      "Promise.resolve('discarded'); try {} catch (error) {} finally {}",
+    ]) {
+      const { cdp, calls } = cdpHarness({ result: { value: undefined } });
+      await evaluateAppScriptCompletion(cdp, source, {
+        observePromiseRejection: true,
+        completionKey: 'empty-completion',
+      });
+      expect(calls[0]?.params?.expression).toBe(source);
+    }
+  });
+
   test('retains labeled break paths through finalizers and nested switches', async () => {
     const sources = [
       'const flag = true; L: { try { throw 1; } finally { if (flag) break L; } } Promise.reject(new Error("outer labeled completion rejection"));',
@@ -617,6 +642,8 @@ describe('shared app evaluation policy', () => {
     await expect(evaluate(
       'let i = 0; while (i < 1) { i += 1; if (true) continue; Promise.resolve("unreachable after continue"); }',
     )).resolves.toBeUndefined();
+    await expect(evaluate('1; L: { 2; if (false) break L; {} }'))
+      .resolves.toBeUndefined();
   });
 
   test('keeps guarded values only when a finally exit is not taken', async () => {
@@ -650,7 +677,7 @@ describe('shared app evaluation policy', () => {
     const sourceCall = calls.find((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('trailing declaration rejection'));
-    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
   });
 
   test('does not invoke a native Promise subclass then override during observation', async () => {
@@ -673,6 +700,28 @@ describe('shared app evaluation policy', () => {
     // The wrapper uses the intrinsic method; only SETTLE_REMOTE's single
     // assimilation invokes the subclass override.
     expect(transport.context).toHaveProperty('thenOverrideCalls', 1);
+  });
+
+  test('settles a Promise after the source clears the global Promise constructor', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      `const value = Promise.resolve(11);
+       globalThis.Promise = null;
+       value;`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(11);
+  });
+
+  test('settles a Promise after the source patches its Promise prototype', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      `const value = Promise.resolve(12);
+       Promise.prototype.then = function() { throw new Error('patched then'); };
+       value;`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(12);
   });
 
   test('keeps declaration-form scripts in the direct evaluation scope', async () => {
@@ -802,7 +851,7 @@ describe('shared app evaluation policy', () => {
     })).resolves.toBe(6);
     expect(calls.some((call) =>
       call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('PromiseCtor.prototype.then.call'))).toBe(true);
+      String(call.params.expression).includes('promiseThen.call'))).toBe(true);
   });
 
   test('keeps anonymous and async/generator declarations direct', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -394,7 +394,7 @@ describe('shared app evaluation policy', () => {
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'));
     expect(sourceCall?.params.awaitPromise).toBe(false);
-    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
+    expect(String(sourceCall?.params.expression)).toContain('state.observe(value)');
     expect(calls.filter((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'))).toHaveLength(1);
@@ -465,27 +465,29 @@ describe('shared app evaluation policy', () => {
       `markedThenable('discarded branch value', 'discarded-branch');
        if (false) markedThenable('untaken', 'untaken');`,
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('discarded branch value');
     await expect(evalInApp(
       `while (true) {
          markedThenable('discarded break value', 'discarded-break');
          if (true) break;
        }`,
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
-    expect(transport.context.observedThenables).toEqual(['final']);
+    )).resolves.toBe('discarded break value');
+    expect(transport.context.observedThenables).toEqual([
+      'final', 'discarded-branch', 'discarded-break',
+    ]);
     await expect(evalInApp(
       'let index = 0; while (index < 2) { index += 1; if (index === 1) Promise.resolve("first"); }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe(2);
     await expect(evalInApp(
       "let switchIndex = 0; while (switchIndex++ < 2) { switch (switchIndex) { case 1: Promise.resolve('kept'); break; default: continue; } }",
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('kept');
     await expect(evalInApp(
       "let mixedIndex = 0; while (mixedIndex++ < 2) { if (mixedIndex === 1) Promise.resolve('first'); if (false) Promise.resolve('never'); continue; }",
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('first');
     await expect(evalInApp(
       "let continueIndex = 0; while (continueIndex++ < 2) { Promise.resolve('kept'); continue; }",
       { awaitPromise: true, timeout: 1000 },
@@ -531,6 +533,10 @@ describe('shared app evaluation policy', () => {
       awaitPromise: true,
       timeout: 1000,
     })).resolves.toBe(9);
+    await expect(evalInApp('#! /usr/bin/env node\nPromise.resolve(10)', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(10);
   });
 
   test('observes completion Promises through control-flow statements before a delayed response', async () => {
@@ -571,7 +577,7 @@ describe('shared app evaluation policy', () => {
     }
   });
 
-  test('leaves discarded prior values untransformed before empty catch or finally statements', async () => {
+  test('retains prior values through empty catch and finally statements', async () => {
     for (const source of [
       "Promise.resolve('discarded'); try {} finally {}",
       "Promise.resolve('discarded'); try {} catch {}",
@@ -582,7 +588,8 @@ describe('shared app evaluation policy', () => {
         observePromiseRejection: true,
         completionKey: 'empty-completion',
       });
-      expect(calls[0]?.params?.expression).toBe(source);
+      expect(calls[0]?.params?.expression).not.toBe(source);
+      expect(String(calls[0]?.params?.expression)).toContain('Promise.resolve');
     }
   });
 
@@ -615,35 +622,62 @@ describe('shared app evaluation policy', () => {
     }
   });
 
-  test('matches native empty completions across untaken branches and exits', async () => {
+  test('matches Hermes completion inheritance across control-flow paths', async () => {
     const evaluate = (source: string) => createAppEvaluator(vmTransport().transport, lifecycle())(
       source,
       { awaitPromise: true, timeout: 1000 },
     );
 
-    await expect(evaluate('Promise.resolve("discarded"); if (false) 2')).resolves.toBeUndefined();
+    await expect(evaluate('Promise.resolve("discarded"); if (false) 2')).resolves.toBe('discarded');
     await expect(evaluate('while (false) Promise.resolve("discarded")')).resolves.toBeUndefined();
     await expect(evaluate('for (let i = 0; i < 0; i += 1) Promise.resolve("discarded")'))
       .resolves.toBeUndefined();
     await expect(evaluate('while (true) { Promise.resolve("direct"); break; }'))
       .resolves.toBe('direct');
     await expect(evaluate('while (true) { Promise.resolve("conditional"); if (true) break; }'))
-      .resolves.toBeUndefined();
+      .resolves.toBe('conditional');
     await expect(evaluate(
       'let i = 0; while (i < 2) { i += 1; if (i === 1) { Promise.resolve("discarded"); continue; } Promise.resolve("final"); }',
     )).resolves.toBe('final');
     await expect(evaluate('switch (1) { case 1: Promise.resolve("direct"); break; }'))
       .resolves.toBe('direct');
     await expect(evaluate('switch (1) { case 1: Promise.resolve("conditional"); if (true) break; }'))
-      .resolves.toBeUndefined();
+      .resolves.toBe('conditional');
+    await expect(evaluate(
+      'let continueIndex = 0; while (continueIndex++ < 1) { Promise.resolve("conditional continue"); if (true) continue; }',
+    )).resolves.toBe('conditional continue');
+    await expect(evaluate(
+      'let outerIndex = 0; outer: while (outerIndex++ < 2) { if (outerIndex === 1) Promise.resolve("nested value"); else for (let inner = 0; inner < 0; inner += 1) {} }',
+    )).resolves.toBe('nested value');
+    await expect(evaluate(
+      'let emptyIndex = 0; while (emptyIndex++ < 2) { if (emptyIndex === 1) Promise.resolve("empty iteration"); else {} }',
+    )).resolves.toBe('empty iteration');
+    await expect(evaluate(
+      'L: { Promise.resolve("label break"); if (true) break L; Promise.resolve("unreachable"); }',
+    )).resolves.toBe('label break');
+    await expect(evaluate(
+      'L: { Promise.resolve("try break"); try {} finally { if (true) break L; } }',
+    )).resolves.toBe('try break');
+    await expect(evaluate(
+      'L: { Promise.resolve("try catch break"); try { throw new Error("stop"); } catch { if (true) break L; } }',
+    )).resolves.toBe('try catch break');
+    await expect(evaluate(
+      'L: switch (1) { case 1: Promise.resolve("switch label"); if (true) break L; }',
+    )).resolves.toBe('switch label');
+    await expect(evaluate(
+      'L: switch (1) { case 1: try { Promise.resolve("switch finally"); } finally { if (true) break L; } }',
+    )).resolves.toBe('switch finally');
+    await expect(evaluate(
+      'let loopIndex = 0; while (loopIndex++ < 1) { Promise.resolve("loop abrupt"); if (true) break; }',
+    )).resolves.toBe('loop abrupt');
     await expect(evaluate(
       'while (true) { if (true) break; Promise.resolve("unreachable after break"); }',
     )).resolves.toBeUndefined();
     await expect(evaluate(
       'let i = 0; while (i < 1) { i += 1; if (true) continue; Promise.resolve("unreachable after continue"); }',
-    )).resolves.toBeUndefined();
+    )).resolves.toBe(1);
     await expect(evaluate('1; L: { 2; if (false) break L; {} }'))
-      .resolves.toBeUndefined();
+      .resolves.toBe(2);
   });
 
   test('keeps guarded values only when a finally exit is not taken', async () => {
@@ -651,7 +685,7 @@ describe('shared app evaluation policy', () => {
     await expect(taken(
       'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('guarded');
 
     const skipped = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(skipped(
@@ -663,7 +697,7 @@ describe('shared app evaluation policy', () => {
     await expect(continued(
       'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { if (i === 1) continue outer; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('guarded');
   });
 
   test('observes a completion expression before trailing declarations', async () => {
@@ -677,7 +711,7 @@ describe('shared app evaluation policy', () => {
     const sourceCall = calls.find((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('trailing declaration rejection'));
-    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
+    expect(String(sourceCall?.params.expression)).toContain('state.observe(value)');
   });
 
   test('does not invoke a native Promise subclass then override during observation', async () => {
@@ -722,6 +756,23 @@ describe('shared app evaluation policy', () => {
        value;`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe(12);
+  });
+
+  test('settles through the realm after an earlier evaluation poisons Promise.then', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      'Promise.prototype.then = function() { throw new Error("poisoned then"); }; 0;',
+      { awaitPromise: false, timeout: 1000 },
+    )).resolves.toBe(0);
+    await expect(evalInApp(
+      'Promise.resolve(42);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(42);
+    await expect(evalInApp(
+      'Promise.reject(new Error("poisoned rejection"));',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('poisoned rejection');
   });
 
   test('keeps declaration-form scripts in the direct evaluation scope', async () => {
@@ -851,7 +902,7 @@ describe('shared app evaluation policy', () => {
     })).resolves.toBe(6);
     expect(calls.some((call) =>
       call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('promiseThen.call'))).toBe(true);
+      String(call.params.expression).includes('state.observe(value)'))).toBe(true);
   });
 
   test('keeps anonymous and async/generator declarations direct', async () => {
@@ -1024,7 +1075,7 @@ describe('shared app evaluation policy', () => {
     expect(calls.length).toBeGreaterThan(2);
   });
 
-  test('leaves a pre-dispatch settlement loss pending without replay', async () => {
+  test('survives a lost redundant settlement response without replaying the source', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let settlementAttempts = 0;
@@ -1041,7 +1092,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp(
       'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
       { awaitPromise: true, timeout: 40 },
-    )).rejects.toThrow('timed out');
+    )).resolves.toBe(1);
     expect(transport.context).toHaveProperty('executionCount', 1);
     expect(state.state().reconnectCount).toBe(1);
     expect(settlementAttempts).toBe(1);

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -698,6 +698,36 @@ describe('shared app evaluation policy', () => {
       'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { if (i === 1) continue outer; } }',
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('guarded');
+
+    const skippedAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(skippedAfterValue(
+      'globalThis.flag = false; L: try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const takenAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(takenAfterValue(
+      'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { Promise.resolve("finalizer exit"); if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('finalizer exit');
+
+    const skippedContinueAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(skippedContinueAfterValue(
+      'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (i > 1) continue outer; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const nested = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nested(
+      'L: try { Promise.resolve("guarded"); } finally { try { Promise.resolve("discarded outer finalizer"); } finally { Promise.resolve("discarded inner finalizer"); if (false) break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const directive = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(directive(
+      'L: try { Promise.resolve("guarded"); } finally { "use strict"; Promise.resolve("discarded finalizer"); if (false) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
   });
 
   test('observes a completion expression before trailing declarations', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -545,7 +545,7 @@ describe('shared app evaluation policy', () => {
       'if (true) Promise.reject(new Error("if completion rejection"));',
       'if (false) {} else Promise.reject(new Error("else completion rejection"));',
       'try { Promise.reject(new Error("try completion rejection")); } finally {}',
-      'try { Promise.reject(new Error("try/finally completion rejection")); } finally { Promise.resolve(1); }',
+      'try { Promise.resolve(1); } finally { Promise.reject(new Error("try/finally completion rejection")); }',
       'switch (1) { case 1: Promise.resolve(1); case 2: Promise.reject(new Error("switch completion rejection")); break; }',
     ];
     let unhandledRejections = 0;
@@ -680,7 +680,29 @@ describe('shared app evaluation policy', () => {
       .resolves.toBe(2);
   });
 
-  test('keeps guarded values only when a finally exit is not taken', async () => {
+  test('returns normal finally values as direct Hermes evaluation does', async () => {
+    for (const source of [
+      'try { 1; } finally { 2; }',
+      'L: try { 1; } finally { 2; if (false) break L; }',
+      'try { Promise.resolve(1); } finally { Promise.resolve(2); }',
+      'L: try { Promise.resolve(1); } finally { Promise.resolve(2); if (false) break L; }',
+      'L: { try { Promise.resolve(1); break L; } finally { Promise.resolve(2); } }',
+    ]) {
+      const evaluate = createAppEvaluator(vmTransport().transport, lifecycle());
+      await expect(evaluate(source, { awaitPromise: true, timeout: 1000 })).resolves.toBe(2);
+    }
+  });
+
+  test('does not observe a guarded thenable replaced by a normal finalizer', async () => {
+    const evaluate = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(evaluate(
+      'this.finallyThenCalls = 0; try { ({ then(resolve) { finallyThenCalls += 1; resolve(1); } }); } finally { Promise.resolve(2); }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(2);
+    await expect(evaluate('finallyThenCalls', { awaitPromise: true, timeout: 1000 })).resolves.toBe(0);
+  });
+
+  test('preserves the last reached Hermes value through normal and abrupt finalizers', async () => {
     const taken = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(taken(
       'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
@@ -703,7 +725,7 @@ describe('shared app evaluation policy', () => {
     await expect(skippedAfterValue(
       'globalThis.flag = false; L: try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (flag) break L; }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded finalizer');
 
     const takenAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(takenAfterValue(
@@ -715,19 +737,19 @@ describe('shared app evaluation policy', () => {
     await expect(skippedContinueAfterValue(
       'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (i > 1) continue outer; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded finalizer');
 
     const nested = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(nested(
       'L: try { Promise.resolve("guarded"); } finally { try { Promise.resolve("discarded outer finalizer"); } finally { Promise.resolve("discarded inner finalizer"); if (false) break L; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded inner finalizer');
 
     const directive = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(directive(
       'L: try { Promise.resolve("guarded"); } finally { "use strict"; Promise.resolve("discarded finalizer"); if (false) break L; }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded finalizer');
 
     const nestedFinallyExit = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(nestedFinallyExit(
@@ -739,7 +761,7 @@ describe('shared app evaluation policy', () => {
     await expect(nestedConditionalFinallyExit(
       'globalThis.flag = false; L: try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { if (flag) break L; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('outer');
+    )).resolves.toBe('inner');
 
     const nestedFinallyContinue = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(nestedFinallyContinue(

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, test } from 'bun:test';
 import vm from 'node:vm';
-import { createAppEvaluator, evaluateAppScript } from './evaluate-app.js';
+import {
+  createAppEvaluator,
+  evaluateAppScript,
+  evaluateAppScriptCompletion,
+} from './evaluate-app.js';
 
 function cdpHarness(response: unknown) {
-  const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const calls: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
   const cdp = {
-    send: async (method: string, params?: Record<string, unknown>) => {
-      calls.push({ method, params });
+    send: async (
+      method: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => {
+      calls.push({ method, params, options });
       if (response instanceof Error) throw response;
       return response;
     },
@@ -27,6 +39,7 @@ describe('raw app evaluation', () => {
         awaitPromise: false,
         timeout: 1234,
       },
+      options: { timeoutMs: 1234 },
     }]);
   });
 
@@ -38,6 +51,27 @@ describe('raw app evaluation', () => {
     expect(calls).toHaveLength(1);
   });
 
+  test('keeps the engine timeout with a remote completion group', async () => {
+    const { cdp, calls } = cdpHarness({
+      result: { type: 'object', subtype: 'promise', objectId: 'promise-1' },
+    });
+    await expect(evaluateAppScriptCompletion(cdp, 'Promise.resolve(42)', {
+      timeout: 321,
+      objectGroup: 'group-1',
+    })).resolves.toEqual({ objectId: 'promise-1' });
+    expect(calls[0]).toEqual({
+      method: 'Runtime.evaluate',
+      params: {
+        expression: 'Promise.resolve(42)',
+        returnByValue: false,
+        awaitPromise: false,
+        timeout: 321,
+        objectGroup: 'group-1',
+      },
+      options: { timeoutMs: 321 },
+    });
+  });
+
   test('propagates an ambiguous transport failure after one dispatch', async () => {
     const { cdp, calls } = cdpHarness(new Error('WebSocket closed'));
     await expect(evaluateAppScript(cdp, 'increment();')).rejects.toThrow('WebSocket closed');
@@ -47,19 +81,52 @@ describe('raw app evaluation', () => {
 
 function vmTransport() {
   let appGlobal = vm.createContext({ setTimeout, clearTimeout });
-  const calls: Array<Record<string, unknown>> = [];
+  let nextObjectId = 0;
+  let remoteObjects = new Map<string, unknown>();
+  const calls: Array<{
+    method: string;
+    params: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
   const transport = {
-    send: async (_method: string, params?: Record<string, unknown>) => {
-      calls.push(params ?? {});
-      const result = new vm.Script(String(params?.expression)).runInContext(appGlobal);
-      return {
-        result: {
-          value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)),
-        },
-      };
+    send: async (
+      method: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => {
+      const actualParams = params ?? {};
+      calls.push({ method, params: actualParams, options });
+      if (method === 'Runtime.evaluate') {
+        const result = new vm.Script(String(actualParams.expression)).runInContext(appGlobal);
+        if (actualParams.returnByValue === false && result !== null &&
+            (typeof result === 'object' || typeof result === 'function')) {
+          const objectId = `remote-${++nextObjectId}`;
+          remoteObjects.set(objectId, result);
+          return {
+            result: {
+              type: 'object',
+              subtype: result instanceof Promise ? 'promise' : undefined,
+              objectId,
+            },
+          };
+        }
+        return {
+          result: {
+            value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)),
+          },
+        };
+      }
+      if (method === 'Runtime.callFunctionOn') {
+        const object = remoteObjects.get(String(actualParams.objectId));
+        const fn = new vm.Script(`(${String(actualParams.functionDeclaration)})`).runInContext(appGlobal) as Function;
+        fn.call(object, ...((actualParams.arguments as Array<{ value: unknown }> | undefined)?.map((arg) => arg.value) ?? []));
+        return { result: { value: true } };
+      }
+      return { result: { value: undefined } };
     },
     replaceContext() {
       appGlobal = vm.createContext({ setTimeout, clearTimeout });
+      remoteObjects = new Map();
     },
     get context() {
       return appGlobal;
@@ -86,6 +153,28 @@ function lifecycle(overrides: Partial<{
 }
 
 describe('shared app evaluation policy', () => {
+  test('passes only the remaining deadline to transport after connection setup', async () => {
+    const { cdp, calls } = cdpHarness({ result: { value: 42 } });
+    const evaluate = createAppEvaluator(cdp, lifecycle({
+      ensureConnected: async () => { await new Promise((resolve) => setTimeout(resolve, 30)); },
+    }));
+    const deadline = Date.now() + 200;
+    expect(await evaluate('42', { timeout: 200, deadline })).toBe(42);
+    expect(calls[0].options?.timeoutMs).toBeGreaterThan(0);
+    expect(calls[0].options?.timeoutMs).toBeLessThanOrEqual(175);
+  });
+
+  test('does not dispatch after connection setup outlives the caller deadline', async () => {
+    const { cdp, calls } = cdpHarness({ result: { value: 42 } });
+    const evaluate = createAppEvaluator(cdp, lifecycle({
+      ensureConnected: async () => { await new Promise((resolve) => setTimeout(resolve, 50)); },
+    }));
+    await expect(evaluate('mutate()', { awaitPromise: true, timeout: 10 })).rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate')).toHaveLength(0);
+    expect(calls).toHaveLength(1); // bounded late-completion group cleanup
+  });
+
   test('does not replay a script after an ambiguous initial dispatch', async () => {
     const { transport, calls } = vmTransport();
     const initialContext = transport.context;
@@ -93,7 +182,8 @@ describe('shared app evaluation policy', () => {
     const originalSend = transport.send;
     transport.send = async (method, params) => {
       const result = await originalSend(method, params);
-      if (first) {
+      if (first && method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
         first = false;
         throw new Error('WebSocket closed');
       }
@@ -106,7 +196,8 @@ describe('shared app evaluation policy', () => {
       { awaitPromise: true, timeout: 1000 },
     )).rejects.toThrow('WebSocket closed');
     expect(initialContext).toHaveProperty('executionCount', 1);
-    expect(calls).toHaveLength(2); // initial dispatch plus mailbox cleanup
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
   });
 
   test('reconnects mailbox reads without replaying the original source', async () => {
@@ -114,7 +205,8 @@ describe('shared app evaluation policy', () => {
     let firstPoll = true;
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (firstPoll && calls.length === 1) {
+      if (firstPoll && method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('return { status:')) {
         firstPoll = false;
         throw new Error('WebSocket closed');
       }
@@ -154,14 +246,16 @@ describe('shared app evaluation policy', () => {
     expect(initialContext).toHaveProperty('executionCount', 1);
     expect(state.state().reconnectCount).toBe(0);
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.awaitPromise).toBe(false);
+    expect(calls[0]?.params.awaitPromise).toBe(false);
   });
 
   test('reports a lost mailbox when reconnect lands in a new app context', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 1) transport.replaceContext();
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        transport.replaceContext();
+      }
       return originalSend(method, params);
     };
     const evalInApp = createAppEvaluator(transport, lifecycle());
@@ -186,14 +280,16 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2); // stalled setup plus bounded group cleanup
   });
 
   test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 1) return new Promise(() => {});
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        return new Promise(() => {});
+      }
       return originalSend(method, params);
     };
     const started = Date.now();
@@ -202,15 +298,17 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded cleanup
   });
 
   test('bounds reconnect recovery after a dropped mailbox read', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 0) return originalSend(method, params);
-      throw new Error('WebSocket closed');
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
     };
     const state = lifecycle({ reconnect: async () => new Promise(() => {}) });
     const started = Date.now();
@@ -225,7 +323,9 @@ describe('shared app evaluation policy', () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 2) return new Promise(() => {});
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('clearTimeout(state.timer)')) {
+        return new Promise(() => {});
+      }
       return originalSend(method, params);
     };
     const started = Date.now();

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -859,6 +859,57 @@ describe('shared app evaluation policy', () => {
     )).rejects.toThrow('poisoned rejection');
   });
 
+  test('keeps the awaited mailbox hidden and read-only with normal intrinsics', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(`(function() {
+      var prefix = '__METRO_MCP_ASYNC_';
+      var key = Object.getOwnPropertyNames(this).find(name => name.startsWith(prefix));
+      var descriptor = Object.getOwnPropertyDescriptor(this, key);
+      var iterated = [];
+      for (var name in this) if (name.startsWith(prefix)) iterated.push(name);
+      return {
+        enumerable: descriptor.enumerable,
+        writable: descriptor.writable,
+        configurable: descriptor.configurable,
+        keys: Object.keys(this).filter(name => name.startsWith(prefix)),
+        iterated: iterated
+      };
+    })()`, { awaitPromise: true, timeout: 1000 })).resolves.toEqual({
+      enumerable: false, writable: false, configurable: true, keys: [], iterated: [],
+    });
+  });
+
+  test('creates a mailbox after an earlier evaluation mutates Object globals', async () => {
+    for (const mutation of [
+      'Object.defineProperty = null; 0;',
+      'Object = null; 0;',
+      'Object.defineProperty = function() {}; 0;',
+    ]) {
+      const { transport } = vmTransport();
+      const evalInApp = createAppEvaluator(transport, lifecycle());
+      await expect(evalInApp(mutation, { awaitPromise: true, timeout: 1000 }))
+        .resolves.toBe(0);
+      await expect(evalInApp(
+        'Promise.resolve(13);',
+        { awaitPromise: true, timeout: 1000 },
+      )).resolves.toBe(13);
+      await expect(evalInApp(`(function() {
+        var root = this;
+        var keys = Reflect.ownKeys(root).filter(name => typeof name === 'string' && name.startsWith('__METRO_MCP_ASYNC_'));
+        return {
+          found: keys.length > 0,
+          hidden: keys.every(function(key) {
+            var descriptor = Reflect.getOwnPropertyDescriptor(root, key);
+            return descriptor.enumerable === false && descriptor.writable === false;
+          })
+        };
+      })()`, { awaitPromise: true, timeout: 1000 })).resolves.toEqual({
+        found: true, hidden: true,
+      });
+    }
+  });
+
   test('keeps declaration-form scripts in the direct evaluation scope', async () => {
     const { transport } = vmTransport();
     const evalInApp = createAppEvaluator(transport, lifecycle());
@@ -1070,7 +1121,7 @@ describe('shared app evaluation policy', () => {
     let generation = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         setupAttempts += 1;
       }
       if (method === 'Runtime.evaluate' &&
@@ -1102,7 +1153,7 @@ describe('shared app evaluation policy', () => {
     let setupAttempts = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         setupAttempts += 1;
         if (setupAttempts === 1) throw new Error('WebSocket closed');
       }
@@ -1293,7 +1344,7 @@ describe('shared app evaluation policy', () => {
     transport.send = async (method, params) => {
       const result = await originalSend(method, params);
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         generation += 1;
       }
       return result;
@@ -1321,7 +1372,7 @@ describe('shared app evaluation policy', () => {
     const originalSend = transport.send;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         mailboxSetups += 1;
       }
       return originalSend(method, params);
@@ -1447,7 +1498,7 @@ describe('shared app evaluation policy', () => {
       send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>) => {
         calls.push({ method, options });
         if (method === 'Runtime.evaluate' &&
-            String(params?.expression).includes('Object.defineProperty(root')) {
+            String(params?.expression).includes("status: 'pending'")) {
           return { result: { value: true } };
         }
         if (method === 'Runtime.evaluate') {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -728,6 +728,48 @@ describe('shared app evaluation policy', () => {
       'L: try { Promise.resolve("guarded"); } finally { "use strict"; Promise.resolve("discarded finalizer"); if (false) break L; }',
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('guarded');
+
+    const nestedFinallyExit = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nestedFinallyExit(
+      'L: try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('inner');
+
+    const nestedConditionalFinallyExit = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nestedConditionalFinallyExit(
+      'globalThis.flag = false; L: try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { if (flag) break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('outer');
+
+    const nestedFinallyContinue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nestedFinallyContinue(
+      'let i = 0; L: while (i < 1) { i += 1; try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { continue L; } } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('inner');
+
+    const conditionalGuardedBreak = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(conditionalGuardedBreak(
+      'globalThis.flag = true; L: { Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const emptyGuardedBreak = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(emptyGuardedBreak(
+      'globalThis.flag = false; L: { Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('before');
+
+    const conditionalGuardedContinue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(conditionalGuardedContinue(
+      'globalThis.flag = true; let i = 0; L: while (i < 1) { i += 1; Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { continue L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const emptyGuardedContinue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(emptyGuardedContinue(
+      'globalThis.flag = false; let i = 0; L: while (i < 1) { i += 1; Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { continue L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('before');
   });
 
   test('observes a completion expression before trailing declarations', async () => {

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -169,6 +169,22 @@ function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath
   };
 }
 
+function inheritEmptyExit(prior: CompletionPath, path: ExitPath): ExitPath {
+  if (!path.empty || !path.inherit) return path;
+  return {
+    expressions: [...prior.expressions, ...path.expressions],
+    clearRanges: [...prior.clearRanges],
+    empty: prior.empty && path.empty,
+    normal: path.normal,
+    label: path.label,
+    inherit: path.inherit,
+  };
+}
+
+function inheritEmptyExits(prior: CompletionPath, paths: ExitPath[]): ExitPath[] {
+  return paths.map((path) => inheritEmptyExit(prior, path));
+}
+
 function mergeCompletions(left: Completion, right: Completion): Completion {
   const merged = mergePaths(left, right);
   return {
@@ -250,15 +266,23 @@ function completionForStatement(statement: StatementLike): Completion {
       const guarded = mergeCompletions(body, handler);
       if (!statement.finalizer) return guarded;
       const finalizer = completionForStatement(statement.finalizer as StatementLike);
-      if (!finalizer.normal) return finalizer;
+      const finalizerBreaks = inheritEmptyExits(guarded, finalizer.breaks);
+      const finalizerContinues = inheritEmptyExits(guarded, finalizer.continues);
+      if (!finalizer.normal) {
+        return {
+          ...finalizer,
+          breaks: finalizerBreaks,
+          continues: finalizerContinues,
+        };
+      }
       // A normal `finally` completion is UpdateEmpty: its expression value is
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
       const applied = applyFinallyCompletion(guarded, finalizer);
       return {
         ...applied,
-        breaks: [...guarded.breaks, ...finalizer.breaks],
-        continues: [...guarded.continues, ...finalizer.continues],
+        breaks: [...guarded.breaks, ...finalizerBreaks],
+        continues: [...guarded.continues, ...finalizerContinues],
       };
     }
     case 'LabeledStatement':
@@ -329,15 +353,11 @@ function completionForStatements(statements: StatementLike[]): Completion {
     const next = completionForStatement(statement);
     const breaks: ExitPath[] = [
       ...completion.breaks,
-      ...next.breaks.map((path) => path.empty && path.inherit
-        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
-        : path),
+      ...inheritEmptyExits(completion, next.breaks),
     ];
     const continues: ExitPath[] = [
       ...completion.continues,
-      ...next.continues.map((path) => path.empty && path.inherit
-        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
-        : path),
+      ...inheritEmptyExits(completion, next.continues),
     ];
     if (!next.normal) {
       return { ...next, breaks, continues };

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -130,12 +130,6 @@ type Completion = CompletionPath & {
   breaks: ExitPath[];
   continues: ExitPath[];
 };
-type FinallyRestore = {
-  entry: number;
-  exit: number;
-  slot: string;
-};
-
 const emptyCompletion = (): Completion => ({
   expressions: [],
   clearRanges: [],
@@ -153,16 +147,6 @@ const abruptCompletion = (): Completion => ({
   breaks: [],
   continues: [],
 });
-
-function applyFinallyCompletion(
-  guarded: Completion,
-  _finalizer: Completion,
-): CompletionPath {
-  // A normal finally completion is always discarded by TryStatement. The
-  // guarded completion is returned whether the finalizer's own completion is
-  // empty, undefined, or a value; only an abrupt finalizer replaces it.
-  return guarded;
-}
 
 function completionFromExit(path: ExitPath): CompletionPath {
   return path.inherit ? { ...path, clearRanges: [] } : path;
@@ -292,12 +276,13 @@ function completionForStatement(statement: StatementLike): Completion {
           continues: finalizerContinues,
         };
       }
-      // A normal `finally` completion is UpdateEmpty: its expression value is
-      // discarded, while the prior try/catch completion is retained. This is
-      // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
-      const applied = applyFinallyCompletion(guarded, finalizer);
+      // Hermes retains the last reached expression, including a normally
+      // completing finalizer. Capture both paths in execution order so an
+      // empty finalizer inherits the guarded value and a valued one replaces it.
       return {
-        ...applied,
+        ...mergePaths(guarded, finalizer),
+        empty: guarded.empty && finalizer.empty,
+        normal: guarded.normal,
         breaks: [...guarded.breaks, ...finalizerBreaks],
         continues: [...guarded.continues, ...finalizerContinues],
       };
@@ -388,74 +373,6 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
-function collectFinallyRestores(
-  statement: StatementLike,
-  restores: FinallyRestore[] = [],
-): FinallyRestore[] {
-  switch (statement.type) {
-    case 'BlockStatement':
-      for (const child of (statement.body as StatementLike[] | undefined) ?? []) {
-        collectFinallyRestores(child, restores);
-      }
-      break;
-    case 'IfStatement':
-      collectFinallyRestores(statement.consequent as StatementLike, restores);
-      if (statement.alternate) {
-        collectFinallyRestores(statement.alternate as StatementLike, restores);
-      }
-      break;
-    case 'TryStatement': {
-      collectFinallyRestores(statement.block as StatementLike, restores);
-      const handler = statement.handler as { body: StatementLike } | null | undefined;
-      if (handler) collectFinallyRestores(handler.body, restores);
-      const finalizer = statement.finalizer as StatementLike | null | undefined;
-      if (finalizer) {
-        const completion = completionForStatement(finalizer);
-        const hasEscapingValue = [...completion.breaks, ...completion.continues]
-          .some((path) => path.expressions.length > 0);
-        const start = finalizer.start;
-        const end = finalizer.end;
-        if (
-          completion.normal &&
-          hasEscapingValue &&
-          typeof start === 'number' &&
-          typeof end === 'number'
-        ) {
-          const directives = (finalizer.directives as Array<{ end?: number | null }> | undefined) ?? [];
-          restores.push({
-            entry: directives.length > 0
-              ? directives[directives.length - 1]!.end as number
-              : start + 1,
-            exit: end - 1,
-            slot: `finally:${start}:${end}`,
-          });
-        }
-        collectFinallyRestores(finalizer, restores);
-      }
-      break;
-    }
-    case 'LabeledStatement':
-    case 'WithStatement':
-    case 'ForStatement':
-    case 'ForInStatement':
-    case 'ForOfStatement':
-    case 'WhileStatement':
-    case 'DoWhileStatement':
-      collectFinallyRestores(statement.body as StatementLike, restores);
-      break;
-    case 'SwitchStatement':
-      for (const switchCase of (
-        statement.cases as Array<{ consequent: StatementLike[] }> | undefined
-      ) ?? []) {
-        for (const child of switchCase.consequent) {
-          collectFinallyRestores(child, restores);
-        }
-      }
-      break;
-  }
-  return restores;
-}
-
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -498,21 +415,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
-  const finallyRestores = collectFinallyRestores({
-    type: 'BlockStatement',
-    body: ast.program.body as StatementLike[],
-  });
-  const saveFinallyCompletion = (slot: string): string => `(function(root) {
-    var state = root[${keyLiteral}];
-    if (state) state[${JSON.stringify(slot)}] = state.completionValue;
-  })(this)`;
-  const restoreFinallyCompletion = (slot: string): string => `(function(root) {
-    var state = root[${keyLiteral}];
-    if (state) {
-      state.completionValue = state[${JSON.stringify(slot)}];
-      delete state[${JSON.stringify(slot)}];
-    }
-  })(this)`;
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -527,15 +429,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
-    ...finallyRestores.flatMap(({ entry, exit, slot }) => [{
-      start: exit,
-      end: exit,
-      replacement: `;\n${restoreFinallyCompletion(slot)};\n`,
-    }, {
-      start: entry,
-      end: entry,
-      replacement: `;\n${saveFinallyCompletion(slot)};\n`,
-    }]),
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
     transformed = transformed.slice(0, start) + replacement +

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -185,6 +185,11 @@ function inheritEmptyExits(prior: CompletionPath, paths: ExitPath[]): ExitPath[]
   return paths.map((path) => inheritEmptyExit(prior, path));
 }
 
+function completionWithEscapingValues(completion: Completion): CompletionPath {
+  return [...completion.breaks, ...completion.continues]
+    .reduce(mergePaths, completion);
+}
+
 function mergeCompletions(left: Completion, right: Completion): Completion {
   const merged = mergePaths(left, right);
   return {
@@ -266,8 +271,9 @@ function completionForStatement(statement: StatementLike): Completion {
       const guarded = mergeCompletions(body, handler);
       if (!statement.finalizer) return guarded;
       const finalizer = completionForStatement(statement.finalizer as StatementLike);
-      const finalizerBreaks = inheritEmptyExits(guarded, finalizer.breaks);
-      const finalizerContinues = inheritEmptyExits(guarded, finalizer.continues);
+      const guardedWithEscapingValues = completionWithEscapingValues(guarded);
+      const finalizerBreaks = inheritEmptyExits(guardedWithEscapingValues, finalizer.breaks);
+      const finalizerContinues = inheritEmptyExits(guardedWithEscapingValues, finalizer.continues);
       if (!finalizer.normal) {
         return {
           ...finalizer,

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -156,42 +156,27 @@ export function createAppEvaluator(
     options: { timeout?: number; deadline: number },
   ): Promise<boolean> => {
     const remaining = Math.max(1, options.deadline - Date.now());
-    let settled = false;
-    let released = false;
-    try {
-      const result = (await cdp.send(
-        'Runtime.callFunctionOn',
-        {
-          objectId,
-          functionDeclaration: SETTLE_REMOTE_FUNCTION,
-          arguments: [{ value: mailboxKey }],
-          returnByValue: true,
-        },
-        { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
-      )) as Record<string, unknown>;
-      if (result.exceptionDetails) {
-        throw new Error(
-          extractCDPExceptionMessage(
-            result.exceptionDetails as Record<string, unknown>,
-          ),
-        );
-      }
-      settled = ((result.result as Record<string, unknown> | undefined)?.value !== false);
-    } finally {
-      // The completion handle is only needed while its settlement callback is
-      // being attached. Releasing it avoids retaining every awaited Promise.
-      try {
-        await cdp.send(
-          'Runtime.releaseObject',
-          { objectId },
-          { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
-        );
-        released = true;
-      } catch {
-        // The object group cleanup in awaitAppResult remains the fallback.
-      }
+    const result = (await cdp.send(
+      'Runtime.callFunctionOn',
+      {
+        objectId,
+        functionDeclaration: SETTLE_REMOTE_FUNCTION,
+        arguments: [{ value: mailboxKey }],
+        returnByValue: true,
+      },
+      { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+    )) as Record<string, unknown>;
+    if (result.exceptionDetails) {
+      throw new Error(
+        extractCDPExceptionMessage(
+          result.exceptionDetails as Record<string, unknown>,
+        ),
+      );
     }
-    return settled && released;
+    // Keep the unique object group responsible for cleanup. Its separately
+    // bounded release runs after mailbox settlement, so handle cleanup cannot
+    // delay polling or leave a detached, permanently pending transport call.
+    return false;
   };
 
   const releaseObjectGroup = async (

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -50,7 +50,9 @@ function isDefinitivePreDispatchFailure(error: unknown): boolean {
   return (
     error instanceof Error &&
     !(error instanceof AppEvaluationError) &&
-    error.message === 'Not connected to CDP target'
+    (error.message === 'Not connected to CDP target' ||
+      error.message ===
+        'Not connected to Metro. Use list_devices to check connection status.')
   );
 }
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -101,6 +101,8 @@ async function sendRuntimeEvaluate(
 
 type StatementLike = {
   type: string;
+  start?: number | null;
+  end?: number | null;
   body?: unknown;
   expression?: ExpressionLike;
   [key: string]: unknown;
@@ -108,10 +110,12 @@ type StatementLike = {
 type ExpressionLike = { start: number | null; end: number | null };
 type CompletionPath = {
   expressions: ExpressionLike[];
+  clearRanges: Array<{ start: number; end: number; kind: 'break' | 'continue'; label: string | null }>;
   empty: boolean;
+  undefined: boolean;
   normal: boolean;
 };
-type ExitPath = CompletionPath & { label: string | null };
+type ExitPath = CompletionPath & { label: string | null; inherit: boolean };
 type Completion = CompletionPath & {
   breaks: ExitPath[];
   continues: ExitPath[];
@@ -119,7 +123,9 @@ type Completion = CompletionPath & {
 
 const emptyCompletion = (): Completion => ({
   expressions: [],
+  clearRanges: [],
   empty: true,
+  undefined: false,
   normal: true,
   breaks: [],
   continues: [],
@@ -127,16 +133,71 @@ const emptyCompletion = (): Completion => ({
 
 const abruptCompletion = (): Completion => ({
   expressions: [],
+  clearRanges: [],
   empty: false,
+  undefined: false,
   normal: false,
   breaks: [],
   continues: [],
 });
 
+const undefinedCompletion = (): Completion => ({
+  expressions: [],
+  clearRanges: [],
+  empty: false,
+  undefined: true,
+  normal: true,
+  breaks: [],
+  continues: [],
+});
+
+function normalizeControlCompletion(completion: Completion): Completion {
+  return {
+    ...completion,
+    empty: false,
+    undefined: completion.undefined || completion.empty,
+  };
+}
+
+function asFinallyCompletion(completion: Completion): Completion {
+  // A normal finalizer uses UpdateEmpty. Control statements such as an
+  // untaken if/loop therefore preserve the guarded completion in a finally
+  // clause, even though they produce undefined at script level.
+  return {
+    ...completion,
+    empty: completion.empty || completion.undefined,
+    undefined: false,
+  };
+}
+
+function applyFinallyCompletion(
+  guarded: Completion,
+  _finalizer: Completion,
+): CompletionPath {
+  // A normal finally completion is always discarded by TryStatement. The
+  // guarded completion is returned whether the finalizer's own completion is
+  // empty, undefined, or a value; only an abrupt finalizer replaces it.
+  return guarded;
+}
+
+function markNonInheritingExits(completion: Completion): Completion {
+  return {
+    ...completion,
+    breaks: completion.breaks.map((path) => ({ ...path, inherit: false })),
+    continues: completion.continues.map((path) => ({ ...path, inherit: false })),
+  };
+}
+
+function completionFromExit(path: ExitPath): CompletionPath {
+  return path.inherit ? { ...path, clearRanges: [] } : path;
+}
+
 function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath {
   return {
     expressions: [...left.expressions, ...right.expressions],
+    clearRanges: [...left.clearRanges, ...right.clearRanges],
     empty: left.empty || right.empty,
+    undefined: left.undefined || right.undefined,
     normal: left.normal || right.normal,
   };
 }
@@ -154,7 +215,7 @@ function consumeBreaks(completion: Completion, label: string | null = null): Com
   let normal: CompletionPath = completion;
   const remaining: ExitPath[] = [];
   for (const path of completion.breaks) {
-    if (path.label === label) normal = mergePaths(normal, path);
+    if (path.label === label) normal = mergePaths(normal, completionFromExit(path));
     else remaining.push(path);
   }
   return { ...normal, breaks: remaining, continues: completion.continues };
@@ -165,11 +226,11 @@ function consumeLoopExits(completion: Completion): Completion {
   const breaks: ExitPath[] = [];
   const continues: ExitPath[] = [];
   for (const path of completion.breaks) {
-    if (path.label === null) normal = mergePaths(normal, path);
+    if (path.label === null) normal = mergePaths(normal, completionFromExit(path));
     else breaks.push(path);
   }
   for (const path of completion.continues) {
-    if (path.label === null) normal = mergePaths(normal, path);
+    if (path.label === null) normal = mergePaths(normal, completionFromExit(path));
     else continues.push(path);
   }
   return { ...normal, breaks, continues };
@@ -180,7 +241,7 @@ function consumeLabelExits(completion: Completion, label: string): Completion {
   let normal: CompletionPath = afterBreaks;
   const continues: ExitPath[] = [];
   for (const path of afterBreaks.continues) {
-    if (path.label === label) normal = mergePaths(normal, path);
+    if (path.label === label) normal = mergePaths(normal, completionFromExit(path));
     else continues.push(path);
   }
   return { ...normal, breaks: afterBreaks.breaks, continues };
@@ -197,7 +258,9 @@ function completionForStatement(statement: StatementLike): Completion {
     case 'ExpressionStatement':
       return statement.expression ? {
         expressions: [statement.expression],
+        clearRanges: [],
         empty: false,
+        undefined: false,
         normal: true,
         breaks: [],
         continues: [],
@@ -210,8 +273,10 @@ function completionForStatement(statement: StatementLike): Completion {
       const consequent = completionForStatement(statement.consequent as StatementLike);
       const alternate = statement.alternate
         ? completionForStatement(statement.alternate as StatementLike)
-        : emptyCompletion();
-      return mergeCompletions(consequent, alternate);
+        : undefinedCompletion();
+      return normalizeControlCompletion(markNonInheritingExits(
+        mergeCompletions(consequent, alternate),
+      ));
     }
     case 'TryStatement': {
       const body = completionForStatement(statement.block as StatementLike);
@@ -219,16 +284,25 @@ function completionForStatement(statement: StatementLike): Completion {
         ? completionForStatement((statement.handler as { body: StatementLike }).body)
         : abruptCompletion();
       const guarded = mergeCompletions(body, handler);
-      if (!statement.finalizer) return guarded;
-      const finalizer = completionForStatement(statement.finalizer as StatementLike);
+      if (!statement.finalizer) return normalizeControlCompletion(guarded);
+      const finalizer = asFinallyCompletion(
+        completionForStatement(statement.finalizer as StatementLike),
+      );
       if (!finalizer.normal) return finalizer;
       // A normal `finally` completion is UpdateEmpty: its expression value is
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
+      const applied = applyFinallyCompletion(guarded, finalizer);
       return {
-        ...guarded,
-        breaks: [...guarded.breaks, ...finalizer.breaks],
-        continues: [...guarded.continues, ...finalizer.continues],
+        ...applied,
+        breaks: [
+          ...guarded.breaks,
+          ...finalizer.breaks.map((path) => ({ ...path, inherit: false })),
+        ],
+        continues: [
+          ...guarded.continues,
+          ...finalizer.continues.map((path) => ({ ...path, inherit: false })),
+        ],
       };
     }
     case 'LabeledStatement':
@@ -237,42 +311,61 @@ function completionForStatement(statement: StatementLike): Completion {
         (statement.label as { name: string } | null | undefined)?.name ?? '',
       );
     case 'WithStatement':
-      return completionForStatement(statement.body as StatementLike);
+      return normalizeControlCompletion(markNonInheritingExits(
+        completionForStatement(statement.body as StatementLike),
+      ));
     case 'SwitchStatement': {
       const cases = (statement.cases as Array<{ consequent: StatementLike[] }> | undefined) ?? [];
-      let completion = emptyCompletion();
+      let completion = undefinedCompletion();
       for (let index = 0; index < cases.length; index += 1) {
         const caseCompletion = completionForStatements(
           cases.slice(index).flatMap((entry) => entry.consequent),
         );
         completion = mergeCompletions(
           completion,
-          consumeBreaks(caseCompletion),
+          normalizeControlCompletion(consumeBreaks(caseCompletion)),
         );
       }
-      return completion;
+      return normalizeControlCompletion(completion);
     }
     case 'ForStatement':
     case 'ForInStatement':
     case 'ForOfStatement':
     case 'WhileStatement':
     case 'DoWhileStatement':
-      return mergeCompletions(
-        consumeLoopExits(completionForStatement(statement.body as StatementLike)),
-        emptyCompletion(),
+      const body = normalizeControlCompletion(
+        completionForStatement(statement.body as StatementLike),
       );
+      const loop = consumeLoopExits(body);
+      return statement.type === 'DoWhileStatement'
+        ? normalizeControlCompletion(loop)
+        : normalizeControlCompletion(mergeCompletions(loop, undefinedCompletion()));
     case 'ThrowStatement':
     case 'ReturnStatement':
       return abruptCompletion();
     case 'BreakStatement':
       return {
         ...abruptCompletion(),
-        breaks: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+        breaks: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          inherit: true,
+          clearRanges: [{
+            start: statement.start as number,
+            end: statement.end as number,
+            kind: 'break',
+            label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          }] }],
       };
     case 'ContinueStatement':
       return {
         ...abruptCompletion(),
-        continues: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+        continues: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          inherit: true,
+          clearRanges: [{
+            start: statement.start as number,
+            end: statement.end as number,
+            kind: 'continue',
+            label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          }] }],
       };
     default:
       return abruptCompletion();
@@ -285,11 +378,15 @@ function completionForStatements(statements: StatementLike[]): Completion {
     const next = completionForStatement(statement);
     const breaks: ExitPath[] = [
       ...completion.breaks,
-      ...next.breaks.map((path) => path.empty ? { ...completion, label: path.label } : path),
+      ...next.breaks.map((path) => path.empty && path.inherit
+        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
+        : path),
     ];
     const continues: ExitPath[] = [
       ...completion.continues,
-      ...next.continues.map((path) => path.empty ? { ...completion, label: path.label } : path),
+      ...next.continues.map((path) => path.empty && path.inherit
+        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
+        : path),
     ];
     if (!next.normal) {
       return { ...next, breaks, continues };
@@ -326,6 +423,10 @@ function promiseObservationExpression(expression: string, completionKey?: string
   if (!completionKey) return expression;
   const key = completionKey;
   const keyLiteral = JSON.stringify(key);
+  const clearCompletion = `(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) state.completionValue = void 0;
+  })(this)`;
   const capture = (candidate: string): string => `(function(root, value) {
     var state = root[${keyLiteral}];
     if (state) state.completionValue = value;
@@ -333,11 +434,31 @@ function promiseObservationExpression(expression: string, completionKey?: string
   })(this, (\n    ${candidate}
   ))`;
   let transformed = expression;
-  for (const { start, end } of candidates
-    .map(({ start, end }) => ({ start: start as number, end: end as number }))
-    .sort((left, right) => right.start - left.start)) {
-    const candidate = expression.slice(start, end);
-    transformed = transformed.slice(0, start) + capture(candidate) + transformed.slice(end);
+  const clearRanges = completion.clearRanges.filter((range, index, all) =>
+    all.findIndex((other) =>
+      other.start === range.start &&
+      other.end === range.end &&
+      other.kind === range.kind &&
+      other.label === range.label,
+    ) === index,
+  );
+  const replacements = [
+    ...candidates.map(({ start, end }) => ({
+      start: start as number,
+      end: end as number,
+      replacement: capture(expression.slice(start as number, end as number)),
+    })),
+    ...clearRanges.map(({ start, end, kind, label }) => ({
+      start,
+      end,
+      // A plain block keeps an unlabeled break/continue targeted at its
+      // original enclosing switch or loop. An artificial loop here would
+      // capture that exit and change the caller's control flow.
+      replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
+    })),
+  ].sort((left, right) => right.start - left.start);
+  for (const { start, end, replacement } of replacements) {
+    transformed = transformed.slice(0, start) + replacement + transformed.slice(end);
   }
   const directives = (ast.program.directives as Array<{
     end?: number | null;
@@ -346,12 +467,9 @@ function promiseObservationExpression(expression: string, completionKey?: string
   const directiveEnd = directives.length > 0
     ? directives[directives.length - 1]!.end as number
     : 0;
-  const initialValue = directives.length > 0
-    ? JSON.stringify(directives[directives.length - 1]!.value?.value)
-    : 'void 0';
   const setup = `;\n(function(root) {
     var state = root[${keyLiteral}];
-    if (state) state.completionValue = ${initialValue};
+    if (state) state.completionValue = void 0;
   })(this);\n`;
   transformed = transformed.slice(0, directiveEnd) + setup + transformed.slice(directiveEnd);
   const observe = `(function(root) {
@@ -523,7 +641,10 @@ export function createAppEvaluator(
     let sourceGeneration = options?.generation;
     const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
       const recovered = await ensureConnectedForDispatch(options);
-      if (recovered && options?.retryMailboxSetup) {
+      const generationChanged = sourceGeneration !== undefined &&
+        lifecycle.getGeneration &&
+        sourceGeneration !== lifecycle.getGeneration();
+      if ((recovered || generationChanged) && options?.retryMailboxSetup) {
         if (options.deadline === undefined) {
           throw new Error('App evaluation retry requires a deadline');
         }
@@ -532,11 +653,8 @@ export function createAppEvaluator(
           deadline: options.deadline,
         });
       }
-      if (
-        sourceGeneration !== undefined &&
-        lifecycle.getGeneration &&
-        sourceGeneration !== lifecycle.getGeneration()
-      ) {
+      if (sourceGeneration !== undefined && lifecycle.getGeneration &&
+          sourceGeneration !== lifecycle.getGeneration()) {
         throw new Error('App evaluation context changed before source dispatch');
       }
       const timeout = boundedRequestTimeout(options);

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -59,6 +59,17 @@ function isServerDisconnectedError(error: unknown): boolean {
     error.message === 'Not connected to Metro. Use list_devices to check connection status.';
 }
 
+// A Runtime.evaluate completion handle belongs to the runtime generation that
+// created it. Reconnects can invalidate that handle after the source has
+// already started observing its completion in the mailbox. In that case the
+// mailbox is still the only safe source of the result; calling the source or
+// the stale handle again could replay user code or a thenable.
+function isStaleRemoteHandleError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /(?:cannot|could not|can't) find (?:the )?(?:remote )?object with given id/i.test(error.message) ||
+    /(?:invalid|unknown|stale) (?:remote )?object(?: handle)?/i.test(error.message);
+}
+
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
@@ -798,6 +809,10 @@ export function createAppEvaluator(
     try {
       return await attachRemoteSettlement();
     } catch (error) {
+      // A reconnect can invalidate the completion handle after the source has
+      // run. Its transformed observation is already attached to the mailbox,
+      // so continue polling rather than trying to reattach or replay it.
+      if (isStaleRemoteHandleError(error)) return false;
       if (!isTransportError(error)) throw error;
       // The request may have run the user's thenable before its response was
       // lost. Remote handles are invalid after reconnect, so replaying this

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -303,7 +303,7 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
-function promiseObservationExpression(expression: string): string {
+function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
     ast = parse(expression, { sourceType: 'script' });
@@ -312,29 +312,59 @@ function promiseObservationExpression(expression: string): string {
   }
   const completion = completionForStatements(ast.program.body as StatementLike[]);
   if (!completion.normal || completion.expressions.length === 0) return expression;
-  const edits = completion.expressions
+  const candidates = completion.expressions
     .filter(({ start, end }) => start !== null && end !== null)
-    .map(({ start, end }) => ({ start: start as number, end: end as number }))
-    .filter((edit, index, all) =>
-      all.findIndex((candidate) => candidate.start === edit.start && candidate.end === edit.end) === index,
-    )
-    .sort((left, right) => right.start - left.start);
-  let transformed = expression;
-  for (const { start, end } of edits) {
-    const candidate = expression.slice(start, end);
-    const observer = `(function observePromise(value) {
-      try {
-        var PromiseCtor = globalThis.Promise;
-        if (PromiseCtor) {
-          PromiseCtor.prototype.then.call(value, function() {}, function() {});
-        }
-      } catch (_) {}
-      return value;
-    })((${candidate}
+    .filter((candidate, index, all) =>
+      all.findIndex((other) =>
+        other.start === candidate.start && other.end === candidate.end,
+      ) === index,
+    );
+  if (candidates.length === 0) return expression;
+  // Awaited evaluation always supplies the already-expiring mailbox key. If
+  // this low-level helper is called without one, leave the source untouched
+  // rather than creating state that cannot be cleaned up on an exception.
+  if (!completionKey) return expression;
+  const key = completionKey;
+  const keyLiteral = JSON.stringify(key);
+  const capture = (candidate: string): string => `(function(root, value) {
+    var state = root[${keyLiteral}];
+    if (state) state.completionValue = value;
+    return value;
+  })(this, (\n    ${candidate}
   ))`;
-    transformed = transformed.slice(0, start) + observer + transformed.slice(end);
+  let transformed = expression;
+  for (const { start, end } of candidates
+    .map(({ start, end }) => ({ start: start as number, end: end as number }))
+    .sort((left, right) => right.start - left.start)) {
+    const candidate = expression.slice(start, end);
+    transformed = transformed.slice(0, start) + capture(candidate) + transformed.slice(end);
   }
-  return transformed;
+  const directives = (ast.program.directives as Array<{
+    end?: number | null;
+    value?: { value?: unknown };
+  }> | undefined) ?? [];
+  const directiveEnd = directives.length > 0
+    ? directives[directives.length - 1]!.end as number
+    : 0;
+  const initialValue = directives.length > 0
+    ? JSON.stringify(directives[directives.length - 1]!.value?.value)
+    : 'void 0';
+  const setup = `;\n(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) state.completionValue = ${initialValue};
+  })(this);\n`;
+  transformed = transformed.slice(0, directiveEnd) + setup + transformed.slice(directiveEnd);
+  const observe = `(function(root) {
+    var state = root[${keyLiteral}];
+    var value = state ? state.completionValue : void 0;
+    try {
+      var PromiseCtor = root && root.Promise;
+      if (PromiseCtor) PromiseCtor.prototype.then.call(value, function() {}, function() {});
+    } catch (_) {}
+    if (state) state.completionValue = void 0;
+    return value;
+  })(this)`;
+  return `${transformed}\n;\n${observe}`;
 }
 
 /**
@@ -367,11 +397,11 @@ export async function evaluateAppScript(
 export async function evaluateAppScriptCompletion(
   cdp: Pick<CDPConnection, 'send'>,
   expression: string,
-  options?: EvalOptions & { observePromiseRejection?: boolean },
+  options?: EvalOptions & { observePromiseRejection?: boolean; completionKey?: string },
 ): Promise<AppEvaluationCompletion> {
   const result = await sendRuntimeEvaluate(cdp, {
     expression: options?.observePromiseRejection
-      ? promiseObservationExpression(expression)
+      ? promiseObservationExpression(expression, options.completionKey)
       : expression,
     returnByValue: false,
     awaitPromise: false,
@@ -390,10 +420,11 @@ export async function evaluateAppScriptCompletion(
 }
 
 const SETTLE_REMOTE_FUNCTION = `function(key) {
-  var state = globalThis[key];
+  var root = (function() { return this; })();
+  var state = root[key];
   if (!state) return false;
   function fulfill(value) {
-    if (globalThis[key] !== state) return;
+    if (root[key] !== state) return;
     state.unserializableValue = undefined;
     if (typeof value === 'number') {
       if (value !== value) state.unserializableValue = 'NaN';
@@ -418,7 +449,7 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     return 'Promise rejected with an unstringifiable reason';
   }
   function reject(error) {
-    if (globalThis[key] !== state) return;
+    if (root[key] !== state) return;
     state.error = rejectionMessage(error);
     state.status = 'rejected';
   }
@@ -426,7 +457,7 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     // Assimilate arbitrary thenables exactly once. Calling this.then
     // directly would accept a second callback or a nested thenable as the
     // final value, unlike JavaScript Promise resolution.
-    Promise.resolve(this).then(fulfill, reject);
+    root.Promise.resolve(this).then(fulfill, reject);
   } catch (error) { reject(error); }
   return true;
 }`;
@@ -482,6 +513,7 @@ export function createAppEvaluator(
       timeout?: number;
       deadline?: number;
       objectGroup?: string;
+      completionKey?: string;
       generation?: number;
       retryMailboxSetup?: (
         options: { timeout?: number; deadline: number },
@@ -512,6 +544,7 @@ export function createAppEvaluator(
         timeout,
         objectGroup: options?.objectGroup,
         observePromiseRejection: true,
+        completionKey: options?.completionKey,
       });
     };
     try {

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -32,6 +32,14 @@ function isTransportError(error: unknown): boolean {
   );
 }
 
+// Metro Bridge uses this exact error when it rejects a request before writing
+// anything to the target. It is safe to retry that request once after
+// connection recovery; errors such as WebSocket closed can follow a request
+// that already ran and must remain one-shot.
+function isDefinitivePreDispatchFailure(error: unknown): boolean {
+  return error instanceof Error && error.message === 'Not connected to CDP target';
+}
+
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
@@ -166,19 +174,35 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
 
 /**
  * Create the shared PluginContext evaluator policy. The raw primitive above
- * remains one-shot; only mailbox reads are eligible for reconnect/retry.
+ * remains one-shot after dispatch; a definitive pre-dispatch disconnect may
+ * be recovered once, while mailbox reads also have their safe retry policy.
  */
 export function createAppEvaluator(
   cdp: Pick<CDPConnection, 'send'>,
   lifecycle: AppEvaluationLifecycle,
 ): (expression: string, options?: EvalOptions) => Promise<unknown> {
-  const rawEvaluate = async (
+  const rawEvaluateOnce = async (
     expression: string,
     options?: EvalOptions,
   ): Promise<unknown> => {
     await lifecycle.ensureConnected(options?.deadline);
     const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
+  };
+
+  const rawEvaluate = async (
+    expression: string,
+    options?: EvalOptions,
+  ): Promise<unknown> => {
+    try {
+      return await rawEvaluateOnce(expression, options);
+    } catch (error) {
+      if (!isDefinitivePreDispatchFailure(error)) throw error;
+      // The Bridge rejected before writing Runtime.evaluate, so reconnecting
+      // and issuing this one request cannot replay caller code.
+      await recoverTransport(options?.deadline, options?.timeout);
+      return rawEvaluateOnce(expression, options);
+    }
   };
 
   const evaluateScript = async (
@@ -188,36 +212,75 @@ export function createAppEvaluator(
       deadline?: number;
       objectGroup?: string;
       generation?: number;
+      retryMailboxSetup?: (
+        options: { timeout?: number; deadline: number },
+      ) => Promise<number | undefined>;
     },
   ): Promise<AppEvaluationCompletion> => {
-    await lifecycle.ensureConnected(options?.deadline);
-    if (
-      options?.generation !== undefined &&
-      lifecycle.getGeneration &&
-      options.generation !== lifecycle.getGeneration()
-    ) {
-      throw new Error('App evaluation context changed before source dispatch');
+    let sourceGeneration = options?.generation;
+    const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
+      await lifecycle.ensureConnected(options?.deadline);
+      if (
+        sourceGeneration !== undefined &&
+        lifecycle.getGeneration &&
+        sourceGeneration !== lifecycle.getGeneration()
+      ) {
+        throw new Error('App evaluation context changed before source dispatch');
+      }
+      const timeout = boundedRequestTimeout(options);
+      return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+    };
+    try {
+      return await evaluateOnce();
+    } catch (error) {
+      if (!isDefinitivePreDispatchFailure(error)) throw error;
+      await recoverTransport(options?.deadline, options?.timeout);
+      if (options?.retryMailboxSetup) {
+        if (options.deadline === undefined) {
+          throw new Error('App evaluation retry requires a deadline');
+        }
+        sourceGeneration = await options.retryMailboxSetup({
+          timeout: options.timeout,
+          deadline: options.deadline,
+        });
+      }
+      return evaluateOnce();
     }
-    const timeout = boundedRequestTimeout(options);
-    return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
   };
 
   const setupMailbox = async (
     expression: string,
     options: { timeout?: number; deadline: number },
   ): Promise<number | undefined> => {
-    await lifecycle.ensureConnected(options.deadline);
-    const generation = lifecycle.getGeneration?.();
-    const timeout = boundedRequestTimeout(options);
-    await evaluateAppScript(cdp, expression, { timeout });
-    if (
-      generation !== undefined &&
-      lifecycle.getGeneration &&
-      generation !== lifecycle.getGeneration()
-    ) {
-      throw new Error('App evaluation context changed during mailbox setup');
+    const setupOnce = async (): Promise<number | undefined> => {
+      await lifecycle.ensureConnected(options.deadline);
+      const generation = lifecycle.getGeneration?.();
+      const timeout = boundedRequestTimeout(options);
+      await evaluateAppScript(cdp, expression, { timeout });
+      if (
+        generation !== undefined &&
+        lifecycle.getGeneration &&
+        generation !== lifecycle.getGeneration()
+      ) {
+        throw new Error('App evaluation context changed during mailbox setup');
+      }
+      return generation;
+    };
+
+    try {
+      return await setupOnce();
+    } catch (error) {
+      if (!isTransportError(error)) throw error;
+      // Mailbox setup happens before the caller source is dispatched. A lost
+      // setup response can therefore be retried safely after one bounded
+      // reconnect, even when the first setup may already have installed the
+      // mailbox in the old runtime.
+      await recoverTransport(options.deadline, options.timeout);
+      if (Date.now() >= options.deadline) {
+        throw timeoutError(options.timeout ?? 10_000);
+      }
+      return setupOnce();
     }
-    return generation;
   };
 
   const settleRemote = async (

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -139,9 +139,20 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     state.value = state.unserializableValue === undefined ? value : undefined;
     state.status = 'fulfilled';
   }
+  function rejectionMessage(error) {
+    var message;
+    try {
+      if (error !== null && error !== undefined) message = error.message;
+    } catch (_) {}
+    if (message !== undefined && message !== null) {
+      try { return String(message); } catch (_) {}
+    }
+    try { return String(error); } catch (_) {}
+    return 'Promise rejected with an unstringifiable reason';
+  }
   function reject(error) {
     if (globalThis[key] !== state) return;
-    state.error = String(error && error.message || error);
+    state.error = rejectionMessage(error);
     state.status = 'rejected';
   }
   try {
@@ -250,7 +261,7 @@ export function createAppEvaluator(
       // transport and continue mailbox polling; a pre-dispatch loss remains
       // pending and is allowed to time out.
       await awaitPromiseBeforeDeadline(
-        recoverTransport(options.deadline),
+        recoverTransport(options.deadline, options.timeout),
         options.deadline,
         options.timeout ?? 10_000,
       );
@@ -272,11 +283,16 @@ export function createAppEvaluator(
     );
   };
 
-  async function recoverTransport(deadline?: number): Promise<void> {
+  async function recoverTransport(deadline?: number, timeout = 10_000): Promise<void> {
+    if (deadline !== undefined && Date.now() >= deadline) {
+      throw timeoutError(timeout);
+    }
     if (lifecycle.isReconnecting()) {
       await lifecycle.waitForReconnect(deadline);
     } else {
-      await lifecycle.reconnect();
+      const reconnect = lifecycle.reconnect();
+      if (deadline === undefined) await reconnect;
+      else await awaitPromiseBeforeDeadline(reconnect, deadline, timeout);
     }
   }
 
@@ -288,7 +304,10 @@ export function createAppEvaluator(
       return await rawEvaluate(expression, options);
     } catch (error) {
       if (!isTransportError(error)) throw error;
-      await recoverTransport(options?.deadline);
+      await recoverTransport(options?.deadline, options?.timeout);
+      if (options?.deadline !== undefined && Date.now() >= options.deadline) {
+        throw timeoutError(options.timeout ?? 10_000);
+      }
       // This expression is a mailbox read. The original caller source is
       // never passed here after Runtime.evaluate has been dispatched.
       return rawEvaluate(expression, options);

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,5 +1,8 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
-import { extractCDPExceptionMessage } from './cdp.js';
+import {
+  decodeCDPUnserializableValue,
+  extractCDPExceptionMessage,
+} from './cdp.js';
 import {
   awaitAppResult,
   awaitPromiseBeforeDeadline,
@@ -33,21 +36,20 @@ function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
 
-function decodeUnserializableValue(value: unknown): unknown {
-  if (value === 'NaN') return Number.NaN;
-  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
-  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
-  if (value === '-0') return -0;
-  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
-    return BigInt(value.slice(0, -1));
-  }
-  throw new Error('Unsupported CDP unserializable value');
-}
-
 function remoteObjectValue(remote: Record<string, unknown>): unknown {
   return Object.prototype.hasOwnProperty.call(remote, 'unserializableValue')
-    ? decodeUnserializableValue(remote.unserializableValue)
+    ? decodeCDPUnserializableValue(remote.unserializableValue)
     : remote.value;
+}
+
+function boundedRequestTimeout(options?: {
+  timeout?: number;
+  deadline?: number;
+}): number | undefined {
+  if (options?.deadline === undefined) return options?.timeout;
+  const remaining = options.deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(options.timeout ?? 10_000);
+  return Math.min(options.timeout ?? 10_000, Math.max(1, remaining));
 }
 
 async function sendRuntimeEvaluate(
@@ -164,12 +166,7 @@ export function createAppEvaluator(
     options?: EvalOptions,
   ): Promise<unknown> => {
     await lifecycle.ensureConnected();
-    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw timeoutError(options.timeout ?? 10_000);
-    }
-    const timeout = options?.deadline === undefined
-      ? options?.timeout
-      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
   };
 
@@ -190,12 +187,7 @@ export function createAppEvaluator(
     ) {
       throw new Error('App evaluation context changed before source dispatch');
     }
-    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw timeoutError(options.timeout ?? 10_000);
-    }
-    const timeout = options?.deadline === undefined
-      ? options?.timeout
-      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    const timeout = boundedRequestTimeout(options);
     return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
   };
 
@@ -204,14 +196,8 @@ export function createAppEvaluator(
     options: { timeout?: number; deadline: number },
   ): Promise<number | undefined> => {
     await lifecycle.ensureConnected();
-    if (Date.now() >= options.deadline) {
-      throw timeoutError(options.timeout ?? 10_000);
-    }
     const generation = lifecycle.getGeneration?.();
-    const timeout = Math.min(
-      options.timeout ?? 10_000,
-      Math.max(1, options.deadline - Date.now()),
-    );
+    const timeout = boundedRequestTimeout(options);
     await evaluateAppScript(cdp, expression, { timeout });
     if (
       generation !== undefined &&

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -22,7 +22,16 @@ export interface AppEvaluationLifecycle {
   getGeneration?: () => number;
 }
 
+/** An exception returned by the app runtime, after Runtime.evaluate ran. */
+class AppEvaluationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AppEvaluationError';
+  }
+}
+
 function isTransportError(error: unknown): boolean {
+  if (error instanceof AppEvaluationError) return false;
   return (
     error instanceof Error &&
     (error.message === 'WebSocket closed' ||
@@ -37,7 +46,11 @@ function isTransportError(error: unknown): boolean {
 // connection recovery; errors such as WebSocket closed can follow a request
 // that already ran and must remain one-shot.
 function isDefinitivePreDispatchFailure(error: unknown): boolean {
-  return error instanceof Error && error.message === 'Not connected to CDP target';
+  return (
+    error instanceof Error &&
+    !(error instanceof AppEvaluationError) &&
+    error.message === 'Not connected to CDP target'
+  );
 }
 
 function timeoutError(timeout: number): Error {
@@ -71,7 +84,7 @@ async function sendRuntimeEvaluate(
     timeout === undefined ? undefined : { timeoutMs: timeout },
   )) as Record<string, unknown>;
   if (result.exceptionDetails) {
-    throw new Error(
+    throw new AppEvaluationError(
       extractCDPExceptionMessage(
         result.exceptionDetails as Record<string, unknown>,
       ),
@@ -302,7 +315,7 @@ export function createAppEvaluator(
         { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
       )) as Record<string, unknown>;
       if (result.exceptionDetails) {
-        throw new Error(
+        throw new AppEvaluationError(
           extractCDPExceptionMessage(
             result.exceptionDetails as Record<string, unknown>,
           ),
@@ -390,6 +403,7 @@ export function createAppEvaluator(
           releaseObjectGroup,
           getRuntimeGeneration: lifecycle.getGeneration,
           setupMailbox,
+          deadline: options.deadline,
         },
       );
     }

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -119,6 +119,11 @@ type Completion = CompletionPath & {
   breaks: ExitPath[];
   continues: ExitPath[];
 };
+type FinallyRestore = {
+  entry: number;
+  exit: number;
+  slot: string;
+};
 
 const emptyCompletion = (): Completion => ({
   expressions: [],
@@ -346,6 +351,74 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
+function collectFinallyRestores(
+  statement: StatementLike,
+  restores: FinallyRestore[] = [],
+): FinallyRestore[] {
+  switch (statement.type) {
+    case 'BlockStatement':
+      for (const child of (statement.body as StatementLike[] | undefined) ?? []) {
+        collectFinallyRestores(child, restores);
+      }
+      break;
+    case 'IfStatement':
+      collectFinallyRestores(statement.consequent as StatementLike, restores);
+      if (statement.alternate) {
+        collectFinallyRestores(statement.alternate as StatementLike, restores);
+      }
+      break;
+    case 'TryStatement': {
+      collectFinallyRestores(statement.block as StatementLike, restores);
+      const handler = statement.handler as { body: StatementLike } | null | undefined;
+      if (handler) collectFinallyRestores(handler.body, restores);
+      const finalizer = statement.finalizer as StatementLike | null | undefined;
+      if (finalizer) {
+        const completion = completionForStatement(finalizer);
+        const hasEscapingValue = [...completion.breaks, ...completion.continues]
+          .some((path) => path.expressions.length > 0);
+        const start = finalizer.start;
+        const end = finalizer.end;
+        if (
+          completion.normal &&
+          hasEscapingValue &&
+          typeof start === 'number' &&
+          typeof end === 'number'
+        ) {
+          const directives = (finalizer.directives as Array<{ end?: number | null }> | undefined) ?? [];
+          restores.push({
+            entry: directives.length > 0
+              ? directives[directives.length - 1]!.end as number
+              : start + 1,
+            exit: end - 1,
+            slot: `finally:${start}:${end}`,
+          });
+        }
+        collectFinallyRestores(finalizer, restores);
+      }
+      break;
+    }
+    case 'LabeledStatement':
+    case 'WithStatement':
+    case 'ForStatement':
+    case 'ForInStatement':
+    case 'ForOfStatement':
+    case 'WhileStatement':
+    case 'DoWhileStatement':
+      collectFinallyRestores(statement.body as StatementLike, restores);
+      break;
+    case 'SwitchStatement':
+      for (const switchCase of (
+        statement.cases as Array<{ consequent: StatementLike[] }> | undefined
+      ) ?? []) {
+        for (const child of switchCase.consequent) {
+          collectFinallyRestores(child, restores);
+        }
+      }
+      break;
+  }
+  return restores;
+}
+
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -388,6 +461,21 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
+  const finallyRestores = collectFinallyRestores({
+    type: 'BlockStatement',
+    body: ast.program.body as StatementLike[],
+  });
+  const saveFinallyCompletion = (slot: string): string => `(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) state[${JSON.stringify(slot)}] = state.completionValue;
+  })(this)`;
+  const restoreFinallyCompletion = (slot: string): string => `(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) {
+      state.completionValue = state[${JSON.stringify(slot)}];
+      delete state[${JSON.stringify(slot)}];
+    }
+  })(this)`;
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -402,6 +490,15 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
+    ...finallyRestores.flatMap(({ entry, exit, slot }) => [{
+      start: exit,
+      end: exit,
+      replacement: `;\n${restoreFinallyCompletion(slot)};\n`,
+    }, {
+      start: entry,
+      end: entry,
+      replacement: `;\n${saveFinallyCompletion(slot)};\n`,
+    }]),
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
     transformed = transformed.slice(0, start) + replacement +

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -15,6 +15,8 @@ export interface AppEvaluationLifecycle {
   reconnect(): Promise<void>;
   /** Whether a reconnect attempt is already running. */
   isReconnecting(): boolean;
+  /** Monotonic runtime generation; changes invalidate remote handles. */
+  getGeneration?: () => number;
 }
 
 function isTransportError(error: unknown): boolean {
@@ -29,6 +31,23 @@ function isTransportError(error: unknown): boolean {
 
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
+}
+
+function decodeUnserializableValue(value: unknown): unknown {
+  if (value === 'NaN') return Number.NaN;
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
+  if (value === '-0') return -0;
+  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
+    return BigInt(value.slice(0, -1));
+  }
+  throw new Error('Unsupported CDP unserializable value');
+}
+
+function remoteObjectValue(remote: Record<string, unknown>): unknown {
+  return Object.prototype.hasOwnProperty.call(remote, 'unserializableValue')
+    ? decodeUnserializableValue(remote.unserializableValue)
+    : remote.value;
 }
 
 async function sendRuntimeEvaluate(
@@ -70,7 +89,7 @@ export async function evaluateAppScript(
     awaitPromise: false,
     ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
   }, options?.timeout);
-  return (result.result as Record<string, unknown>).value;
+  return remoteObjectValue((result.result ?? {}) as Record<string, unknown>);
 }
 
 /**
@@ -91,13 +110,14 @@ export async function evaluateAppScriptCompletion(
     ...(options?.objectGroup ? { objectGroup: options.objectGroup } : {}),
   }, options?.timeout);
   const remote = (result.result ?? {}) as Record<string, unknown>;
+  const value = remoteObjectValue(remote);
   if (typeof remote.objectId === 'string') {
     return {
       objectId: remote.objectId,
-      ...(remote.value === undefined ? {} : { value: remote.value }),
+      ...(value === undefined ? {} : { value }),
     };
   }
-  return { value: remote.value };
+  return { value };
 }
 
 const SETTLE_REMOTE_FUNCTION = `function(key) {
@@ -105,7 +125,16 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
   if (!state) return false;
   function fulfill(value) {
     if (globalThis[key] !== state) return;
-    state.value = value;
+    state.unserializableValue = undefined;
+    if (typeof value === 'number') {
+      if (value !== value) state.unserializableValue = 'NaN';
+      else if (value === Infinity) state.unserializableValue = 'Infinity';
+      else if (value === -Infinity) state.unserializableValue = '-Infinity';
+      else if (value === 0 && 1 / value === -Infinity) state.unserializableValue = '-0';
+    } else if (typeof value === 'bigint') {
+      state.unserializableValue = String(value) + 'n';
+    }
+    state.value = state.unserializableValue === undefined ? value : undefined;
     state.status = 'fulfilled';
   }
   function reject(error) {
@@ -146,9 +175,21 @@ export function createAppEvaluator(
 
   const evaluateScript = async (
     expression: string,
-    options?: { timeout?: number; deadline?: number; objectGroup?: string },
+    options?: {
+      timeout?: number;
+      deadline?: number;
+      objectGroup?: string;
+      generation?: number;
+    },
   ): Promise<AppEvaluationCompletion> => {
     await lifecycle.ensureConnected();
+    if (
+      options?.generation !== undefined &&
+      lifecycle.getGeneration &&
+      options.generation !== lifecycle.getGeneration()
+    ) {
+      throw new Error('App evaluation context changed before source dispatch');
+    }
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
       throw timeoutError(options.timeout ?? 10_000);
     }
@@ -156,6 +197,30 @@ export function createAppEvaluator(
       ? options?.timeout
       : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
     return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+  };
+
+  const setupMailbox = async (
+    expression: string,
+    options: { timeout?: number; deadline: number },
+  ): Promise<number | undefined> => {
+    await lifecycle.ensureConnected();
+    if (Date.now() >= options.deadline) {
+      throw timeoutError(options.timeout ?? 10_000);
+    }
+    const generation = lifecycle.getGeneration?.();
+    const timeout = Math.min(
+      options.timeout ?? 10_000,
+      Math.max(1, options.deadline - Date.now()),
+    );
+    await evaluateAppScript(cdp, expression, { timeout });
+    if (
+      generation !== undefined &&
+      lifecycle.getGeneration &&
+      generation !== lifecycle.getGeneration()
+    ) {
+      throw new Error('App evaluation context changed during mailbox setup');
+    }
+    return generation;
   };
 
   const settleRemote = async (
@@ -193,10 +258,11 @@ export function createAppEvaluator(
       return await attachRemoteSettlement();
     } catch (error) {
       if (!isTransportError(error)) throw error;
-      // Attaching the same settlement callback twice is safe: it only writes
-      // the private mailbox and never re-runs the caller's source. Bound the
-      // reconnect itself by the same deadline as the attach and re-check it
-      // before dispatching the retry, since reconnect may finish late.
+      // The request may have run the user's thenable before its response was
+      // lost. Remote handles are invalid after reconnect, so replaying this
+      // callFunctionOn could invoke a side-effecting thenable twice. Recover
+      // transport and continue mailbox polling; a pre-dispatch loss remains
+      // pending and is allowed to time out.
       await awaitPromiseBeforeDeadline(
         recoverTransport(),
         options.deadline,
@@ -205,7 +271,7 @@ export function createAppEvaluator(
       if (Date.now() >= options.deadline) {
         throw timeoutError(options.timeout ?? 10_000);
       }
-      return attachRemoteSettlement();
+      return false;
     }
   };
 
@@ -254,6 +320,8 @@ export function createAppEvaluator(
           evaluateScript,
           settleRemote,
           releaseObjectGroup,
+          getRuntimeGeneration: lifecycle.getGeneration,
+          setupMailbox,
         },
       );
     }

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -112,7 +112,6 @@ type CompletionPath = {
   expressions: ExpressionLike[];
   clearRanges: Array<{ start: number; end: number; kind: 'break' | 'continue'; label: string | null }>;
   empty: boolean;
-  undefined: boolean;
   normal: boolean;
 };
 type ExitPath = CompletionPath & { label: string | null; inherit: boolean };
@@ -125,7 +124,6 @@ const emptyCompletion = (): Completion => ({
   expressions: [],
   clearRanges: [],
   empty: true,
-  undefined: false,
   normal: true,
   breaks: [],
   continues: [],
@@ -135,40 +133,10 @@ const abruptCompletion = (): Completion => ({
   expressions: [],
   clearRanges: [],
   empty: false,
-  undefined: false,
   normal: false,
   breaks: [],
   continues: [],
 });
-
-const undefinedCompletion = (): Completion => ({
-  expressions: [],
-  clearRanges: [],
-  empty: false,
-  undefined: true,
-  normal: true,
-  breaks: [],
-  continues: [],
-});
-
-function normalizeControlCompletion(completion: Completion): Completion {
-  return {
-    ...completion,
-    empty: false,
-    undefined: completion.undefined || completion.empty,
-  };
-}
-
-function asFinallyCompletion(completion: Completion): Completion {
-  // A normal finalizer uses UpdateEmpty. Control statements such as an
-  // untaken if/loop therefore preserve the guarded completion in a finally
-  // clause, even though they produce undefined at script level.
-  return {
-    ...completion,
-    empty: completion.empty || completion.undefined,
-    undefined: false,
-  };
-}
 
 function applyFinallyCompletion(
   guarded: Completion,
@@ -180,14 +148,6 @@ function applyFinallyCompletion(
   return guarded;
 }
 
-function markNonInheritingExits(completion: Completion): Completion {
-  return {
-    ...completion,
-    breaks: completion.breaks.map((path) => ({ ...path, inherit: false })),
-    continues: completion.continues.map((path) => ({ ...path, inherit: false })),
-  };
-}
-
 function completionFromExit(path: ExitPath): CompletionPath {
   return path.inherit ? { ...path, clearRanges: [] } : path;
 }
@@ -196,11 +156,10 @@ function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath
   return {
     expressions: [...left.expressions, ...right.expressions],
     clearRanges: [...left.clearRanges, ...right.clearRanges],
-    // A merged path is empty only when every contributing completion is
-    // empty. An explicit undefined completion from a catch/finally or a later
-    // empty loop iteration must replace an earlier value.
-    empty: left.empty && right.empty,
-    undefined: left.undefined || right.undefined,
+    // Hermes reports the previous value for an empty control-flow path. Keep
+    // empty completion inheritance here; the mailbox starts empty for each
+    // evaluation, so this cannot leak a prior request's value.
+    empty: left.empty || right.empty,
     normal: left.normal || right.normal,
   };
 }
@@ -263,7 +222,6 @@ function completionForStatement(statement: StatementLike): Completion {
         expressions: [statement.expression],
         clearRanges: [],
         empty: false,
-        undefined: false,
         normal: true,
         breaks: [],
         continues: [],
@@ -276,10 +234,8 @@ function completionForStatement(statement: StatementLike): Completion {
       const consequent = completionForStatement(statement.consequent as StatementLike);
       const alternate = statement.alternate
         ? completionForStatement(statement.alternate as StatementLike)
-        : undefinedCompletion();
-      return normalizeControlCompletion(markNonInheritingExits(
-        mergeCompletions(consequent, alternate),
-      ));
+        : emptyCompletion();
+      return mergeCompletions(consequent, alternate);
     }
     case 'TryStatement': {
       const body = completionForStatement(statement.block as StatementLike);
@@ -287,27 +243,18 @@ function completionForStatement(statement: StatementLike): Completion {
         ? completionForStatement((statement.handler as { body: StatementLike }).body)
         : abruptCompletion();
       const guarded = mergeCompletions(body, handler);
-      if (!statement.finalizer) return normalizeControlCompletion(guarded);
-      const finalizer = asFinallyCompletion(
-        completionForStatement(statement.finalizer as StatementLike),
-      );
+      if (!statement.finalizer) return guarded;
+      const finalizer = completionForStatement(statement.finalizer as StatementLike);
       if (!finalizer.normal) return finalizer;
       // A normal `finally` completion is UpdateEmpty: its expression value is
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
       const applied = applyFinallyCompletion(guarded, finalizer);
-      const result = {
+      return {
         ...applied,
-        breaks: [
-          ...guarded.breaks,
-          ...finalizer.breaks.map((path) => ({ ...path, inherit: false })),
-        ],
-        continues: [
-          ...guarded.continues,
-          ...finalizer.continues.map((path) => ({ ...path, inherit: false })),
-        ],
+        breaks: [...guarded.breaks, ...finalizer.breaks],
+        continues: [...guarded.continues, ...finalizer.continues],
       };
-      return result.normal ? normalizeControlCompletion(result) : result;
     }
     case 'LabeledStatement':
       return consumeLabelExits(
@@ -315,35 +262,30 @@ function completionForStatement(statement: StatementLike): Completion {
         (statement.label as { name: string } | null | undefined)?.name ?? '',
       );
     case 'WithStatement':
-      return normalizeControlCompletion(markNonInheritingExits(
-        completionForStatement(statement.body as StatementLike),
-      ));
+      return completionForStatement(statement.body as StatementLike);
     case 'SwitchStatement': {
       const cases = (statement.cases as Array<{ consequent: StatementLike[] }> | undefined) ?? [];
-      let completion = undefinedCompletion();
+      let completion = emptyCompletion();
       for (let index = 0; index < cases.length; index += 1) {
         const caseCompletion = completionForStatements(
           cases.slice(index).flatMap((entry) => entry.consequent),
         );
         completion = mergeCompletions(
           completion,
-          normalizeControlCompletion(consumeBreaks(caseCompletion)),
+          consumeBreaks(caseCompletion),
         );
       }
-      return normalizeControlCompletion(completion);
+      return completion;
     }
     case 'ForStatement':
     case 'ForInStatement':
     case 'ForOfStatement':
     case 'WhileStatement':
     case 'DoWhileStatement':
-      const body = normalizeControlCompletion(
-        completionForStatement(statement.body as StatementLike),
+      return mergeCompletions(
+        consumeLoopExits(completionForStatement(statement.body as StatementLike)),
+        emptyCompletion(),
       );
-      const loop = consumeLoopExits(body);
-      return statement.type === 'DoWhileStatement'
-        ? normalizeControlCompletion(loop)
-        : normalizeControlCompletion(mergeCompletions(loop, undefinedCompletion()));
     case 'ThrowStatement':
     case 'ReturnStatement':
       return abruptCompletion();
@@ -404,85 +346,6 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
-type SourceInsertion = { start: number; end?: number; replacement: string };
-
-function collectLoopEntryInsertions(
-  statement: StatementLike,
-  clearCompletion: string,
-  insertions: SourceInsertion[],
-): void {
-  const visit = (child: unknown): void => {
-    if (child && typeof child === 'object' && 'type' in child) {
-      collectLoopEntryInsertions(child as StatementLike, clearCompletion, insertions);
-    }
-  };
-  const visitList = (children: unknown): void => {
-    if (Array.isArray(children)) children.forEach(visit);
-  };
-
-  switch (statement.type) {
-    case 'BlockStatement':
-      visitList(statement.body);
-      return;
-    case 'IfStatement':
-      visit(statement.consequent);
-      visit(statement.alternate);
-      return;
-    case 'TryStatement':
-      visit(statement.block);
-      visit((statement.handler as { body?: unknown } | null | undefined)?.body);
-      visit(statement.finalizer);
-      return;
-    case 'LabeledStatement':
-    case 'WithStatement':
-      visit(statement.body);
-      return;
-    case 'SwitchStatement':
-      for (const switchCase of (statement.cases as Array<{ consequent?: unknown }> | undefined) ?? []) {
-        visitList(switchCase.consequent);
-      }
-      return;
-    case 'ForStatement':
-    case 'ForInStatement':
-    case 'ForOfStatement':
-    case 'WhileStatement':
-    case 'DoWhileStatement': {
-      const body = statement.body as StatementLike | undefined;
-      if (body?.start !== null && body?.start !== undefined &&
-          body.end !== null && body.end !== undefined) {
-        const bodyCompletion = completionForStatement(body);
-        // Each iteration computes a fresh body completion. A reached
-        // candidate immediately replaces this reset; a runtime path that
-        // reaches none of the candidates completes with undefined instead of
-        // leaking a value from an earlier iteration.
-        if (bodyCompletion.expressions.length === 0) {
-          visit(body);
-          return;
-        }
-        if (body.type === 'BlockStatement') {
-          const directives = (body.directives as Array<{ end?: number | null }> | undefined) ?? [];
-          const entry = directives.length > 0
-            ? directives[directives.length - 1]!.end
-            : (body.start as number) + 1;
-          if (entry !== null && entry !== undefined) {
-            insertions.push({ start: entry, replacement: ` ${clearCompletion}; ` });
-          }
-        } else {
-          insertions.push({
-            start: body.start as number,
-            replacement: `{ ${clearCompletion}; `,
-          });
-          insertions.push({ start: body.end as number, replacement: ' }' });
-        }
-      }
-      visit(body);
-      return;
-    }
-    default:
-      return;
-  }
-}
-
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -525,10 +388,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
-  const loopInsertions: SourceInsertion[] = [];
-  for (const statement of ast.program.body as StatementLike[]) {
-    collectLoopEntryInsertions(statement, clearCompletion, loopInsertions);
-  }
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -543,7 +402,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
-    ...loopInsertions,
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
     transformed = transformed.slice(0, start) + replacement +
@@ -556,19 +414,23 @@ function promiseObservationExpression(expression: string, completionKey?: string
   const directiveEnd = directives.length > 0
     ? directives[directives.length - 1]!.end as number
     : 0;
+  // Babel stores a hashbang separately from the program body. Keep it as the
+  // first source line when inserting mailbox setup or the generated script
+  // becomes invalid JavaScript.
+  const prefixEnd = Math.max(directiveEnd, ast.program.interpreter?.end ?? 0);
   const setup = `;\n(function(root) {
     var state = root[${keyLiteral}];
     if (state) state.completionValue = void 0;
   })(this);\n`;
-  transformed = transformed.slice(0, directiveEnd) + setup + transformed.slice(directiveEnd);
+  transformed = transformed.slice(0, prefixEnd) + setup + transformed.slice(prefixEnd);
   const observe = `(function(root) {
     var state = root[${keyLiteral}];
     var value = state ? state.completionValue : void 0;
     try {
-      var PromiseCtor = state && (state.promiseConstructor || root.Promise);
-      var promiseThen = (state && state.promiseThen) ||
-        (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
-      if (promiseThen) promiseThen.call(value, function() {}, function() {});
+      // Start the mailbox's single realm-internal assimilation in the same
+      // JavaScript job, so an immediately rejected completion is observed
+      // before Runtime.evaluate returns.
+      if (state && typeof state.observe === 'function') state.observe(value);
     } catch (_) {}
     if (state) state.completionValue = void 0;
     return value;
@@ -632,49 +494,12 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
   var root = (function() { return this; })();
   var state = root[key];
   if (!state) return false;
-  function fulfill(value) {
-    if (root[key] !== state) return;
-    state.unserializableValue = undefined;
-    if (typeof value === 'number') {
-      if (value !== value) state.unserializableValue = 'NaN';
-      else if (value === Infinity) state.unserializableValue = 'Infinity';
-      else if (value === -Infinity) state.unserializableValue = '-Infinity';
-      else if (value === 0 && 1 / value === -Infinity) state.unserializableValue = '-0';
-    } else if (typeof value === 'bigint') {
-      state.unserializableValue = String(value) + 'n';
-    }
-    state.value = state.unserializableValue === undefined ? value : undefined;
-    state.status = 'fulfilled';
-  }
-  function rejectionMessage(error) {
-    var message;
-    try {
-      if (error !== null && error !== undefined) message = error.message;
-    } catch (_) {}
-    if (message !== undefined && message !== null) {
-      try { return String(message); } catch (_) {}
-    }
-    try { return String(error); } catch (_) {}
-    return 'Promise rejected with an unstringifiable reason';
-  }
-  function reject(error) {
-    if (root[key] !== state) return;
-    state.error = rejectionMessage(error);
-    state.status = 'rejected';
-  }
   try {
-    // Assimilate arbitrary thenables exactly once. Calling this.then
-    // directly would accept a second callback or a nested thenable as the
-    // final value, unlike JavaScript Promise resolution.
-    var PromiseCtor = state.promiseConstructor || root.Promise;
-    var promiseResolve = state.promiseResolve || (PromiseCtor && PromiseCtor.resolve);
-    if (!promiseResolve) throw new Error('Promise constructor unavailable');
-    var resolved = promiseResolve.call(PromiseCtor, this);
-    var promiseThen = state.promiseThen ||
-      (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
-    if (!promiseThen) throw new Error('Promise then unavailable');
-    promiseThen.call(resolved, fulfill, reject);
-  } catch (error) { reject(error); }
+    // Transformed sources start this before Runtime.evaluate returns. Sources
+    // that could not be transformed start the same one-shot assimilation here.
+    if (typeof state.observe !== 'function') return false;
+    state.observe(this);
+  } catch (_) { return false; }
   return true;
 }`;
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -440,13 +440,15 @@ export function createAppEvaluator(
   cdp: Pick<CDPConnection, 'send'>,
   lifecycle: AppEvaluationLifecycle,
 ): (expression: string, options?: EvalOptions) => Promise<unknown> {
-  const ensureConnectedForDispatch = async (options?: EvalOptions): Promise<void> => {
+  const ensureConnectedForDispatch = async (options?: EvalOptions): Promise<boolean> => {
     try {
       await lifecycle.ensureConnected(options?.deadline);
+      return false;
     } catch (error) {
       if (!isServerDisconnectedError(error)) throw error;
       await recoverTransport(options?.deadline, options?.timeout);
       await lifecycle.ensureConnected(options?.deadline);
+      return true;
     }
   };
 
@@ -488,7 +490,16 @@ export function createAppEvaluator(
   ): Promise<AppEvaluationCompletion> => {
     let sourceGeneration = options?.generation;
     const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
-      await ensureConnectedForDispatch(options);
+      const recovered = await ensureConnectedForDispatch(options);
+      if (recovered && options?.retryMailboxSetup) {
+        if (options.deadline === undefined) {
+          throw new Error('App evaluation retry requires a deadline');
+        }
+        sourceGeneration = await options.retryMailboxSetup({
+          timeout: options.timeout,
+          deadline: options.deadline,
+        });
+      }
       if (
         sourceGeneration !== undefined &&
         lifecycle.getGeneration &&

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -11,9 +11,9 @@ import {
 
 export interface AppEvaluationLifecycle {
   /** Ensure a request can be sent before it is dispatched. */
-  ensureConnected(): Promise<void>;
+  ensureConnected(deadline?: number): Promise<void>;
   /** Wait for an already running reconnect attempt. */
-  waitForReconnect(): Promise<void>;
+  waitForReconnect(deadline?: number): Promise<void>;
   /** Start a reconnect attempt when a safe mailbox read loses transport. */
   reconnect(): Promise<void>;
   /** Whether a reconnect attempt is already running. */
@@ -165,7 +165,7 @@ export function createAppEvaluator(
     expression: string,
     options?: EvalOptions,
   ): Promise<unknown> => {
-    await lifecycle.ensureConnected();
+    await lifecycle.ensureConnected(options?.deadline);
     const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
   };
@@ -179,7 +179,7 @@ export function createAppEvaluator(
       generation?: number;
     },
   ): Promise<AppEvaluationCompletion> => {
-    await lifecycle.ensureConnected();
+    await lifecycle.ensureConnected(options?.deadline);
     if (
       options?.generation !== undefined &&
       lifecycle.getGeneration &&
@@ -195,7 +195,7 @@ export function createAppEvaluator(
     expression: string,
     options: { timeout?: number; deadline: number },
   ): Promise<number | undefined> => {
-    await lifecycle.ensureConnected();
+    await lifecycle.ensureConnected(options.deadline);
     const generation = lifecycle.getGeneration?.();
     const timeout = boundedRequestTimeout(options);
     await evaluateAppScript(cdp, expression, { timeout });
@@ -250,7 +250,7 @@ export function createAppEvaluator(
       // transport and continue mailbox polling; a pre-dispatch loss remains
       // pending and is allowed to time out.
       await awaitPromiseBeforeDeadline(
-        recoverTransport(),
+        recoverTransport(options.deadline),
         options.deadline,
         options.timeout ?? 10_000,
       );
@@ -272,9 +272,9 @@ export function createAppEvaluator(
     );
   };
 
-  async function recoverTransport(): Promise<void> {
+  async function recoverTransport(deadline?: number): Promise<void> {
     if (lifecycle.isReconnecting()) {
-      await lifecycle.waitForReconnect();
+      await lifecycle.waitForReconnect(deadline);
     } else {
       await lifecycle.reconnect();
     }
@@ -288,7 +288,7 @@ export function createAppEvaluator(
       return await rawEvaluate(expression, options);
     } catch (error) {
       if (!isTransportError(error)) throw error;
-      await recoverTransport();
+      await recoverTransport(options?.deadline);
       // This expression is a mailbox read. The original caller source is
       // never passed here after Runtime.evaluate has been dispatched.
       return rawEvaluate(expression, options);

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,6 +1,6 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
 import { extractCDPExceptionMessage } from './cdp.js';
-import { awaitAppResult } from './await-app-result.js';
+import { awaitAppResult, type AppEvaluationCompletion } from './await-app-result.js';
 
 export interface AppEvaluationLifecycle {
   /** Ensure a request can be sent before it is dispatched. */
@@ -23,6 +23,26 @@ function isTransportError(error: unknown): boolean {
   );
 }
 
+async function sendRuntimeEvaluate(
+  cdp: Pick<CDPConnection, 'send'>,
+  params: Record<string, unknown>,
+  timeout?: number,
+): Promise<Record<string, unknown>> {
+  const result = (await cdp.send(
+    'Runtime.evaluate',
+    params,
+    timeout === undefined ? undefined : { timeoutMs: timeout },
+  )) as Record<string, unknown>;
+  if (result.exceptionDetails) {
+    throw new Error(
+      extractCDPExceptionMessage(
+        result.exceptionDetails as Record<string, unknown>,
+      ),
+    );
+  }
+  return result;
+}
+
 /**
  * Send one Runtime.evaluate request and return its by-value completion value.
  *
@@ -36,21 +56,63 @@ export async function evaluateAppScript(
   expression: string,
   options?: EvalOptions,
 ): Promise<unknown> {
-  const result = (await cdp.send('Runtime.evaluate', {
+  const result = await sendRuntimeEvaluate(cdp, {
     expression,
     returnByValue: true,
     awaitPromise: false,
-    timeout: options?.timeout,
-  })) as Record<string, unknown>;
-  if (result.exceptionDetails) {
-    throw new Error(
-      extractCDPExceptionMessage(
-        result.exceptionDetails as Record<string, unknown>,
-      ),
-    );
-  }
+    ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
+  }, options?.timeout);
   return (result.result as Record<string, unknown>).value;
 }
+
+/**
+ * Execute a script once and retain its remote completion object. Keeping the
+ * Runtime.evaluate request separate from mailbox setup is what preserves
+ * normal script completion and declaration semantics on persistent runtimes.
+ */
+export async function evaluateAppScriptCompletion(
+  cdp: Pick<CDPConnection, 'send'>,
+  expression: string,
+  options?: EvalOptions,
+): Promise<AppEvaluationCompletion> {
+  const result = await sendRuntimeEvaluate(cdp, {
+    expression,
+    returnByValue: false,
+    awaitPromise: false,
+    ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
+    ...(options?.objectGroup ? { objectGroup: options.objectGroup } : {}),
+  }, options?.timeout);
+  const remote = (result.result ?? {}) as Record<string, unknown>;
+  if (typeof remote.objectId === 'string') {
+    return {
+      objectId: remote.objectId,
+      ...(remote.value === undefined ? {} : { value: remote.value }),
+    };
+  }
+  return { value: remote.value };
+}
+
+const SETTLE_REMOTE_FUNCTION = `function(key) {
+  var state = globalThis[key];
+  if (!state) return false;
+  function fulfill(value) {
+    if (globalThis[key] !== state) return;
+    state.value = value;
+    state.status = 'fulfilled';
+  }
+  function reject(error) {
+    if (globalThis[key] !== state) return;
+    state.error = String(error && error.message || error);
+    state.status = 'rejected';
+  }
+  try {
+    // Assimilate arbitrary thenables exactly once. Calling this.then
+    // directly would accept a second callback or a nested thenable as the
+    // final value, unlike JavaScript Promise resolution.
+    Promise.resolve(this).then(fulfill, reject);
+  } catch (error) { reject(error); }
+  return true;
+}`;
 
 /**
  * Create the shared PluginContext evaluator policy. The raw primitive above
@@ -68,7 +130,79 @@ export function createAppEvaluator(
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
       throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
     }
-    return evaluateAppScript(cdp, expression, options);
+    const timeout = options?.deadline === undefined
+      ? options?.timeout
+      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    return evaluateAppScript(cdp, expression, { ...options, timeout });
+  };
+
+  const evaluateScript = async (
+    expression: string,
+    options?: { timeout?: number; deadline?: number; objectGroup?: string },
+  ): Promise<AppEvaluationCompletion> => {
+    await lifecycle.ensureConnected();
+    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
+      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+    }
+    const timeout = options?.deadline === undefined
+      ? options?.timeout
+      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+  };
+
+  const settleRemote = async (
+    objectId: string,
+    mailboxKey: string,
+    options: { timeout?: number; deadline: number },
+  ): Promise<boolean> => {
+    const remaining = Math.max(1, options.deadline - Date.now());
+    let settled = false;
+    let released = false;
+    try {
+      const result = (await cdp.send(
+        'Runtime.callFunctionOn',
+        {
+          objectId,
+          functionDeclaration: SETTLE_REMOTE_FUNCTION,
+          arguments: [{ value: mailboxKey }],
+          returnByValue: true,
+        },
+        { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+      )) as Record<string, unknown>;
+      if (result.exceptionDetails) {
+        throw new Error(
+          extractCDPExceptionMessage(
+            result.exceptionDetails as Record<string, unknown>,
+          ),
+        );
+      }
+      settled = ((result.result as Record<string, unknown> | undefined)?.value !== false);
+    } finally {
+      // The completion handle is only needed while its settlement callback is
+      // being attached. Releasing it avoids retaining every awaited Promise.
+      try {
+        await cdp.send(
+          'Runtime.releaseObject',
+          { objectId },
+          { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+        );
+        released = true;
+      } catch {
+        // The object group cleanup in awaitAppResult remains the fallback.
+      }
+    }
+    return settled && released;
+  };
+
+  const releaseObjectGroup = async (
+    objectGroup: string,
+    options: { timeout?: number },
+  ): Promise<void> => {
+    await cdp.send(
+      'Runtime.releaseObjectGroup',
+      { objectGroup },
+      { timeoutMs: options.timeout ?? 500 },
+    );
   };
 
   async function recoverTransport(): Promise<void> {
@@ -100,7 +234,12 @@ export function createAppEvaluator(
         rawEvaluate,
         expression,
         options.timeout ?? 10_000,
-        { pollEvaluate: retryMailboxRead },
+        {
+          pollEvaluate: retryMailboxRead,
+          evaluateScript,
+          settleRemote,
+          releaseObjectGroup,
+        },
       );
     }
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,6 +1,10 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
 import { extractCDPExceptionMessage } from './cdp.js';
-import { awaitAppResult, type AppEvaluationCompletion } from './await-app-result.js';
+import {
+  awaitAppResult,
+  awaitPromiseBeforeDeadline,
+  type AppEvaluationCompletion,
+} from './await-app-result.js';
 
 export interface AppEvaluationLifecycle {
   /** Ensure a request can be sent before it is dispatched. */
@@ -25,24 +29,6 @@ function isTransportError(error: unknown): boolean {
 
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
-}
-
-async function awaitBeforeDeadline<T>(
-  operation: Promise<T>,
-  deadline: number,
-  timeout: number,
-): Promise<T> {
-  const remaining = deadline - Date.now();
-  if (remaining <= 0) throw timeoutError(timeout);
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadlineReached = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
-  });
-  try {
-    return await Promise.race([operation, deadlineReached]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
 }
 
 async function sendRuntimeEvaluate(
@@ -150,7 +136,7 @@ export function createAppEvaluator(
   ): Promise<unknown> => {
     await lifecycle.ensureConnected();
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+      throw timeoutError(options.timeout ?? 10_000);
     }
     const timeout = options?.deadline === undefined
       ? options?.timeout
@@ -164,7 +150,7 @@ export function createAppEvaluator(
   ): Promise<AppEvaluationCompletion> => {
     await lifecycle.ensureConnected();
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+      throw timeoutError(options.timeout ?? 10_000);
     }
     const timeout = options?.deadline === undefined
       ? options?.timeout
@@ -177,7 +163,7 @@ export function createAppEvaluator(
     mailboxKey: string,
     options: { timeout?: number; deadline: number },
   ): Promise<boolean> => {
-    const attach = async (): Promise<boolean> => {
+    const attachRemoteSettlement = async (): Promise<boolean> => {
       const remaining = options.deadline - Date.now();
       if (remaining <= 0) throw timeoutError(options.timeout ?? 10_000);
       const result = (await cdp.send(
@@ -204,14 +190,14 @@ export function createAppEvaluator(
     };
 
     try {
-      return await attach();
+      return await attachRemoteSettlement();
     } catch (error) {
       if (!isTransportError(error)) throw error;
       // Attaching the same settlement callback twice is safe: it only writes
       // the private mailbox and never re-runs the caller's source. Bound the
       // reconnect itself by the same deadline as the attach and re-check it
       // before dispatching the retry, since reconnect may finish late.
-      await awaitBeforeDeadline(
+      await awaitPromiseBeforeDeadline(
         recoverTransport(),
         options.deadline,
         options.timeout ?? 10_000,
@@ -219,7 +205,7 @@ export function createAppEvaluator(
       if (Date.now() >= options.deadline) {
         throw timeoutError(options.timeout ?? 10_000);
       }
-      return attach();
+      return attachRemoteSettlement();
     }
   };
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -23,6 +23,28 @@ function isTransportError(error: unknown): boolean {
   );
 }
 
+function timeoutError(timeout: number): Error {
+  return new Error(`App evaluation timed out after ${timeout}ms`);
+}
+
+async function awaitBeforeDeadline<T>(
+  operation: Promise<T>,
+  deadline: number,
+  timeout: number,
+): Promise<T> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(timeout);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadlineReached = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
+  });
+  try {
+    return await Promise.race([operation, deadlineReached]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function sendRuntimeEvaluate(
   cdp: Pick<CDPConnection, 'send'>,
   params: Record<string, unknown>,
@@ -155,28 +177,50 @@ export function createAppEvaluator(
     mailboxKey: string,
     options: { timeout?: number; deadline: number },
   ): Promise<boolean> => {
-    const remaining = Math.max(1, options.deadline - Date.now());
-    const result = (await cdp.send(
-      'Runtime.callFunctionOn',
-      {
-        objectId,
-        functionDeclaration: SETTLE_REMOTE_FUNCTION,
-        arguments: [{ value: mailboxKey }],
-        returnByValue: true,
-      },
-      { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
-    )) as Record<string, unknown>;
-    if (result.exceptionDetails) {
-      throw new Error(
-        extractCDPExceptionMessage(
-          result.exceptionDetails as Record<string, unknown>,
-        ),
+    const attach = async (): Promise<boolean> => {
+      const remaining = options.deadline - Date.now();
+      if (remaining <= 0) throw timeoutError(options.timeout ?? 10_000);
+      const result = (await cdp.send(
+        'Runtime.callFunctionOn',
+        {
+          objectId,
+          functionDeclaration: SETTLE_REMOTE_FUNCTION,
+          arguments: [{ value: mailboxKey }],
+          returnByValue: true,
+        },
+        { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+      )) as Record<string, unknown>;
+      if (result.exceptionDetails) {
+        throw new Error(
+          extractCDPExceptionMessage(
+            result.exceptionDetails as Record<string, unknown>,
+          ),
+        );
+      }
+      // Keep the unique object group responsible for cleanup. Its separately
+      // bounded release runs after mailbox settlement, so handle cleanup cannot
+      // delay polling or leave a detached, permanently pending transport call.
+      return false;
+    };
+
+    try {
+      return await attach();
+    } catch (error) {
+      if (!isTransportError(error)) throw error;
+      // Attaching the same settlement callback twice is safe: it only writes
+      // the private mailbox and never re-runs the caller's source. Bound the
+      // reconnect itself by the same deadline as the attach and re-check it
+      // before dispatching the retry, since reconnect may finish late.
+      await awaitBeforeDeadline(
+        recoverTransport(),
+        options.deadline,
+        options.timeout ?? 10_000,
       );
+      if (Date.now() >= options.deadline) {
+        throw timeoutError(options.timeout ?? 10_000);
+      }
+      return attach();
     }
-    // Keep the unique object group responsible for cleanup. Its separately
-    // bounded release runs after mailbox settlement, so handle cleanup cannot
-    // delay polling or leave a detached, permanently pending transport call.
-    return false;
   };
 
   const releaseObjectGroup = async (

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,0 +1,112 @@
+import type { CDPConnection, EvalOptions } from '../plugin.js';
+import { extractCDPExceptionMessage } from './cdp.js';
+import { awaitAppResult } from './await-app-result.js';
+
+export interface AppEvaluationLifecycle {
+  /** Ensure a request can be sent before it is dispatched. */
+  ensureConnected(): Promise<void>;
+  /** Wait for an already running reconnect attempt. */
+  waitForReconnect(): Promise<void>;
+  /** Start a reconnect attempt when a safe mailbox read loses transport. */
+  reconnect(): Promise<void>;
+  /** Whether a reconnect attempt is already running. */
+  isReconnecting(): boolean;
+}
+
+function isTransportError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === 'WebSocket closed' ||
+      error.message === 'Not connected to CDP target' ||
+      error.message ===
+        'Not connected to Metro. Use list_devices to check connection status.')
+  );
+}
+
+/**
+ * Send one Runtime.evaluate request and return its by-value completion value.
+ *
+ * This intentionally has no reconnect or retry policy. A transport error after
+ * dispatch cannot tell us whether the app ran the script, so replaying it could
+ * duplicate a mutation. Retry policy belongs to callers that know their read
+ * is safe, such as mailbox polling.
+ */
+export async function evaluateAppScript(
+  cdp: Pick<CDPConnection, 'send'>,
+  expression: string,
+  options?: EvalOptions,
+): Promise<unknown> {
+  const result = (await cdp.send('Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+    awaitPromise: false,
+    timeout: options?.timeout,
+  })) as Record<string, unknown>;
+  if (result.exceptionDetails) {
+    throw new Error(
+      extractCDPExceptionMessage(
+        result.exceptionDetails as Record<string, unknown>,
+      ),
+    );
+  }
+  return (result.result as Record<string, unknown>).value;
+}
+
+/**
+ * Create the shared PluginContext evaluator policy. The raw primitive above
+ * remains one-shot; only mailbox reads are eligible for reconnect/retry.
+ */
+export function createAppEvaluator(
+  cdp: Pick<CDPConnection, 'send'>,
+  lifecycle: AppEvaluationLifecycle,
+): (expression: string, options?: EvalOptions) => Promise<unknown> {
+  const rawEvaluate = async (
+    expression: string,
+    options?: EvalOptions,
+  ): Promise<unknown> => {
+    await lifecycle.ensureConnected();
+    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
+      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+    }
+    return evaluateAppScript(cdp, expression, options);
+  };
+
+  async function recoverTransport(): Promise<void> {
+    if (lifecycle.isReconnecting()) {
+      await lifecycle.waitForReconnect();
+    } else {
+      await lifecycle.reconnect();
+    }
+  }
+
+  const retryMailboxRead = async (
+    expression: string,
+    options?: EvalOptions,
+  ): Promise<unknown> => {
+    try {
+      return await rawEvaluate(expression, options);
+    } catch (error) {
+      if (!isTransportError(error)) throw error;
+      await recoverTransport();
+      // This expression is a mailbox read. The original caller source is
+      // never passed here after Runtime.evaluate has been dispatched.
+      return rawEvaluate(expression, options);
+    }
+  };
+
+  return async (expression: string, options?: EvalOptions): Promise<unknown> => {
+    if (options?.awaitPromise) {
+      return awaitAppResult(
+        rawEvaluate,
+        expression,
+        options.timeout ?? 10_000,
+        { pollEvaluate: retryMailboxRead },
+      );
+    }
+
+    // Runtime.evaluate is one-shot for all scripts. A transport failure after
+    // dispatch is ambiguous, so retrying here could replay a mutation. The
+    // awaitPromise:false option only changes completion handling.
+    return rawEvaluate(expression, options);
+  };
+}

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -50,10 +50,13 @@ function isDefinitivePreDispatchFailure(error: unknown): boolean {
   return (
     error instanceof Error &&
     !(error instanceof AppEvaluationError) &&
-    (error.message === 'Not connected to CDP target' ||
-      error.message ===
-        'Not connected to Metro. Use list_devices to check connection status.')
+    error.message === 'Not connected to CDP target'
   );
+}
+
+function isServerDisconnectedError(error: unknown): boolean {
+  return error instanceof Error &&
+    error.message === 'Not connected to Metro. Use list_devices to check connection status.';
 }
 
 function timeoutError(timeout: number): Error {
@@ -437,11 +440,21 @@ export function createAppEvaluator(
   cdp: Pick<CDPConnection, 'send'>,
   lifecycle: AppEvaluationLifecycle,
 ): (expression: string, options?: EvalOptions) => Promise<unknown> {
+  const ensureConnectedForDispatch = async (options?: EvalOptions): Promise<void> => {
+    try {
+      await lifecycle.ensureConnected(options?.deadline);
+    } catch (error) {
+      if (!isServerDisconnectedError(error)) throw error;
+      await recoverTransport(options?.deadline, options?.timeout);
+      await lifecycle.ensureConnected(options?.deadline);
+    }
+  };
+
   const rawEvaluateOnce = async (
     expression: string,
     options?: EvalOptions,
   ): Promise<unknown> => {
-    await lifecycle.ensureConnected(options?.deadline);
+    await ensureConnectedForDispatch(options);
     const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
   };
@@ -475,7 +488,7 @@ export function createAppEvaluator(
   ): Promise<AppEvaluationCompletion> => {
     let sourceGeneration = options?.generation;
     const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
-      await lifecycle.ensureConnected(options?.deadline);
+      await ensureConnectedForDispatch(options);
       if (
         sourceGeneration !== undefined &&
         lifecycle.getGeneration &&

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -196,7 +196,10 @@ function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath
   return {
     expressions: [...left.expressions, ...right.expressions],
     clearRanges: [...left.clearRanges, ...right.clearRanges],
-    empty: left.empty || right.empty,
+    // A merged path is empty only when every contributing completion is
+    // empty. An explicit undefined completion from a catch/finally or a later
+    // empty loop iteration must replace an earlier value.
+    empty: left.empty && right.empty,
     undefined: left.undefined || right.undefined,
     normal: left.normal || right.normal,
   };
@@ -293,7 +296,7 @@ function completionForStatement(statement: StatementLike): Completion {
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
       const applied = applyFinallyCompletion(guarded, finalizer);
-      return {
+      const result = {
         ...applied,
         breaks: [
           ...guarded.breaks,
@@ -304,6 +307,7 @@ function completionForStatement(statement: StatementLike): Completion {
           ...finalizer.continues.map((path) => ({ ...path, inherit: false })),
         ],
       };
+      return result.normal ? normalizeControlCompletion(result) : result;
     }
     case 'LabeledStatement':
       return consumeLabelExits(
@@ -400,6 +404,85 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
+type SourceInsertion = { start: number; end?: number; replacement: string };
+
+function collectLoopEntryInsertions(
+  statement: StatementLike,
+  clearCompletion: string,
+  insertions: SourceInsertion[],
+): void {
+  const visit = (child: unknown): void => {
+    if (child && typeof child === 'object' && 'type' in child) {
+      collectLoopEntryInsertions(child as StatementLike, clearCompletion, insertions);
+    }
+  };
+  const visitList = (children: unknown): void => {
+    if (Array.isArray(children)) children.forEach(visit);
+  };
+
+  switch (statement.type) {
+    case 'BlockStatement':
+      visitList(statement.body);
+      return;
+    case 'IfStatement':
+      visit(statement.consequent);
+      visit(statement.alternate);
+      return;
+    case 'TryStatement':
+      visit(statement.block);
+      visit((statement.handler as { body?: unknown } | null | undefined)?.body);
+      visit(statement.finalizer);
+      return;
+    case 'LabeledStatement':
+    case 'WithStatement':
+      visit(statement.body);
+      return;
+    case 'SwitchStatement':
+      for (const switchCase of (statement.cases as Array<{ consequent?: unknown }> | undefined) ?? []) {
+        visitList(switchCase.consequent);
+      }
+      return;
+    case 'ForStatement':
+    case 'ForInStatement':
+    case 'ForOfStatement':
+    case 'WhileStatement':
+    case 'DoWhileStatement': {
+      const body = statement.body as StatementLike | undefined;
+      if (body?.start !== null && body?.start !== undefined &&
+          body.end !== null && body.end !== undefined) {
+        const bodyCompletion = completionForStatement(body);
+        // Each iteration computes a fresh body completion. A reached
+        // candidate immediately replaces this reset; a runtime path that
+        // reaches none of the candidates completes with undefined instead of
+        // leaking a value from an earlier iteration.
+        if (bodyCompletion.expressions.length === 0) {
+          visit(body);
+          return;
+        }
+        if (body.type === 'BlockStatement') {
+          const directives = (body.directives as Array<{ end?: number | null }> | undefined) ?? [];
+          const entry = directives.length > 0
+            ? directives[directives.length - 1]!.end
+            : (body.start as number) + 1;
+          if (entry !== null && entry !== undefined) {
+            insertions.push({ start: entry, replacement: ` ${clearCompletion}; ` });
+          }
+        } else {
+          insertions.push({
+            start: body.start as number,
+            replacement: `{ ${clearCompletion}; `,
+          });
+          insertions.push({ start: body.end as number, replacement: ' }' });
+        }
+      }
+      visit(body);
+      return;
+    }
+    default:
+      return;
+  }
+}
+
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -442,6 +525,10 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
+  const loopInsertions: SourceInsertion[] = [];
+  for (const statement of ast.program.body as StatementLike[]) {
+    collectLoopEntryInsertions(statement, clearCompletion, loopInsertions);
+  }
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -456,9 +543,11 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
+    ...loopInsertions,
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
-    transformed = transformed.slice(0, start) + replacement + transformed.slice(end);
+    transformed = transformed.slice(0, start) + replacement +
+      transformed.slice(end === undefined ? start : end);
   }
   const directives = (ast.program.directives as Array<{
     end?: number | null;
@@ -476,8 +565,10 @@ function promiseObservationExpression(expression: string, completionKey?: string
     var state = root[${keyLiteral}];
     var value = state ? state.completionValue : void 0;
     try {
-      var PromiseCtor = root && root.Promise;
-      if (PromiseCtor) PromiseCtor.prototype.then.call(value, function() {}, function() {});
+      var PromiseCtor = state && (state.promiseConstructor || root.Promise);
+      var promiseThen = (state && state.promiseThen) ||
+        (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
+      if (promiseThen) promiseThen.call(value, function() {}, function() {});
     } catch (_) {}
     if (state) state.completionValue = void 0;
     return value;
@@ -575,7 +666,14 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     // Assimilate arbitrary thenables exactly once. Calling this.then
     // directly would accept a second callback or a nested thenable as the
     // final value, unlike JavaScript Promise resolution.
-    root.Promise.resolve(this).then(fulfill, reject);
+    var PromiseCtor = state.promiseConstructor || root.Promise;
+    var promiseResolve = state.promiseResolve || (PromiseCtor && PromiseCtor.resolve);
+    if (!promiseResolve) throw new Error('Promise constructor unavailable');
+    var resolved = promiseResolve.call(PromiseCtor, this);
+    var promiseThen = state.promiseThen ||
+      (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
+    if (!promiseThen) throw new Error('Promise then unavailable');
+    promiseThen.call(resolved, fulfill, reject);
   } catch (error) { reject(error); }
   return true;
 }`;

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,4 +1,5 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
+import { parse } from '@babel/parser';
 import {
   decodeCDPUnserializableValue,
   extractCDPExceptionMessage,
@@ -93,6 +94,244 @@ async function sendRuntimeEvaluate(
   return result;
 }
 
+type StatementLike = {
+  type: string;
+  body?: unknown;
+  expression?: ExpressionLike;
+  [key: string]: unknown;
+};
+type ExpressionLike = { start: number | null; end: number | null };
+type CompletionPath = {
+  expressions: ExpressionLike[];
+  empty: boolean;
+  normal: boolean;
+};
+type ExitPath = CompletionPath & { label: string | null };
+type Completion = CompletionPath & {
+  breaks: ExitPath[];
+  continues: ExitPath[];
+};
+
+const emptyCompletion = (): Completion => ({
+  expressions: [],
+  empty: true,
+  normal: true,
+  breaks: [],
+  continues: [],
+});
+
+const abruptCompletion = (): Completion => ({
+  expressions: [],
+  empty: false,
+  normal: false,
+  breaks: [],
+  continues: [],
+});
+
+function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath {
+  return {
+    expressions: [...left.expressions, ...right.expressions],
+    empty: left.empty || right.empty,
+    normal: left.normal || right.normal,
+  };
+}
+
+function mergeCompletions(left: Completion, right: Completion): Completion {
+  const merged = mergePaths(left, right);
+  return {
+    ...merged,
+    breaks: [...left.breaks, ...right.breaks],
+    continues: [...left.continues, ...right.continues],
+  };
+}
+
+function consumeBreaks(completion: Completion, label: string | null = null): Completion {
+  let normal: CompletionPath = completion;
+  const remaining: ExitPath[] = [];
+  for (const path of completion.breaks) {
+    if (path.label === label) normal = mergePaths(normal, path);
+    else remaining.push(path);
+  }
+  return { ...normal, breaks: remaining, continues: completion.continues };
+}
+
+function consumeLoopExits(completion: Completion): Completion {
+  let normal: CompletionPath = completion;
+  const breaks: ExitPath[] = [];
+  const continues: ExitPath[] = [];
+  for (const path of completion.breaks) {
+    if (path.label === null) normal = mergePaths(normal, path);
+    else breaks.push(path);
+  }
+  for (const path of completion.continues) {
+    if (path.label === null) normal = mergePaths(normal, path);
+    else continues.push(path);
+  }
+  return { ...normal, breaks, continues };
+}
+
+function consumeLabelExits(completion: Completion, label: string): Completion {
+  const afterBreaks = consumeBreaks(completion, label);
+  let normal: CompletionPath = afterBreaks;
+  const continues: ExitPath[] = [];
+  for (const path of afterBreaks.continues) {
+    if (path.label === label) normal = mergePaths(normal, path);
+    else continues.push(path);
+  }
+  return { ...normal, breaks: afterBreaks.breaks, continues };
+}
+
+function completionForStatement(statement: StatementLike): Completion {
+  switch (statement.type) {
+    case 'EmptyStatement':
+    case 'VariableDeclaration':
+    case 'FunctionDeclaration':
+    case 'ClassDeclaration':
+    case 'DebuggerStatement':
+      return emptyCompletion();
+    case 'ExpressionStatement':
+      return statement.expression ? {
+        expressions: [statement.expression],
+        empty: false,
+        normal: true,
+        breaks: [],
+        continues: [],
+      } : emptyCompletion();
+    case 'BlockStatement':
+      return Array.isArray(statement.body)
+        ? completionForStatements(statement.body as StatementLike[])
+        : emptyCompletion();
+    case 'IfStatement': {
+      const consequent = completionForStatement(statement.consequent as StatementLike);
+      const alternate = statement.alternate
+        ? completionForStatement(statement.alternate as StatementLike)
+        : emptyCompletion();
+      return mergeCompletions(consequent, alternate);
+    }
+    case 'TryStatement': {
+      const body = completionForStatement(statement.block as StatementLike);
+      const handler = statement.handler
+        ? completionForStatement((statement.handler as { body: StatementLike }).body)
+        : abruptCompletion();
+      const guarded = mergeCompletions(body, handler);
+      if (!statement.finalizer) return guarded;
+      const finalizer = completionForStatement(statement.finalizer as StatementLike);
+      if (!finalizer.normal) return finalizer;
+      // A normal `finally` completion is UpdateEmpty: its expression value is
+      // discarded, while the prior try/catch completion is retained. This is
+      // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
+      return {
+        ...guarded,
+        breaks: [...guarded.breaks, ...finalizer.breaks],
+        continues: [...guarded.continues, ...finalizer.continues],
+      };
+    }
+    case 'LabeledStatement':
+      return consumeLabelExits(
+        completionForStatement(statement.body as StatementLike),
+        (statement.label as { name: string } | null | undefined)?.name ?? '',
+      );
+    case 'WithStatement':
+      return completionForStatement(statement.body as StatementLike);
+    case 'SwitchStatement': {
+      const cases = (statement.cases as Array<{ consequent: StatementLike[] }> | undefined) ?? [];
+      let completion = emptyCompletion();
+      for (let index = 0; index < cases.length; index += 1) {
+        const caseCompletion = completionForStatements(
+          cases.slice(index).flatMap((entry) => entry.consequent),
+        );
+        completion = mergeCompletions(
+          completion,
+          consumeBreaks(caseCompletion),
+        );
+      }
+      return completion;
+    }
+    case 'ForStatement':
+    case 'ForInStatement':
+    case 'ForOfStatement':
+    case 'WhileStatement':
+    case 'DoWhileStatement':
+      return mergeCompletions(
+        consumeLoopExits(completionForStatement(statement.body as StatementLike)),
+        emptyCompletion(),
+      );
+    case 'ThrowStatement':
+    case 'ReturnStatement':
+      return abruptCompletion();
+    case 'BreakStatement':
+      return {
+        ...abruptCompletion(),
+        breaks: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+      };
+    case 'ContinueStatement':
+      return {
+        ...abruptCompletion(),
+        continues: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+      };
+    default:
+      return abruptCompletion();
+  }
+}
+
+function completionForStatements(statements: StatementLike[]): Completion {
+  let completion = emptyCompletion();
+  for (const statement of statements) {
+    const next = completionForStatement(statement);
+    const breaks: ExitPath[] = [
+      ...completion.breaks,
+      ...next.breaks.map((path) => path.empty ? { ...completion, label: path.label } : path),
+    ];
+    const continues: ExitPath[] = [
+      ...completion.continues,
+      ...next.continues.map((path) => path.empty ? { ...completion, label: path.label } : path),
+    ];
+    if (!next.normal) {
+      return { ...next, breaks, continues };
+    }
+    completion = {
+      ...(next.empty ? mergePaths(completion, next) : next),
+      breaks,
+      continues,
+    };
+  }
+  return completion;
+}
+
+function promiseObservationExpression(expression: string): string {
+  let ast;
+  try {
+    ast = parse(expression, { sourceType: 'script' });
+  } catch {
+    return expression;
+  }
+  const completion = completionForStatements(ast.program.body as StatementLike[]);
+  if (!completion.normal || completion.expressions.length === 0) return expression;
+  const edits = completion.expressions
+    .filter(({ start, end }) => start !== null && end !== null)
+    .map(({ start, end }) => ({ start: start as number, end: end as number }))
+    .filter((edit, index, all) =>
+      all.findIndex((candidate) => candidate.start === edit.start && candidate.end === edit.end) === index,
+    )
+    .sort((left, right) => right.start - left.start);
+  let transformed = expression;
+  for (const { start, end } of edits) {
+    const candidate = expression.slice(start, end);
+    const observer = `(function observePromise(value) {
+      try {
+        var PromiseCtor = globalThis.Promise;
+        if (PromiseCtor) {
+          PromiseCtor.prototype.then.call(value, function() {}, function() {});
+        }
+      } catch (_) {}
+      return value;
+    })((${candidate}
+  ))`;
+    transformed = transformed.slice(0, start) + observer + transformed.slice(end);
+  }
+  return transformed;
+}
+
 /**
  * Send one Runtime.evaluate request and return its by-value completion value.
  *
@@ -123,10 +362,12 @@ export async function evaluateAppScript(
 export async function evaluateAppScriptCompletion(
   cdp: Pick<CDPConnection, 'send'>,
   expression: string,
-  options?: EvalOptions,
+  options?: EvalOptions & { observePromiseRejection?: boolean },
 ): Promise<AppEvaluationCompletion> {
   const result = await sendRuntimeEvaluate(cdp, {
-    expression,
+    expression: options?.observePromiseRejection
+      ? promiseObservationExpression(expression)
+      : expression,
     returnByValue: false,
     awaitPromise: false,
     ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
@@ -241,7 +482,11 @@ export function createAppEvaluator(
         throw new Error('App evaluation context changed before source dispatch');
       }
       const timeout = boundedRequestTimeout(options);
-      return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+      return evaluateAppScriptCompletion(cdp, expression, {
+        timeout,
+        objectGroup: options?.objectGroup,
+        observePromiseRejection: true,
+      });
     };
     try {
       return await evaluateOnce();

--- a/src/utils/fiber.ts
+++ b/src/utils/fiber.ts
@@ -323,7 +323,7 @@ export const FIBER_WALKER_JS = `
     };
   }
 
-  function metroWalkFibers(options, visitor) {
+  function metroWalkFibers(options, visitor, initialNavigationState) {
     var requestedDepth = Number(options.maxDepth);
     var requestedNodes = Number(options.maxNodes);
     var maxDepth = Math.min(600, Math.max(
@@ -362,7 +362,9 @@ export const FIBER_WALKER_JS = `
     }
 
     var entries = [];
-    var navigationState = metroNavigationState();
+    var navigationState = initialNavigationState === undefined
+      ? metroNavigationState()
+      : initialNavigationState;
     while (stack.length) {
       if (state.scannedNodes >= maxNodes) {
         state.complete = false;

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,82 @@
+import type { PluginContext } from '../plugin.js';
+import { buildFiberReadExpression, MAX_FIBER_DEPTH, MAX_FIBER_NODES } from './fiber.js';
+
+/** Shared by navigation inspection and automation; SDK state may be asynchronous. */
+export const NAVIGATION_STATE_EXPR = buildFiberReadExpression(`
+  function fallbackState() {
+    try {
+      var ref = globalThis.__METRO_MCP_NAV_REF__;
+      if (ref && ref.getRootState) {
+        var refState = ref.getRootState();
+        if (refState) return refState;
+      }
+      if (ref && ref.getCurrentRoute) {
+        var route = ref.getCurrentRoute();
+        if (route) return { index: 0, routes: [route] };
+      }
+    } catch (_) {}
+    try {
+      var expoState = globalThis.__EXPO_ROUTER_STATE__;
+      if (typeof expoState === 'function') expoState = expoState();
+      if (expoState) return expoState;
+    } catch (_) {}
+
+    var state = null;
+    metroWalkFibers(FIBER_OPTIONS, function(fiber) {
+      if (!state) state = metroNavigationStateFromFiber(fiber);
+    }, null);
+    return state;
+  }
+
+  try {
+    var bridge = globalThis.__METRO_BRIDGE__ || globalThis.__METRO_MCP__;
+    if (bridge && bridge.navigation && bridge.navigation.getState) {
+      var state = bridge.navigation.getState();
+      if (state && typeof state.then === 'function') {
+        return state.then(function(value) { return value || fallbackState(); }, fallbackState);
+      }
+      if (state) return state;
+    }
+  } catch (_) {}
+  return fallbackState();
+`, { maxDepth: MAX_FIBER_DEPTH, maxNodes: MAX_FIBER_NODES });
+
+export interface FocusedRoute {
+  name: string;
+  params: unknown;
+  key: unknown;
+}
+
+export function getFocusedRoute(state: unknown): FocusedRoute | null {
+  const seen = new Set<unknown>();
+  let current = state;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const navigation = current as Record<string, unknown>;
+    if (!Array.isArray(navigation.routes) || !navigation.routes.length) return null;
+    const index = navigation.index ?? navigation.routes.length - 1;
+    if (typeof index !== 'number' || !Number.isInteger(index)) return null;
+    const route = navigation.routes[index] as Record<string, unknown> | undefined;
+    if (!route || typeof route.name !== 'string') return null;
+    if (route.state && typeof route.state === 'object') {
+      current = route.state;
+      continue;
+    }
+    return { name: route.name, params: route.params || {}, key: route.key };
+  }
+  return null;
+}
+
+export async function readFocusedRoute(
+  evalInApp: PluginContext['evalInApp'],
+  timeout?: number,
+): Promise<FocusedRoute | null> {
+  return getFocusedRoute(await readNavigationState(evalInApp, timeout));
+}
+
+export function readNavigationState(
+  evalInApp: PluginContext['evalInApp'],
+  timeout?: number,
+): Promise<unknown> {
+  return evalInApp(NAVIGATION_STATE_EXPR, { awaitPromise: true, timeout });
+}

--- a/src/utils/tool-results.test.ts
+++ b/src/utils/tool-results.test.ts
@@ -41,6 +41,27 @@ test('serializes nested BigInts without throwing', () => {
   });
 });
 
+test('serializes boxed BigInts without throwing', () => {
+  expect(normalizeToolResult(Object(4n))).toEqual({
+    content: [{ type: 'text', text: '4n' }],
+  });
+  expect(normalizeToolResult({ count: Object(5n) })).toEqual({
+    content: [{ type: 'text', text: '{"count":"5n"}' }],
+  });
+});
+
+test('does not treat a spoofed BigInt tag as a boxed BigInt', () => {
+  const result = {
+    [Symbol.toStringTag]: 'BigInt',
+    valueOf: () => {
+      throw new Error('must not be called');
+    },
+  };
+  expect(normalizeToolResult(result)).toEqual({
+    content: [{ type: 'text', text: '{}' }],
+  });
+});
+
 test('preserves existing JSON handling for non-BigInt primitives', () => {
   expect(normalizeToolResult({
     nan: Number.NaN,

--- a/src/utils/tool-results.test.ts
+++ b/src/utils/tool-results.test.ts
@@ -23,6 +23,38 @@ test('serializes ordinary plugin results as text', () => {
   });
 });
 
+test('serializes a BigInt scalar using its JavaScript literal spelling', () => {
+  expect(normalizeToolResult(1n)).toEqual({
+    content: [{ type: 'text', text: '1n' }],
+  });
+});
+
+test('serializes nested BigInts without throwing', () => {
+  expect(normalizeToolResult({
+    count: 1n,
+    values: [2n, { total: 3n }],
+  })).toEqual({
+    content: [{
+      type: 'text',
+      text: '{"count":"1n","values":["2n",{"total":"3n"}]}',
+    }],
+  });
+});
+
+test('preserves existing JSON handling for non-BigInt primitives', () => {
+  expect(normalizeToolResult({
+    nan: Number.NaN,
+    positiveInfinity: Number.POSITIVE_INFINITY,
+    negativeInfinity: Number.NEGATIVE_INFINITY,
+    negativeZero: -0,
+  })).toEqual({
+    content: [{
+      type: 'text',
+      text: '{"nan":null,"positiveInfinity":null,"negativeInfinity":null,"negativeZero":0}',
+    }],
+  });
+});
+
 test('serializes content-shaped objects that are not valid MCP results', () => {
   const result = { content: [{ type: 'custom', value: 42 }] };
 

--- a/src/utils/tool-results.ts
+++ b/src/utils/tool-results.ts
@@ -4,15 +4,26 @@ import {
   type ToolHandlerResult,
 } from '../plugin.js';
 
+function serializeBigInt(value: unknown): string | undefined {
+  if (typeof value === 'bigint') return `${value}n`;
+  if (typeof value !== 'object' || value === null) return undefined;
+  try {
+    // Use the intrinsic method as the brand check. Symbol.toStringTag and an
+    // object's own valueOf() can both be overridden by ordinary plugin data.
+    return `${BigInt.prototype.valueOf.call(value)}n`;
+  } catch {}
+  return undefined;
+}
+
 function serializeToolValue(result: unknown): string {
   // BigInt is a valid evaluation result, but JSON.stringify throws before it
   // can produce the text response used by ordinary plugin tools. Keep the
   // familiar JavaScript literal spelling while making nested values JSON safe.
-  if (typeof result === 'bigint') return `${result}n`;
+  const bigint = serializeBigInt(result);
+  if (bigint !== undefined) return bigint;
   return JSON.stringify(
     result,
-    (_key, value: unknown) =>
-      typeof value === 'bigint' ? `${value}n` : value,
+    (_key, value: unknown) => serializeBigInt(value) ?? value,
   ) ?? String(result);
 }
 

--- a/src/utils/tool-results.ts
+++ b/src/utils/tool-results.ts
@@ -4,11 +4,23 @@ import {
   type ToolHandlerResult,
 } from '../plugin.js';
 
+function serializeToolValue(result: unknown): string {
+  // BigInt is a valid evaluation result, but JSON.stringify throws before it
+  // can produce the text response used by ordinary plugin tools. Keep the
+  // familiar JavaScript literal spelling while making nested values JSON safe.
+  if (typeof result === 'bigint') return `${result}n`;
+  return JSON.stringify(
+    result,
+    (_key, value: unknown) =>
+      typeof value === 'bigint' ? `${value}n` : value,
+  ) ?? String(result);
+}
+
 export function normalizeToolResult(result: ToolHandlerResult): CallToolResult {
   if (isNativeToolResult(result)) return result;
   const text =
     typeof result === 'string'
       ? result
-      : (JSON.stringify(result) ?? String(result));
+      : serializeToolValue(result);
   return { content: [{ type: 'text', text }] };
 }

--- a/tests/reconnect.test.ts
+++ b/tests/reconnect.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  waitForReconnect,
+  type ReconnectWaitTimers,
+} from '../src/server.js';
+
+function timerHarness() {
+  let intervalCallback: (() => void) | undefined;
+  let timeoutCallback: (() => void) | undefined;
+  let intervalActive = false;
+  let timeoutActive = false;
+  let intervalCleared = 0;
+  let timeoutCleared = 0;
+
+  const timers: ReconnectWaitTimers = {
+    setInterval(callback) {
+      intervalCallback = callback;
+      intervalActive = true;
+      return 1 as ReturnType<typeof setInterval>;
+    },
+    clearInterval() {
+      intervalActive = false;
+      intervalCleared += 1;
+    },
+    setTimeout(callback) {
+      timeoutCallback = callback;
+      timeoutActive = true;
+      return 1 as ReturnType<typeof setTimeout>;
+    },
+    clearTimeout() {
+      timeoutActive = false;
+      timeoutCleared += 1;
+    },
+  };
+
+  return {
+    timers,
+    fireInterval() {
+      if (intervalActive) intervalCallback?.();
+    },
+    fireTimeout() {
+      if (timeoutActive) timeoutCallback?.();
+    },
+    state() {
+      return { intervalActive, timeoutActive, intervalCleared, timeoutCleared };
+    },
+  };
+}
+
+describe('reconnect waits', () => {
+  test('clears caller polling when its deadline expires', async () => {
+    const harness = timerHarness();
+    const wait = waitForReconnect(
+      () => true,
+      Date.now() + 1000,
+      harness.timers,
+    );
+
+    expect(harness.state()).toMatchObject({
+      intervalActive: true,
+      timeoutActive: true,
+    });
+    harness.fireTimeout();
+
+    await expect(wait).rejects.toThrow('App evaluation timed out');
+    expect(harness.state()).toMatchObject({
+      intervalActive: false,
+      timeoutActive: false,
+      intervalCleared: 1,
+      timeoutCleared: 1,
+    });
+    harness.fireInterval();
+    expect(harness.state().intervalCleared).toBe(1);
+  });
+});


### PR DESCRIPTION
Navigation waits now use the same discovery and focused-route resolution as navigation inspection. This supports SDK state, navigation refs, Expo/Fiber discovery, and nested focused routes, so an already-focused route succeeds and later transitions are observed without changing the success response shape.

Fixes #83. Depends on #93; prerequisite commits are included with merge ancestry, and this PR targets main. The published Metro Bridge 0.2.10 timeout dependency is included in the current head.

Validation: Bun 1.3.10, 203 tests, typecheck, package build, docs build, and diff checks pass. Fixtures cover already-focused and later routes, nested navigation, timeout, serialized async SDK state, and the dependency's bounded reconnect cleanup. The inherited evaluator passed the direct connected-Hermes completion matrix. All three simplification passes used AGENTS.md, followed by a clean independent local review.


Final integration validation (2026-09-04), head `cc54ace`: 203 full tests, typecheck, production build, and diff checks pass. All eleven PR heads combine in the original local worktree; the combined build passes 459 tests, live Hermes comparisons, modern/legacy MCP HTTP and stdio checks, 27 functional tool calls, and a generated Appium sign-in round trip on the dedicated iOS simulator. Simplify and independent local review completed.
