### PR TITLE
Add verified SimView and IDB native input

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "chrome-launcher": "^1.2.1",
         "chromium-edge-launcher": "^0.3.0",
-        "metro-bridge": "^0.2.9",
+        "metro-bridge": "^0.2.10",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },
@@ -349,7 +349,7 @@
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "metro-bridge": ["metro-bridge@0.2.9", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-YRxcbpXr95BZJljRvw9IFWoSybpipYag5922Js1AlnPn0LygK0ciCiNmth1wzyu3pAKDA5YH8NtMWc7DfOeFWw=="],
+    "metro-bridge": ["metro-bridge@0.2.10", "", { "dependencies": { "ws": "^8.20.0" }, "optionalDependencies": { "chrome-launcher": "^1.2.1", "chromium-edge-launcher": "^0.3.0" }, "peerDependencies": { "react-native": ">=0.70.0" }, "optionalPeers": ["react-native"] }, "sha512-4hhoQJvqDzNNkN8IKf712+YSfdTZtXQFeiXuaPpXdpbLooGP+8+Q0S6Zm25VzWY2gqCTLr6gaTN/jpd14QKBYA=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "metro-mcp",
       "dependencies": {
+        "@babel/parser": "^7.29.2",
         "@clack/prompts": "^1.2.0",
         "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/node": "^2.0.0",

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,6 +11,23 @@ Works with **Expo**, **bare React Native**, and any project using **Metro + Herm
 - **Android**: Android SDK with `adb` on your PATH
 - **IDB** _(optional)_: Some iOS operations fall back to [IDB (idb-companion)](https://github.com/facebook/idb) — install with `brew install idb-companion`. Tools will tell you when IDB is needed.
 
+Native input providers can be selected in `metro-mcp.config.ts` without installing anything automatically:
+
+```ts
+export default {
+  input: {
+    nativeBackend: 'auto', // 'auto' | 'simview' | 'idb'
+    // Commands may include literal arguments; paths containing spaces may be quoted.
+    // simviewCommand: '/path/to/simview', // the `mcp` subcommand is added when omitted
+    // idbCommand: '/path/to/idb',
+  },
+};
+```
+
+On iOS, `auto` uses the packaged SimView MCP interface when available and falls back to supported IDB commands. Coordinates are logical screen points and are normalized against the selected device's current geometry.
+
+Provider discovery only runs read-only probes. IDB installations that do not implement `--version` are accepted when their help output advertises the supported UI commands.
+
 ## Installation
 
 ### Claude Code

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -127,14 +127,14 @@ Inspect and manage app permissions on iOS Simulator and Android Emulator without
 
 ## UI Interact
 
-All tools use the CDP fiber tree first, falling back to `simctl`/`adb`, then IDB as a last resort. IDB is optional — tools will prompt you to install it when needed.
+UI actions try the connected app's React handlers first. Coordinate actions then use the installed SimView MCP provider on iOS, followed by supported IDB commands; Android actions use the selected ADB serial. Native results include the backend and whether dispatch was submitted, refused, or uncertain. Providers are optional and are detected with read-only probes.
 
 - **`list_elements`** — Get interactive elements from the React component tree (labels, testIDs, roles) with traversal completeness metadata. No IDB needed.
-- **`tap_element`** — Tap by label/testID (CDP fiber tree) or coordinates (simctl/adb → IDB fallback).
-- **`type_text`** — Type into a TextInput by testID/label or the first visible input (CDP → adb → IDB).
-- **`long_press`** — Long press by label/testID (CDP) or coordinates (adb → IDB).
-- **`swipe`** — Scroll/swipe in a direction (CDP ScrollView → adb → IDB).
-- **`press_button`** — Press HOME (simctl), BACK/ENTER/DELETE (CDP + adb), VOLUME/POWER (adb → IDB).
+- **`tap_element`** — Tap by label/testID through the React fiber tree, or send logical device-point coordinates directly through SimView/IDB on iOS or the selected ADB serial on Android.
+- **`type_text`** — Type into a TextInput by testID/label or the first visible input (bounded Fiber handler → SimView → IDB on iOS, or the selected ADB serial on Android). Native results include the provider and dispatch status.
+- **`long_press`** — Long press through a React handler by label/testID, or send logical device-point coordinates through the native provider.
+- **`swipe`** — Scroll through a React handler, or derive a directional native swipe from the current device geometry.
+- **`press_button`** — Invoke React text-input handlers for ENTER/DELETE before using a supported native button capability.
 
 ## Navigation
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "author": "Stephen Radford",
   "license": "MIT",
   "dependencies": {
+    "@babel/parser": "^7.29.2",
     "@clack/prompts": "^1.2.0",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "chrome-launcher": "^1.2.1",
     "chromium-edge-launcher": "^0.3.0",
-    "metro-bridge": "^0.2.9",
+    "metro-bridge": "^0.2.10",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,9 @@ const DEFAULT_CONFIG: Required<MetroMCPConfig> = {
     enabled: true,
     port: 0,
   },
+  input: {
+    nativeBackend: 'auto',
+  },
 };
 
 function valueAfter(args: string[], flag: string): string | undefined {
@@ -205,5 +208,13 @@ function mergeConfig(
     if (source.proxy.enabled !== undefined)
       target.proxy.enabled = source.proxy.enabled;
     if (source.proxy.port !== undefined) target.proxy.port = source.proxy.port;
+  }
+  if (source.input) {
+    if (source.input.nativeBackend !== undefined)
+      target.input.nativeBackend = source.input.nativeBackend;
+    if (source.input.simviewCommand !== undefined)
+      target.input.simviewCommand = source.input.simviewCommand;
+    if (source.input.idbCommand !== undefined)
+      target.input.idbCommand = source.input.idbCommand;
   }
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -39,6 +39,17 @@ export interface DaemonIdentity {
   env: Record<string, string | undefined>;
   entrypoint: string;
   runtime: string;
+  input?: {
+    nativeBackend?: 'auto' | 'simview' | 'idb';
+    simviewCommand?: string;
+    idbCommand?: string;
+  };
+}
+
+/** The resolved configuration fields that affect daemon ownership. */
+export interface DaemonIdentityOverrides {
+  projectRoot?: string;
+  input?: DaemonIdentity['input'];
 }
 
 export interface DaemonRecord {
@@ -187,6 +198,7 @@ export function createDaemonIdentity(
     env: overrides.env ?? selectedEnv(),
     entrypoint: overrides.entrypoint ?? resolvePath(process.argv[1]),
     runtime: overrides.runtime ?? resolvePath(process.execPath),
+    ...(overrides.input ? { input: structuredClone(overrides.input) } : {}),
   };
 }
 
@@ -549,9 +561,13 @@ export async function cleanupStaleDaemonRecords(): Promise<void> {
   );
 }
 
-async function ensureDaemon(args: string[]): Promise<DaemonRecord> {
+async function ensureDaemon(
+  args: string[],
+  overrides: DaemonIdentityOverrides = {},
+): Promise<DaemonRecord> {
   const identity = createDaemonIdentity(args, {
-    projectRoot: resolveProjectRoot(args),
+    ...overrides,
+    projectRoot: overrides.projectRoot ?? resolveProjectRoot(args),
   });
   const key = getDaemonKey(args, identity);
   await cleanupStaleDaemonRecords();
@@ -726,8 +742,11 @@ export function registerStdioProxyShutdown(
   };
 }
 
-export async function startStdioProxy(args: string[]): Promise<void> {
-  const record = await ensureDaemon(args);
+export async function startStdioProxy(
+  args: string[],
+  identityOverrides: DaemonIdentityOverrides = {},
+): Promise<void> {
+  const record = await ensureDaemon(args, identityOverrides);
   const lease = new DaemonLeaseClient(record);
   const stdio = new StdioServerTransport();
   const daemonTransport = new StreamableHTTPClientTransport(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   removeDaemonRecordForProcess,
   startStdioProxy,
   writeDaemonRecord,
+  type DaemonIdentityOverrides,
 } from './daemon.js';
 import { createLogger } from './utils/logger.js';
 
@@ -99,15 +100,17 @@ Examples:
 
   try {
     const config = await loadConfig(serverArgs);
+    const daemonIdentityOverrides: DaemonIdentityOverrides = {
+      projectRoot: config.projectRoot,
+      input: config.input,
+    };
     logger.info(
       `Starting metro-mcp (Metro: ${config.metro.host}:${config.metro.port})`,
     );
 
     if (subcommand === 'serve') {
       const mcpPort = resolveMcpPort(serverArgs);
-      const identity = createDaemonIdentity(serverArgs, {
-        projectRoot: config.projectRoot,
-      });
+      const identity = createDaemonIdentity(serverArgs, daemonIdentityOverrides);
       const key = getDaemonKeyFromEnv(serverArgs, identity);
       const managed = isManagedDaemonProcess();
       const cleanupDaemonRecord = () =>
@@ -145,7 +148,7 @@ Examples:
       return;
     }
 
-    await startStdioProxy(serverArgs);
+    await startStdioProxy(serverArgs, daemonIdentityOverrides);
   } catch (err) {
     logger.error('Fatal error:', err);
     process.exit(1);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,10 +7,18 @@ import {
 import type { CircularBuffer } from './utils/buffer.js';
 import type { MetroTarget } from 'metro-bridge';
 
+interface CDPSendOptions {
+  timeoutMs?: number;
+}
+
 // ── CDP Connection Interface ──
 
 export interface CDPConnection {
-  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  send(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: CDPSendOptions,
+  ): Promise<unknown>;
   on(event: string, handler: (params: Record<string, unknown>) => void): void;
   off(event: string, handler: (params: Record<string, unknown>) => void): void;
   isConnected: boolean;
@@ -164,6 +172,8 @@ export interface EvalOptions {
   timeout?: number;
   /** Internal absolute deadline used to bound reconnect and transport waits. */
   deadline?: number;
+  /** Internal CDP object group used to release late remote completions. */
+  objectGroup?: string;
 }
 
 // ── Metro Events ──

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -162,6 +162,8 @@ export interface EvalOptions {
   awaitPromise?: boolean;
   /** CDP timeout in milliseconds (default: 10000) */
   timeout?: number;
+  /** Internal absolute deadline used to bound reconnect and transport waits. */
+  deadline?: number;
 }
 
 // ── Metro Events ──

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -213,7 +213,7 @@ export interface PluginContext {
   execFile(
     command: string,
     args: string[],
-    options?: { maxBuffer?: number },
+    options?: { maxBuffer?: number; timeout?: number },
   ): Promise<Buffer>;
   format: FormatUtils;
   /** Evaluate a JavaScript expression in the connected app runtime */

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -191,6 +191,8 @@ export interface PluginContext {
   ): void;
   registerResource(uri: string, config: ResourceConfig): void;
   registerPrompt(name: string, config: PromptConfig): void;
+  /** Register asynchronous resource cleanup for runtime shutdown. */
+  registerCleanup?: (callback: () => void | Promise<void>) => void;
   config: Record<string, unknown>;
   logger: Logger;
   metro: {
@@ -278,6 +280,14 @@ export interface MetroMCPConfig {
     enabled?: boolean;
     /** Port for the proxy server. Use 0 for OS-assigned. Defaults to 0. */
     port?: number;
+  };
+  input?: {
+    /** Native input provider order. Defaults to React handler, SimView, IDB. */
+    nativeBackend?: 'auto' | 'simview' | 'idb';
+    /** Optional executable path for the packaged SimView MCP server. */
+    simviewCommand?: string;
+    /** Optional executable path for IDB. */
+    idbCommand?: string;
   };
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -220,6 +220,8 @@ export interface PluginContext {
   evalInApp(expression: string, options?: EvalOptions): Promise<unknown>;
   /** Returns the active device key (`${port}-${targetId}`), or null if not connected. */
   getActiveDeviceKey(): string | null;
+  /** Monotonic runtime generation; changes invalidate in-flight app targets. */
+  getRuntimeGeneration?(): number;
   /** Returns a human-readable name for the active device, or null if not connected. */
   getActiveDeviceName(): string | null;
   /** Notify subscribed clients that a resource's content has changed */

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -215,7 +215,7 @@ export interface PluginContext {
   execFile(
     command: string,
     args: string[],
-    options?: { maxBuffer?: number },
+    options?: { maxBuffer?: number; timeout?: number },
   ): Promise<Buffer>;
   format: FormatUtils;
   /** Evaluate a JavaScript expression in the connected app runtime */

--- a/src/plugins/deeplink.ts
+++ b/src/plugins/deeplink.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
+import {
+  adbPrefix,
+  resolveDevice,
+} from '../utils/device-discovery.js';
 
 export const deeplinkPlugin = definePlugin({
   name: 'deeplink',
@@ -7,17 +11,8 @@ export const deeplinkPlugin = definePlugin({
   description: 'Cross-platform deep link testing',
 
   async setup(ctx) {
-    async function detectPlatform(): Promise<'ios' | 'android' | null> {
-      try {
-        await ctx.exec('xcrun simctl list booted 2>/dev/null | grep -q Booted');
-        return 'ios';
-      } catch {}
-      try {
-        const output = await ctx.exec('adb devices 2>/dev/null');
-        if (output.trim().split('\n').length > 1) return 'android';
-      } catch {}
-      return null;
-    }
+    const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
+      resolveDevice(ctx, platform, ctx.cdp.getTarget());
 
     ctx.registerTool('open_deeplink', {
       description: 'Open a URL or deep link on the connected iOS simulator or Android device.',
@@ -27,14 +22,15 @@ export const deeplinkPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ url, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         if (p === 'ios') {
-          await ctx.exec(`xcrun simctl openurl booted "${url}"`);
+          await ctx.exec(`xcrun simctl openurl "${target.id}" "${url}"`);
         } else {
           await ctx.exec(
-            `adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "${url}"`
+            `${adbPrefix(target.id)} shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "${url}"`
           );
         }
         return `Opened "${url}" on ${p === 'ios' ? 'iOS simulator' : 'Android device'}.`;
@@ -71,9 +67,9 @@ export const deeplinkPlugin = definePlugin({
 
         // Fallback: check Info.plist on iOS
         try {
-          const platform = await detectPlatform();
-          if (platform === 'android' && bundleId) {
-            const output = await ctx.exec(`adb shell pm dump "${bundleId}" | grep -A5 "scheme" 2>/dev/null`);
+          const target = await resolveTarget('auto');
+          if (target?.platform === 'android' && bundleId) {
+            const output = await ctx.exec(`${adbPrefix(target.id)} shell pm dump "${bundleId}" | grep -A5 "scheme" 2>/dev/null`);
             return output || 'No URL schemes found.';
           }
         } catch {}

--- a/src/plugins/deeplink.ts
+++ b/src/plugins/deeplink.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import {
   adbPrefix,
+  getConnectedDeviceTarget,
   resolveDevice,
 } from '../utils/device-discovery.js';
 
@@ -12,7 +13,7 @@ export const deeplinkPlugin = definePlugin({
 
   async setup(ctx) {
     const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
-      resolveDevice(ctx, platform, ctx.cdp.getTarget());
+      resolveDevice(ctx, platform, getConnectedDeviceTarget(ctx));
 
     ctx.registerTool('open_deeplink', {
       description: 'Open a URL or deep link on the connected iOS simulator or Android device.',

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -430,6 +430,9 @@ describe('fiber read tools', () => {
           ? { value: 'ready', onSubmitEditing: () => { submitted = true; } }
           : {},
       );
+      if (depth === 255) {
+        child.stateNode = { canonical: { publicInstance: { isFocused: () => true } } };
+      }
       append(current, child);
       current = child;
     }

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -77,6 +77,7 @@ function runtimeFor(
 async function createHarness(
   runtime: Record<string, unknown>,
   plugins: PluginDefinition[],
+  commands: Partial<Pick<PluginContext, 'exec' | 'execFile'>> = {},
 ) {
   // Runtime.evaluate executes against a persistent global object. A VM
   // context exercises that behavior, including indirect eval used by the
@@ -97,7 +98,12 @@ async function createHarness(
   // Also works when the screenshot plugin's execFile context API is present.
   const commandStubs = {
     exec: async () => '',
-    execFile: async () => Buffer.alloc(0),
+    execFile: async (command: string, args: string[]) => {
+      if (command === 'xcrun' && args.join(' ') === 'simctl list devices booted --json') {
+        return Buffer.from(JSON.stringify({ devices: { 'com.apple.CoreSimulator.SimRuntime.iOS-26-0': [{ name: 'Test iPhone', udid: 'TEST-UDID', state: 'Booted' }] } }));
+      }
+      return Buffer.alloc(0);
+    },
   };
   const ctx: PluginContext = {
     cdp: {
@@ -116,6 +122,7 @@ async function createHarness(
     logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
     metro: { host: 'localhost', port: 8081, fetch: async () => new Response() },
     ...commandStubs,
+    ...commands,
     format: {
       summarize: () => '',
       compact: (value: unknown) => JSON.stringify(value),
@@ -392,6 +399,80 @@ describe('fiber read tools', () => {
       complete: true,
       depthReached: 210,
     });
+  });
+
+  test('types into an immediate deep TextInput handler beyond depth 200', async () => {
+    const root = fiber('Root');
+    let current = root;
+    let received = '';
+    for (let depth = 1; depth <= 255; depth++) {
+      const child = fiber(depth === 255 ? 'TextInput' : `Wrapper${depth}`, depth === 255 ? { onChangeText: (value: string) => { received = value; } } : {});
+      append(current, child);
+      current = child;
+    }
+    const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
+    expect(await call('type_text', { text: 'immediate', platform: 'ios' })).toBe('Typed "immediate"');
+    expect(received).toBe('immediate');
+  });
+
+  test('presses ENTER through a deep TextInput handler before native input', async () => {
+    const root = fiber('Root');
+    let current = root;
+    let submitted = false;
+    for (let depth = 1; depth <= 255; depth++) {
+      const child = fiber(
+        depth === 255 ? 'TextInput' : `Wrapper${depth}`,
+        depth === 255
+          ? { value: 'ready', onSubmitEditing: () => { submitted = true; } }
+          : {},
+      );
+      append(current, child);
+      current = child;
+    }
+    const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
+    expect(await call('press_button', { button: 'ENTER', platform: 'ios' })).toBe('Pressed ENTER');
+    expect(submitted).toBe(true);
+  });
+
+  test('does not replay a scroll whose React method throws after invocation', async () => {
+    const host = fiber('RCTScrollView', {}, true);
+    host.stateNode = { scrollTo: () => { throw new Error('scroll dispatch uncertain'); } };
+    const root = append(fiber('ScrollView'), host);
+    const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
+    await expect(call('swipe', { direction: 'up', platform: 'ios' }))
+      .rejects.toThrow('scroll dispatch uncertain');
+  });
+
+  test('does not record a native swipe when no provider can dispatch it', async () => {
+    const events: unknown[] = [];
+    const call = await createHarness({
+      ...runtimeFor([fiber('Root')]),
+      __METRO_MCP_REC_ACTIVE__: true,
+      __METRO_MCP_REC_EVENTS__: events,
+    }, [uiInteractPlugin], {
+      execFile: async (command) => {
+        if (command === 'xcrun') return Buffer.from(JSON.stringify({
+          devices: { 'com.apple.CoreSimulator.SimRuntime.iOS-26-0': [
+            { name: 'Test iPhone', udid: 'TEST-UDID', state: 'Booted' },
+          ] },
+        }));
+        throw new Error('Native provider unavailable');
+      },
+    });
+    expect(await call('swipe', { direction: 'up', platform: 'ios' })).toContain('failed');
+    expect(events).toEqual([]);
+  });
+
+  test('does not fall through to native input when a React handler rejects', async () => {
+    const root = fiber('Root');
+    let current = root;
+    for (let depth = 1; depth <= 255; depth++) {
+      const child = fiber(depth === 255 ? 'TextInput' : `Wrapper${depth}`, depth === 255 ? { onChangeText: () => { throw new Error('handler failed'); } } : {});
+      append(current, child);
+      current = child;
+    }
+    const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
+    await expect(call('type_text', { text: 'reject', platform: 'ios' })).rejects.toThrow('handler failed');
   });
 });
 

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -415,7 +415,7 @@ describe('fiber read tools', () => {
       current = child;
     }
     const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
-    expect(await call('type_text', { text: 'immediate', platform: 'ios' })).toBe('Typed "immediate"');
+    expect(await call('type_text', { text: 'immediate', platform: 'auto' })).toBe('Typed "immediate"');
     expect(received).toBe('immediate');
   });
 
@@ -437,7 +437,7 @@ describe('fiber read tools', () => {
       current = child;
     }
     const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
-    expect(await call('press_button', { button: 'ENTER', platform: 'ios' })).toBe('Pressed ENTER');
+    expect(await call('press_button', { button: 'ENTER', platform: 'auto' })).toBe('Pressed ENTER');
     expect(submitted).toBe(true);
   });
 
@@ -446,7 +446,7 @@ describe('fiber read tools', () => {
     host.stateNode = { scrollTo: () => { throw new Error('scroll dispatch uncertain'); } };
     const root = append(fiber('ScrollView'), host);
     const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
-    await expect(call('swipe', { direction: 'up', platform: 'ios' }))
+    await expect(call('swipe', { direction: 'up', platform: 'auto' }))
       .rejects.toThrow('scroll dispatch uncertain');
   });
 
@@ -479,7 +479,7 @@ describe('fiber read tools', () => {
       current = child;
     }
     const call = await createHarness(runtimeFor([root]), [uiInteractPlugin]);
-    await expect(call('type_text', { text: 'reject', platform: 'ios' })).rejects.toThrow('handler failed');
+    await expect(call('type_text', { text: 'reject', platform: 'auto' })).rejects.toThrow('handler failed');
   });
 });
 

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -79,9 +79,9 @@ async function createHarness(
   plugins: PluginDefinition[],
 ) {
   // Runtime.evaluate executes against a persistent global object. A VM
-  // context exercises that behavior, including indirect eval used by the
-  // awaited mailbox path; wrapping snippets in new Function(globalThis) does
-  // not provide equivalent global declaration semantics.
+  // context exercises that behavior. Wrapping snippets in new
+  // Function(globalThis) does not provide equivalent global declaration
+  // semantics.
   const appGlobal = vm.createContext({
     ...runtime,
     setTimeout,
@@ -122,9 +122,13 @@ async function createHarness(
       truncate: (value: string) => value,
       structureOnly: (value: ComponentNode) => value,
     },
-    evalInApp: async (expression) => {
+    evalInApp: async (expression, options) => {
       // Mirror returnByValue without assuming CDP awaits an app's JS Promise.
       const result = new vm.Script(expression).runInContext(appGlobal);
+      if (options?.awaitPromise && result && typeof result === 'object' &&
+          typeof (result as Promise<unknown>).then === 'function') {
+        return result;
+      }
       return result === undefined
         ? undefined
         : JSON.parse(JSON.stringify(result));

--- a/src/plugins/fiber-tools.test.ts
+++ b/src/plugins/fiber-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import vm from 'node:vm';
 import type { z } from 'zod';
 import type {
   ComponentNode,
@@ -77,6 +78,15 @@ async function createHarness(
   runtime: Record<string, unknown>,
   plugins: PluginDefinition[],
 ) {
+  // Runtime.evaluate executes against a persistent global object. A VM
+  // context exercises that behavior, including indirect eval used by the
+  // awaited mailbox path; wrapping snippets in new Function(globalThis) does
+  // not provide equivalent global declaration semantics.
+  const appGlobal = vm.createContext({
+    ...runtime,
+    setTimeout,
+    clearTimeout,
+  });
   const tools = new Map<string, RegisteredTool>();
   const registerTool: PluginContext['registerTool'] = (name, config) => {
     tools.set(name, {
@@ -113,12 +123,8 @@ async function createHarness(
       structureOnly: (value: ComponentNode) => value,
     },
     evalInApp: async (expression) => {
-      const evaluate = new Function(
-        'globalThis',
-        `return ${expression};`,
-      ) as (globalObject: Record<string, unknown>) => unknown;
       // Mirror returnByValue without assuming CDP awaits an app's JS Promise.
-      const result = evaluate(runtime);
+      const result = new vm.Script(expression).runInContext(appGlobal);
       return result === undefined
         ? undefined
         : JSON.parse(JSON.stringify(result));

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
+import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
 
 const MAX_BYTES_DEFAULT = 50 * 1024;  // 50 KB
 const MAX_BYTES_CAP     = 1024 * 1024; // 1 MB
@@ -17,27 +18,8 @@ export const filesystemPlugin = definePlugin({
     '(Documents, Library/Caches, temp). Supports iOS Simulator and Android.',
 
   async setup(ctx) {
-    // Cache the detected platform for the lifetime of this plugin session so
-    // tools with platform:'auto' don't re-run xcrun/adb on every call.
-    let detectedPlatform: 'ios' | 'android' | null | undefined;
-
-    async function detectPlatform(): Promise<'ios' | 'android' | null> {
-      if (detectedPlatform !== undefined) return detectedPlatform;
-      try {
-        const out = await ctx.exec('xcrun simctl list booted 2>/dev/null');
-        if (out.includes('Booted')) return (detectedPlatform = 'ios');
-      } catch {}
-      try {
-        const out = await ctx.exec('adb devices 2>/dev/null');
-        const connected = out
-          .trim()
-          .split('\n')
-          .slice(1)
-          .filter((l) => l.trim() && !l.startsWith('*'));
-        if (connected.length > 0) return (detectedPlatform = 'android');
-      } catch {}
-      return (detectedPlatform = null);
-    }
+    const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
+      resolveDevice(ctx, platform, ctx.cdp.getTarget());
 
     function assertSafePath(p: string): void {
       if (p.split('/').includes('..')) {
@@ -45,9 +27,9 @@ export const filesystemPlugin = definePlugin({
       }
     }
 
-    async function getIosContainer(bundleId: string): Promise<string> {
+    async function getIosContainer(bundleId: string, udid?: string): Promise<string> {
       const out = await ctx.exec(
-        `xcrun simctl get_app_container booted "${bundleId}" data`
+        `xcrun simctl get_app_container "${udid ?? 'booted'}" "${bundleId}" data`
       );
       return out.trim();
     }
@@ -107,13 +89,14 @@ export const filesystemPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ bundleId, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return { error: 'No simulator/emulator detected' };
+        const target = await resolveTarget(platform);
+        if (!target) return { error: 'No simulator/emulator detected' };
+        const p = target.platform;
 
         if (p === 'ios') {
           if (!bundleId) return { error: 'bundleId is required for iOS' };
           try {
-            const root = await getIosContainer(bundleId);
+            const root = await getIosContainer(bundleId, target.id);
             return {
               root,
               documents: `${root}/Documents`,
@@ -132,7 +115,7 @@ export const filesystemPlugin = definePlugin({
         if (bundleId) {
           try {
             const homeOut = await ctx.exec(
-              `adb shell ${runAs(bundleId)}sh -c 'echo $HOME' 2>/dev/null`
+              `${adbPrefix(target.id)} shell ${runAs(bundleId)}sh -c 'echo $HOME' 2>/dev/null`
             );
             const home = homeOut.trim() || `/data/data/${bundleId}`;
             return {
@@ -198,15 +181,16 @@ export const filesystemPlugin = definePlugin({
           .describe('Recursively list subdirectories (returns raw text)'),
       }),
       handler: async ({ path, bundleId, platform, recursive }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return { error: 'No simulator/emulator detected' };
+        const target = await resolveTarget(platform);
+        if (!target) return { error: 'No simulator/emulator detected' };
+        const p = target.platform;
 
         let targetPath = path;
         if (!targetPath) {
           if (!bundleId) return { error: 'Provide either path or bundleId' };
           targetPath =
             p === 'ios'
-              ? await getIosContainer(bundleId)
+              ? await getIosContainer(bundleId, target.id)
               : `/data/data/${bundleId}`;
         }
 
@@ -217,7 +201,7 @@ export const filesystemPlugin = definePlugin({
           const output =
             p === 'ios'
               ? await ctx.exec(`ls ${flags} "${targetPath}" 2>&1`)
-              : await ctx.exec(`adb shell ${runAs(bundleId)}ls ${flags} "${targetPath}" 2>&1`);
+              : await ctx.exec(`${adbPrefix(target.id)} shell ${runAs(bundleId)}ls ${flags} "${targetPath}" 2>&1`);
 
           if (recursive) return output;
           return parseLsOutput(output, targetPath);
@@ -253,8 +237,9 @@ export const filesystemPlugin = definePlugin({
       handler: async ({ path, bundleId, platform, encoding, maxBytes }) => {
         assertSafePath(path);
         const limit = Math.min(maxBytes, MAX_BYTES_CAP);
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return { error: 'No simulator/emulator detected' };
+        const target = await resolveTarget(platform);
+        if (!target) return { error: 'No simulator/emulator detected' };
+        const p = target.platform;
 
         try {
           let content: string;
@@ -270,8 +255,8 @@ export const filesystemPlugin = definePlugin({
             const ra = runAs(bundleId);
             content =
               encoding === 'base64'
-                ? await ctx.exec(`adb shell ${ra}sh -c 'dd if="${path}" bs=${limit} count=1 2>/dev/null | base64'`)
-                : await ctx.exec(`adb shell ${ra}dd if="${path}" bs=${limit} count=1 2>/dev/null`);
+                ? await ctx.exec(`${adbPrefix(target.id)} shell ${ra}sh -c 'dd if="${path}" bs=${limit} count=1 2>/dev/null | base64'`)
+                : await ctx.exec(`${adbPrefix(target.id)} shell ${ra}dd if="${path}" bs=${limit} count=1 2>/dev/null`);
           }
 
           const truncated = encoding === 'base64'
@@ -300,14 +285,15 @@ export const filesystemPlugin = definePlugin({
       }),
       handler: async ({ path, bundleId, platform }) => {
         assertSafePath(path);
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return { error: 'No simulator/emulator detected' };
+        const target = await resolveTarget(platform);
+        if (!target) return { error: 'No simulator/emulator detected' };
+        const p = target.platform;
 
         try {
           const output =
             p === 'ios'
               ? await ctx.exec(`ls -lad "${path}" 2>&1`)
-              : await ctx.exec(`adb shell ${runAs(bundleId)}ls -lad "${path}" 2>&1`);
+              : await ctx.exec(`${adbPrefix(target.id)} shell ${runAs(bundleId)}ls -lad "${path}" 2>&1`);
 
           const info = parseFileInfoLine(output, path);
           return info ?? output.trim();
@@ -340,14 +326,15 @@ export const filesystemPlugin = definePlugin({
           return { error: 'Deletion not confirmed. Pass confirm: true to proceed.' };
         }
         assertSafePath(path);
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return { error: 'No simulator/emulator detected' };
+        const target = await resolveTarget(platform);
+        if (!target) return { error: 'No simulator/emulator detected' };
+        const p = target.platform;
 
         try {
           if (p === 'ios') {
             await ctx.exec(`rm -f "${path}"`);
           } else {
-            await ctx.exec(`adb shell ${runAs(bundleId)}rm "${path}"`);
+            await ctx.exec(`${adbPrefix(target.id)} shell ${runAs(bundleId)}rm "${path}"`);
           }
           return { success: true, deleted: path };
         } catch (err) {

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -93,15 +93,18 @@ export const filesystemPlugin = definePlugin({
         try {
           target = await resolveTarget(platform);
         } catch (error) {
-          if (platform !== 'android') throw error;
+          // Directory discovery has an in-app fallback that works without a
+          // local device transport. Keep explicit iOS strict because its
+          // bundle container path must come from simctl; auto and Android may
+          // continue through the connected app.
+          if (platform === 'ios') throw error;
           target = null;
         }
-        if (!target && platform !== 'android') {
+        if (!target && platform === 'ios') {
           return { error: 'No simulator/emulator detected' };
         }
-        const p = target?.platform ?? 'android';
 
-        if (p === 'ios') {
+        if (target?.platform === 'ios') {
           if (!target) return { error: 'No simulator/emulator detected' };
           if (!bundleId) return { error: 'bundleId is required for iOS' };
           try {
@@ -121,7 +124,7 @@ export const filesystemPlugin = definePlugin({
         }
 
         // Android — try adb first, fall back to evalInApp
-        if (bundleId) {
+        if (bundleId && target?.platform === 'android') {
           try {
             const homeOut = target
               ? await ctx.exec(`${adbPrefix(target.id)} shell ${runAs(bundleId)}sh -c 'echo $HOME' 2>/dev/null`)

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
+import {
+  adbPrefix,
+  getConnectedDeviceTarget,
+  resolveDevice,
+} from '../utils/device-discovery.js';
 
 const MAX_BYTES_DEFAULT = 50 * 1024;  // 50 KB
 const MAX_BYTES_CAP     = 1024 * 1024; // 1 MB
@@ -19,7 +23,7 @@ export const filesystemPlugin = definePlugin({
 
   async setup(ctx) {
     const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
-      resolveDevice(ctx, platform, ctx.cdp.getTarget());
+      resolveDevice(ctx, platform, getConnectedDeviceTarget(ctx));
 
     function assertSafePath(p: string): void {
       if (p.split('/').includes('..')) {

--- a/src/plugins/filesystem.ts
+++ b/src/plugins/filesystem.ts
@@ -89,11 +89,20 @@ export const filesystemPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ bundleId, platform }) => {
-        const target = await resolveTarget(platform);
-        if (!target) return { error: 'No simulator/emulator detected' };
-        const p = target.platform;
+        let target: Awaited<ReturnType<typeof resolveTarget>> = null;
+        try {
+          target = await resolveTarget(platform);
+        } catch (error) {
+          if (platform !== 'android') throw error;
+          target = null;
+        }
+        if (!target && platform !== 'android') {
+          return { error: 'No simulator/emulator detected' };
+        }
+        const p = target?.platform ?? 'android';
 
         if (p === 'ios') {
+          if (!target) return { error: 'No simulator/emulator detected' };
           if (!bundleId) return { error: 'bundleId is required for iOS' };
           try {
             const root = await getIosContainer(bundleId, target.id);
@@ -114,9 +123,10 @@ export const filesystemPlugin = definePlugin({
         // Android — try adb first, fall back to evalInApp
         if (bundleId) {
           try {
-            const homeOut = await ctx.exec(
-              `${adbPrefix(target.id)} shell ${runAs(bundleId)}sh -c 'echo $HOME' 2>/dev/null`
-            );
+            const homeOut = target
+              ? await ctx.exec(`${adbPrefix(target.id)} shell ${runAs(bundleId)}sh -c 'echo $HOME' 2>/dev/null`)
+              : '';
+            if (!homeOut) throw new Error('adb device unavailable');
             const home = homeOut.trim() || `/data/data/${bundleId}`;
             return {
               root:      home,

--- a/src/plugins/inspect-point.ts
+++ b/src/plugins/inspect-point.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { awaitAppResult } from '../utils/await-app-result.js';
 import {
   DEFAULT_FIBER_MAX_DEPTH,
   DEFAULT_FIBER_MAX_NODES,
@@ -184,7 +183,7 @@ export const inspectPointPlugin = definePlugin({
           true,
         );
 
-        return awaitAppResult(ctx.evalInApp, expression);
+        return ctx.evalInApp(expression, { awaitPromise: true });
       },
     });
   },

--- a/src/plugins/issue-79-regressions.test.ts
+++ b/src/plugins/issue-79-regressions.test.ts
@@ -15,6 +15,7 @@ function createContext(options: {
   evaluate?: unknown;
   ios?: string[];
   android?: string[];
+  connected?: boolean;
   target?: { deviceName: string; logicalDeviceId: string };
 }) {
   const tools = new Map<string, RegisteredTool>();
@@ -35,7 +36,7 @@ function createContext(options: {
 
   const ctx: PluginContext = {
     cdp: {
-      on: () => {}, off: () => {}, isConnected: true,
+      on: () => {}, off: () => {}, isConnected: options.connected ?? true,
       getTarget: () => target,
       send: async () => ({}),
     },
@@ -78,6 +79,26 @@ function createContext(options: {
 }
 
 describe('issue 79 device discovery regressions', () => {
+  test('filesystem resolves a replacement device when its disconnected target is stale', async () => {
+    const harness = createContext({
+      inventory: 'android',
+      connected: false,
+      target: { deviceName: 'Old emulator', logicalDeviceId: 'old-serial' },
+    });
+    await filesystemPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('read_file')!;
+
+    await tool.handler(tool.parameters.parse({
+      path: '/data/data/com.example.app/files/state.json',
+      bundleId: 'com.example.app',
+      platform: 'auto',
+    }) as Record<string, unknown>);
+
+    expect(harness.execCalls).toEqual([
+      'adb -s "emulator-42" shell run-as com.example.app dd if="/data/data/com.example.app/files/state.json" bs=51200 count=1 2>/dev/null',
+    ]);
+  });
+
   test('keeps the explicit Android filesystem fallback available without ADB', async () => {
     const harness = createContext({
       inventory: 'missing',

--- a/src/plugins/issue-79-regressions.test.ts
+++ b/src/plugins/issue-79-regressions.test.ts
@@ -104,6 +104,23 @@ describe('issue 79 device discovery regressions', () => {
     expect(harness.execFileCalls).toHaveLength(1);
   });
 
+  test('keeps the default auto filesystem fallback available without ADB', async () => {
+    const directories = {
+      documents: 'file:///data/user/0/com.example.app/files/',
+      cache: 'file:///data/user/0/com.example.app/cache/',
+      temp: 'file:///data/user/0/com.example.app/cache/',
+      library: null,
+    };
+    const harness = createContext({ inventory: 'missing', evaluate: directories });
+    await filesystemPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('get_app_directories')!;
+
+    await expect(tool.handler(tool.parameters.parse({
+      bundleId: 'com.example.app',
+    }) as Record<string, unknown>)).resolves.toEqual(directories);
+    expect(harness.execCalls).toEqual([]);
+  });
+
   test('does not clear app data when Android inventory resolution fails', async () => {
     const harness = createContext({ inventory: 'missing', resetFailure: true });
     await permissionsPlugin.setup(harness.ctx);

--- a/src/plugins/issue-79-regressions.test.ts
+++ b/src/plugins/issue-79-regressions.test.ts
@@ -17,6 +17,8 @@ function createContext(options: {
   android?: string[];
   connected?: boolean;
   target?: { deviceName: string; logicalDeviceId: string };
+  targetTitle?: string;
+  targetAfterInventory?: { title?: string; appId?: string };
 }) {
   const tools = new Map<string, RegisteredTool>();
   const execCalls: string[] = [];
@@ -25,9 +27,17 @@ function createContext(options: {
   const android = [...(options.android ?? (options.inventory === 'android'
     ? ['List of devices attached\nemulator-42\tdevice model:Pixel_8\n']
     : []))];
-  const target = {
+  let target: {
+    id: string;
+    title: string;
+    description: string;
+    type: string;
+    deviceName: string;
+    reactNative: { logicalDeviceId: string };
+    appId?: string;
+  } = {
     id: 'metro-target',
-    title: 'com.example.app (React Native)',
+    title: options.targetTitle ?? 'com.example.app (React Native)',
     description: 'React Native',
     type: 'node',
     deviceName: options.target?.deviceName ?? 'Pixel 8',
@@ -59,6 +69,12 @@ function createContext(options: {
     },
     execFile: async (command, args) => {
       execFileCalls.push([command, ...args]);
+      if (command === 'xcrun' && options.targetAfterInventory) {
+        target = {
+          ...target,
+          ...options.targetAfterInventory,
+        };
+      }
       if (command === 'adb' && options.inventory === 'missing') {
         throw new Error('adb unavailable');
       }
@@ -219,6 +235,62 @@ describe('issue 79 device discovery regressions', () => {
       'xcrun simctl privacy "IOS-1" grant "calendar" "com.example.app"',
     ]);
     expect(harness.execFileCalls.filter(([command]) => command === 'xcrun')).toHaveLength(1);
+  });
+
+  test('derives the permission app ID from the same target snapshot as inventory', async () => {
+    const ios = (udid: string) => JSON.stringify({ devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+        { name: 'iPhone 16', udid, state: 'Booted' },
+      ],
+    } });
+    const harness = createContext({
+      ios: [ios('IOS-1')],
+      target: { deviceName: 'iPhone 16', logicalDeviceId: 'IOS-1' },
+      targetAfterInventory: { title: 'com.other.app (React Native)' },
+    });
+    await permissionsPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('grant_permission')!;
+    const result = await tool.handler(tool.parameters.parse({
+      platform: 'ios', service: 'calendar',
+    }) as Record<string, unknown>);
+
+    expect(result).toContain('Granted');
+    expect(harness.execCalls).toEqual([
+      'xcrun simctl privacy "IOS-1" grant "calendar" "com.example.app"',
+    ]);
+  });
+
+  test('does not reuse an app ID across permission plugin targets', async () => {
+    const ios = (udid: string) => JSON.stringify({ devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+        { name: 'iPhone 16', udid, state: 'Booted' },
+      ],
+    } });
+    const first = createContext({
+      ios: [ios('IOS-1')],
+      target: { deviceName: 'iPhone 16', logicalDeviceId: 'IOS-1' },
+      targetTitle: 'com.first.app (React Native)',
+    });
+    await permissionsPlugin.setup(first.ctx);
+    const firstTool = first.tools.get('grant_permission')!;
+    await firstTool.handler(firstTool.parameters.parse({
+      platform: 'ios', service: 'calendar',
+    }) as Record<string, unknown>);
+
+    const second = createContext({
+      ios: [ios('IOS-2')],
+      target: { deviceName: 'iPhone 16', logicalDeviceId: 'IOS-2' },
+      targetTitle: 'com.second.app (React Native)',
+    });
+    await permissionsPlugin.setup(second.ctx);
+    const secondTool = second.tools.get('grant_permission')!;
+    await secondTool.handler(secondTool.parameters.parse({
+      platform: 'ios', service: 'calendar',
+    }) as Record<string, unknown>);
+
+    expect(second.execCalls).toEqual([
+      'xcrun simctl privacy "IOS-2" grant "calendar" "com.second.app"',
+    ]);
   });
 
   test('uses the originally resolved Android serial for permission reads', async () => {

--- a/src/plugins/issue-79-regressions.test.ts
+++ b/src/plugins/issue-79-regressions.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'bun:test';
+import type { z } from 'zod';
+import type { ComponentNode, PluginContext, ToolHandlerResult } from '../plugin.js';
+import { filesystemPlugin } from './filesystem.js';
+import { permissionsPlugin } from './permissions.js';
+
+type RegisteredTool = {
+  parameters: z.ZodType;
+  handler: (args: Record<string, unknown>) => Promise<ToolHandlerResult>;
+};
+
+function createContext(options: {
+  inventory?: 'android' | 'missing';
+  resetFailure?: boolean;
+  evaluate?: unknown;
+  ios?: string[];
+  android?: string[];
+  target?: { deviceName: string; logicalDeviceId: string };
+}) {
+  const tools = new Map<string, RegisteredTool>();
+  const execCalls: string[] = [];
+  const execFileCalls: string[][] = [];
+  const ios = [...(options.ios ?? [JSON.stringify({ devices: {} })])];
+  const android = [...(options.android ?? (options.inventory === 'android'
+    ? ['List of devices attached\nemulator-42\tdevice model:Pixel_8\n']
+    : []))];
+  const target = {
+    id: 'metro-target',
+    title: 'com.example.app (React Native)',
+    description: 'React Native',
+    type: 'node',
+    deviceName: options.target?.deviceName ?? 'Pixel 8',
+    reactNative: { logicalDeviceId: options.target?.logicalDeviceId ?? 'emulator-42' },
+  } as never;
+
+  const ctx: PluginContext = {
+    cdp: {
+      on: () => {}, off: () => {}, isConnected: true,
+      getTarget: () => target,
+      send: async () => ({}),
+    },
+    events: { on: () => {}, off: () => {}, isConnected: () => true },
+    registerTool: (name, config) => tools.set(name, {
+      parameters: config.parameters,
+      handler: config.handler as RegisteredTool['handler'],
+    }),
+    registerResource: () => {}, registerAppResource: () => {}, registerPrompt: () => {},
+    config: { packageName: 'com.example.app' },
+    logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    metro: { host: 'localhost', port: 8081, fetch: async () => new Response() },
+    exec: async (command) => {
+      execCalls.push(command);
+      if (options.resetFailure && command.includes('pm reset-permissions')) {
+        throw new Error('pm reset unsupported');
+      }
+      if (command.includes('echo $HOME')) return '';
+      return command.includes('pm clear') ? 'Success' : '';
+    },
+    execFile: async (command, args) => {
+      execFileCalls.push([command, ...args]);
+      if (command === 'adb' && options.inventory === 'missing') {
+        throw new Error('adb unavailable');
+      }
+      if (command === 'adb') {
+        return Buffer.from(android.shift() ?? android.at(-1) ?? 'List of devices attached\n');
+      }
+      return Buffer.from(ios.shift() ?? ios.at(-1) ?? JSON.stringify({ devices: {} }));
+    },
+    format: {
+      summarize: () => '', compact: (value: unknown) => JSON.stringify(value),
+      truncate: (value: string) => value, structureOnly: (value: ComponentNode) => value,
+    },
+    evalInApp: async () => options.evaluate,
+    getActiveDeviceKey: () => null, getActiveDeviceName: () => null,
+    notifyResourceUpdated: () => {},
+  };
+  return { ctx, tools, execCalls, execFileCalls };
+}
+
+describe('issue 79 device discovery regressions', () => {
+  test('keeps the explicit Android filesystem fallback available without ADB', async () => {
+    const harness = createContext({
+      inventory: 'missing',
+      evaluate: {
+        documents: 'file:///data/user/0/com.example.app/files/',
+        cache: 'file:///data/user/0/com.example.app/cache/',
+        temp: 'file:///data/user/0/com.example.app/cache/',
+        library: null,
+      },
+    });
+    await filesystemPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('get_app_directories')!;
+    const result = await tool.handler(tool.parameters.parse({
+      bundleId: 'com.example.app', platform: 'android',
+    }) as Record<string, unknown>);
+
+    expect(result).toEqual({
+      documents: 'file:///data/user/0/com.example.app/files/',
+      cache: 'file:///data/user/0/com.example.app/cache/',
+      temp: 'file:///data/user/0/com.example.app/cache/',
+      library: null,
+    });
+    expect(harness.execCalls).toEqual([]);
+    expect(harness.execFileCalls).toHaveLength(1);
+  });
+
+  test('does not clear app data when Android inventory resolution fails', async () => {
+    const harness = createContext({ inventory: 'missing', resetFailure: true });
+    await permissionsPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('reset_permissions')!;
+    const result = await tool.handler(tool.parameters.parse({
+      bundleId: 'com.example.app', platform: 'android',
+    }) as Record<string, unknown>);
+
+    expect(String(result)).toContain('Failed to reset permissions');
+    expect(harness.execCalls).toEqual([]);
+    expect(harness.execFileCalls).toHaveLength(1);
+  });
+
+  test('uses the same resolved Android serial for reset fallback after pm reset dispatch', async () => {
+    const harness = createContext({
+      inventory: 'android',
+      android: [
+        'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+        'List of devices attached\nemulator-99\tdevice model:Pixel_8\n',
+      ],
+      resetFailure: true,
+    });
+    await permissionsPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('reset_permissions')!;
+    const result = await tool.handler(tool.parameters.parse({
+      bundleId: 'com.example.app', platform: 'android',
+    }) as Record<string, unknown>);
+
+    expect(result).toContain('Reset all permissions');
+    expect(harness.execCalls).toEqual([
+      'adb -s "emulator-42" shell pm reset-permissions -p "com.example.app" 2>/dev/null',
+      'adb -s "emulator-42" shell pm clear "com.example.app"',
+    ]);
+    expect(harness.execFileCalls).toHaveLength(1);
+  });
+
+  test('uses the originally resolved Android serial for permission mutations', async () => {
+    const harness = createContext({
+      android: [
+        'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+        'List of devices attached\nemulator-99\tdevice model:Pixel_8\n',
+      ],
+    });
+    await permissionsPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('grant_permission')!;
+    const result = await tool.handler(tool.parameters.parse({
+      bundleId: 'com.example.app', platform: 'android', service: 'camera',
+    }) as Record<string, unknown>);
+
+    expect(result).toContain('Granted');
+    expect(harness.execCalls).toEqual([
+      'adb -s "emulator-42" shell pm grant "com.example.app" "android.permission.CAMERA"',
+    ]);
+    expect(harness.execFileCalls.filter(([command]) => command === 'adb')).toHaveLength(1);
+  });
+
+  test('uses the originally resolved iOS UDID for permission mutations', async () => {
+    const ios = (udid: string) => JSON.stringify({ devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+        { name: 'iPhone 16', udid, state: 'Booted' },
+      ],
+    } });
+    const harness = createContext({
+      ios: [ios('IOS-1'), ios('IOS-2')],
+      target: { deviceName: 'iPhone 16', logicalDeviceId: 'IOS-1' },
+    });
+    await permissionsPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('grant_permission')!;
+    const result = await tool.handler(tool.parameters.parse({
+      bundleId: 'com.example.app', platform: 'ios', service: 'calendar',
+    }) as Record<string, unknown>);
+
+    expect(result).toContain('Granted');
+    expect(harness.execCalls).toEqual([
+      'xcrun simctl privacy "IOS-1" grant "calendar" "com.example.app"',
+    ]);
+    expect(harness.execFileCalls.filter(([command]) => command === 'xcrun')).toHaveLength(1);
+  });
+
+  test('uses the originally resolved Android serial for permission reads', async () => {
+    const harness = createContext({
+      android: [
+        'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+        'List of devices attached\nemulator-99\tdevice model:Pixel_8\n',
+      ],
+    });
+    await permissionsPlugin.setup(harness.ctx);
+    const tool = harness.tools.get('list_permissions')!;
+    const result = await tool.handler(tool.parameters.parse({
+      bundleId: 'com.example.app', platform: 'android',
+    }) as Record<string, unknown>);
+
+    expect(result).toContain('No permissions found');
+    expect(harness.execCalls).toEqual([
+      'adb -s "emulator-42" shell dumpsys package "com.example.app" 2>/dev/null',
+    ]);
+    expect(harness.execFileCalls.filter(([command]) => command === 'adb')).toHaveLength(1);
+  });
+});

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
+import {
+  adbPrefix,
+  getConnectedDeviceTarget,
+  resolveDevice,
+} from '../utils/device-discovery.js';
 
 // Bundle IDs are stable for a plugin session; device state is deliberately
 // resolved on every call so a simulator booted after a miss is visible.
@@ -117,7 +121,7 @@ export const permissionsPlugin = definePlugin({
       const device = await resolveDevice(
         ctx,
         platform === 'auto' || !platform ? 'auto' : platform,
-        ctx.cdp.getTarget(),
+        getConnectedDeviceTarget(ctx),
       );
       if (!device) return 'No simulator/emulator detected.';
       const p = device.platform;
@@ -351,7 +355,7 @@ export const permissionsPlugin = definePlugin({
         const device = await resolveDevice(
           ctx,
           platform === 'auto' ? 'auto' : platform,
-          ctx.cdp.getTarget(),
+          getConnectedDeviceTarget(ctx),
         );
         if (!device) return 'No simulator/emulator detected.';
         const p = device.platform;
@@ -384,7 +388,7 @@ export const permissionsPlugin = definePlugin({
         'Current permission statuses for the connected app (auto-detected platform and bundle ID)',
       mimeType: 'text/plain',
       handler: async () => {
-        const target = await resolveDevice(ctx, 'auto', ctx.cdp.getTarget());
+        const target = await resolveDevice(ctx, 'auto', getConnectedDeviceTarget(ctx));
         if (!target) return '(no simulator/emulator detected)';
         const p = target.platform;
         const id = await detectBundleId(p);

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -4,11 +4,8 @@ import {
   adbPrefix,
   getConnectedDeviceTarget,
   resolveDevice,
+  snapshotConnectedDeviceTarget,
 } from '../utils/device-discovery.js';
-
-// Bundle IDs are stable for a plugin session; device state is deliberately
-// resolved on every call so a simulator booted after a miss is visible.
-let bundleIdCache: string | null = null;
 
 // TCC service name → friendly name
 const TCC_SERVICE_MAP: Record<string, string> = {
@@ -100,16 +97,19 @@ export const permissionsPlugin = definePlugin({
   description: 'Inspect and manage app permissions on iOS Simulator and Android Emulator',
 
   async setup(ctx) {
-    async function detectBundleId(platform: 'ios' | 'android'): Promise<string | null> {
-      if (bundleIdCache) return bundleIdCache;
+    function detectBundleId(
+      platform: 'ios' | 'android',
+      target: ReturnType<typeof getConnectedDeviceTarget>,
+    ): string | null {
       const config = ctx.config as Record<string, unknown>;
       if (platform === 'android' && config.packageName)
-        return (bundleIdCache = String(config.packageName));
-      if (config.bundleId) return (bundleIdCache = String(config.bundleId));
-      const title = ctx.cdp.getTarget()?.title;
+        return String(config.packageName);
+      if (config.bundleId) return String(config.bundleId);
+      if (target?.appId) return String(target.appId);
+      const title = target?.title;
       if (title) {
         const match = title.match(/^(.+?)\s+\(/);
-        if (match?.[1]) return (bundleIdCache = match[1]);
+        if (match?.[1]) return match[1];
       }
       return null;
     }
@@ -118,14 +118,15 @@ export const permissionsPlugin = definePlugin({
       platform: 'ios' | 'android' | 'auto' | undefined,
       bundleId: string | undefined
     ): Promise<{ p: 'ios' | 'android'; id: string; deviceId: string } | string> {
+      const connected = snapshotConnectedDeviceTarget(getConnectedDeviceTarget(ctx));
       const device = await resolveDevice(
         ctx,
         platform === 'auto' || !platform ? 'auto' : platform,
-        getConnectedDeviceTarget(ctx),
+        connected,
       );
       if (!device) return 'No simulator/emulator detected.';
       const p = device.platform;
-      const id = bundleId || (await detectBundleId(p));
+      const id = bundleId || detectBundleId(p, connected);
       if (!id)
         return 'Bundle ID / package name required. Provide bundleId or ensure the app is running.';
       return { p, id, deviceId: device.id };
@@ -352,10 +353,11 @@ export const permissionsPlugin = definePlugin({
           ),
       }),
       handler: async ({ platform, bundleId }) => {
+        const connected = snapshotConnectedDeviceTarget(getConnectedDeviceTarget(ctx));
         const device = await resolveDevice(
           ctx,
           platform === 'auto' ? 'auto' : platform,
-          getConnectedDeviceTarget(ctx),
+          connected,
         );
         if (!device) return 'No simulator/emulator detected.';
         const p = device.platform;
@@ -368,7 +370,7 @@ export const permissionsPlugin = definePlugin({
             return `Failed to open app settings: ${err instanceof Error ? err.message : String(err)}`;
           }
         } else {
-          const id = bundleId || (await detectBundleId(p));
+          const id = bundleId || detectBundleId(p, connected);
           if (!id) return 'Package name required for Android. Provide bundleId.';
           try {
             await ctx.exec(
@@ -388,10 +390,11 @@ export const permissionsPlugin = definePlugin({
         'Current permission statuses for the connected app (auto-detected platform and bundle ID)',
       mimeType: 'text/plain',
       handler: async () => {
-        const target = await resolveDevice(ctx, 'auto', getConnectedDeviceTarget(ctx));
+        const connected = snapshotConnectedDeviceTarget(getConnectedDeviceTarget(ctx));
+        const target = await resolveDevice(ctx, 'auto', connected);
         if (!target) return '(no simulator/emulator detected)';
         const p = target.platform;
-        const id = await detectBundleId(p);
+        const id = detectBundleId(p, connected);
         if (!id) return `(${p}) bundle ID not detected — run the app first`;
         const perms = await fetchPermissions(p, id, target.id);
         if (typeof perms === 'string') return perms;

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -96,16 +96,6 @@ export const permissionsPlugin = definePlugin({
   description: 'Inspect and manage app permissions on iOS Simulator and Android Emulator',
 
   async setup(ctx) {
-    async function detectPlatform(): Promise<'ios' | 'android' | null> {
-      const device = await resolveDevice(ctx, 'auto', ctx.cdp.getTarget());
-      return device?.platform ?? null;
-    }
-
-    async function getBootedIosUdid(): Promise<string | null> {
-      const device = await resolveDevice(ctx, 'ios', ctx.cdp.getTarget());
-      return device?.id ?? null;
-    }
-
     async function detectBundleId(platform: 'ios' | 'android'): Promise<string | null> {
       if (bundleIdCache) return bundleIdCache;
       const config = ctx.config as Record<string, unknown>;
@@ -151,9 +141,7 @@ export const permissionsPlugin = definePlugin({
           const serviceError = validateIosService(service);
           if (serviceError) return serviceError;
           try {
-            const udid = await getBootedIosUdid();
-            if (!udid) return 'No booted iOS simulator found.';
-            await ctx.exec(`xcrun simctl privacy "${udid}" ${action} "${service}" "${id}"`);
+            await ctx.exec(`xcrun simctl privacy "${resolved.deviceId}" ${action} "${service}" "${id}"`);
             return action === 'grant'
               ? `Granted "${service}" permission to ${id} on iOS simulator.`
               : `Revoked "${service}" permission from ${id} on iOS simulator.`;
@@ -163,9 +151,7 @@ export const permissionsPlugin = definePlugin({
         } else {
           const perm = normalizeAndroidPermission(service);
           try {
-            const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
-            if (!device) return 'No authorized Android device found.';
-            await ctx.exec(`${adbPrefix(device.id)} shell pm ${action} "${id}" "${perm}"`);
+            await ctx.exec(`${adbPrefix(resolved.deviceId)} shell pm ${action} "${id}" "${perm}"`);
             return action === 'grant'
               ? `Granted "${perm}" to ${id} on Android device.`
               : `Revoked "${perm}" from ${id} on Android device.`;
@@ -178,13 +164,13 @@ export const permissionsPlugin = definePlugin({
 
     async function fetchPermissions(
       p: 'ios' | 'android',
-      id: string
+      id: string,
+      deviceId: string,
     ): Promise<Record<string, string> | string> {
       if (p === 'ios') {
         try {
           // simctl privacy has no 'list' action — read the TCC database directly.
-          const udid = await getBootedIosUdid();
-          if (!udid) return 'No booted iOS simulator found.';
+          const udid = deviceId;
 
           const safeId = id.replace(/'/g, "''");
           const tccDb = `${process.env.HOME}/Library/Developer/CoreSimulator/Devices/${udid}/data/Library/TCC/TCC.db`;
@@ -228,9 +214,7 @@ export const permissionsPlugin = definePlugin({
         }
       } else {
         try {
-          const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
-          if (!device) return 'No authorized Android device found.';
-          const output = await ctx.exec(`${adbPrefix(device.id)} shell dumpsys package "${id}" 2>/dev/null`);
+          const output = await ctx.exec(`${adbPrefix(deviceId)} shell dumpsys package "${id}" 2>/dev/null`);
           const permissions: Record<string, string> = {};
           const permRegex = /(android\.permission\.\w+):\s*granted=(\w+)/g;
           let match;
@@ -259,7 +243,7 @@ export const permissionsPlugin = definePlugin({
         const resolved = await resolveTarget(platform, bundleId);
         if (typeof resolved === 'string') return resolved;
         const { p, id } = resolved;
-        const perms = await fetchPermissions(p, id);
+        const perms = await fetchPermissions(p, id, resolved.deviceId);
         if (typeof perms === 'string') return perms;
         if (Object.keys(perms).length === 0)
           return p === 'ios'
@@ -364,14 +348,17 @@ export const permissionsPlugin = definePlugin({
           ),
       }),
       handler: async ({ platform, bundleId }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const device = await resolveDevice(
+          ctx,
+          platform === 'auto' ? 'auto' : platform,
+          ctx.cdp.getTarget(),
+        );
+        if (!device) return 'No simulator/emulator detected.';
+        const p = device.platform;
 
         if (p === 'ios') {
           try {
-            const udid = await getBootedIosUdid();
-            if (!udid) return 'No booted iOS simulator found.';
-            await ctx.exec(`xcrun simctl openurl "${udid}" app-settings:`);
+            await ctx.exec(`xcrun simctl openurl "${device.id}" app-settings:`);
             return 'Opened app settings on iOS simulator.';
           } catch (err) {
             return `Failed to open app settings: ${err instanceof Error ? err.message : String(err)}`;
@@ -380,8 +367,6 @@ export const permissionsPlugin = definePlugin({
           const id = bundleId || (await detectBundleId(p));
           if (!id) return 'Package name required for Android. Provide bundleId.';
           try {
-            const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
-            if (!device) return 'No authorized Android device found.';
             await ctx.exec(
               `${adbPrefix(device.id)} shell am start -a android.settings.APPLICATION_DETAILS_SETTINGS -d "package:${id}"`
             );
@@ -399,11 +384,12 @@ export const permissionsPlugin = definePlugin({
         'Current permission statuses for the connected app (auto-detected platform and bundle ID)',
       mimeType: 'text/plain',
       handler: async () => {
-        const p = await detectPlatform();
-        if (!p) return '(no simulator/emulator detected)';
+        const target = await resolveDevice(ctx, 'auto', ctx.cdp.getTarget());
+        if (!target) return '(no simulator/emulator detected)';
+        const p = target.platform;
         const id = await detectBundleId(p);
         if (!id) return `(${p}) bundle ID not detected — run the app first`;
-        const perms = await fetchPermissions(p, id);
+        const perms = await fetchPermissions(p, id, target.id);
         if (typeof perms === 'string') return perms;
         if (Object.keys(perms).length === 0)
           return `[${p}] ${id}\n(no permissions requested yet)`;

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -1,11 +1,10 @@
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
+import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
 
-// Module-level caches — persist across tool handler calls for the lifetime of the server.
-let platformCache: { value: 'ios' | 'android' | null; ts: number } | null = null;
+// Bundle IDs are stable for a plugin session; device state is deliberately
+// resolved on every call so a simulator booted after a miss is visible.
 let bundleIdCache: string | null = null;
-let iosUdidCache: { value: string | null; ts: number } | null = null;
-const IOS_UDID_TTL_MS = 30_000;
 
 // TCC service name → friendly name
 const TCC_SERVICE_MAP: Record<string, string> = {
@@ -98,36 +97,13 @@ export const permissionsPlugin = definePlugin({
 
   async setup(ctx) {
     async function detectPlatform(): Promise<'ios' | 'android' | null> {
-      const now = Date.now();
-      if (platformCache && now - platformCache.ts < IOS_UDID_TTL_MS) return platformCache.value;
-      const [iosUdidResult, androidResult] = await Promise.allSettled([
-        getBootedIosUdid(),
-        ctx.exec('adb devices 2>/dev/null'),
-      ]);
-      let platform: 'ios' | 'android' | null = null;
-      if (iosUdidResult.status === 'fulfilled' && iosUdidResult.value !== null) {
-        platform = 'ios';
-      } else if (androidResult.status === 'fulfilled') {
-        const output = (androidResult as PromiseFulfilledResult<string>).value;
-        if (output.trim().split('\n').length > 1) platform = 'android';
-      }
-      platformCache = { value: platform, ts: now };
-      return platform;
+      const device = await resolveDevice(ctx, 'auto', ctx.cdp.getTarget());
+      return device?.platform ?? null;
     }
 
     async function getBootedIosUdid(): Promise<string | null> {
-      const now = Date.now();
-      if (iosUdidCache && now - iosUdidCache.ts < IOS_UDID_TTL_MS) return iosUdidCache.value;
-      const devicesJson = await ctx.exec('xcrun simctl list devices booted --json');
-      const devicesData = JSON.parse(devicesJson) as {
-        devices: Record<string, Array<{ udid: string; state: string }>>;
-      };
-      const udid =
-        Object.values(devicesData.devices)
-          .flat()
-          .find((d) => d.state === 'Booted')?.udid ?? null;
-      iosUdidCache = { value: udid, ts: now };
-      return udid;
+      const device = await resolveDevice(ctx, 'ios', ctx.cdp.getTarget());
+      return device?.id ?? null;
     }
 
     async function detectBundleId(platform: 'ios' | 'android'): Promise<string | null> {
@@ -170,7 +146,9 @@ export const permissionsPlugin = definePlugin({
           const serviceError = validateIosService(service);
           if (serviceError) return serviceError;
           try {
-            await ctx.exec(`xcrun simctl privacy booted ${action} "${service}" "${id}"`);
+            const udid = await getBootedIosUdid();
+            if (!udid) return 'No booted iOS simulator found.';
+            await ctx.exec(`xcrun simctl privacy "${udid}" ${action} "${service}" "${id}"`);
             return action === 'grant'
               ? `Granted "${service}" permission to ${id} on iOS simulator.`
               : `Revoked "${service}" permission from ${id} on iOS simulator.`;
@@ -180,7 +158,9 @@ export const permissionsPlugin = definePlugin({
         } else {
           const perm = normalizeAndroidPermission(service);
           try {
-            await ctx.exec(`adb shell pm ${action} "${id}" "${perm}"`);
+            const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
+            if (!device) return 'No authorized Android device found.';
+            await ctx.exec(`${adbPrefix(device.id)} shell pm ${action} "${id}" "${perm}"`);
             return action === 'grant'
               ? `Granted "${perm}" to ${id} on Android device.`
               : `Revoked "${perm}" from ${id} on Android device.`;
@@ -243,7 +223,9 @@ export const permissionsPlugin = definePlugin({
         }
       } else {
         try {
-          const output = await ctx.exec(`adb shell dumpsys package "${id}" 2>/dev/null`);
+          const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
+          if (!device) return 'No authorized Android device found.';
+          const output = await ctx.exec(`${adbPrefix(device.id)} shell dumpsys package "${id}" 2>/dev/null`);
           const permissions: Record<string, string> = {};
           const permRegex = /(android\.permission\.\w+):\s*granted=(\w+)/g;
           let match;
@@ -327,7 +309,9 @@ export const permissionsPlugin = definePlugin({
             if (serviceError) return serviceError;
           }
           try {
-            await ctx.exec(`xcrun simctl privacy booted reset "${iosTarget}" "${id}"`);
+            const udid = await getBootedIosUdid();
+            if (!udid) return 'No booted iOS simulator found.';
+            await ctx.exec(`xcrun simctl privacy "${udid}" reset "${iosTarget}" "${id}"`);
             return `Reset ${service ? `"${service}"` : 'all'} permissions for ${id} on iOS simulator.`;
           } catch (err) {
             return `Failed to reset permissions: ${err instanceof Error ? err.message : String(err)}`;
@@ -336,14 +320,20 @@ export const permissionsPlugin = definePlugin({
           try {
             if (service) {
               const perm = normalizeAndroidPermission(service);
-              await ctx.exec(`adb shell pm revoke "${id}" "${perm}"`);
+              const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
+              if (!device) return 'No authorized Android device found.';
+              await ctx.exec(`${adbPrefix(device.id)} shell pm revoke "${id}" "${perm}"`);
               return `Reset "${perm}" for ${id} on Android device.`;
             } else {
               // pm reset-permissions not available on older Android; pm clear resets all app state including permissions
               try {
-                await ctx.exec(`adb shell pm reset-permissions -p "${id}" 2>/dev/null`);
+                const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
+                if (!device) return 'No authorized Android device found.';
+                await ctx.exec(`${adbPrefix(device.id)} shell pm reset-permissions -p "${id}" 2>/dev/null`);
               } catch {
-                await ctx.exec(`adb shell pm clear "${id}"`);
+                const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
+                if (!device) return 'No authorized Android device found.';
+                await ctx.exec(`${adbPrefix(device.id)} shell pm clear "${id}"`);
               }
               return `Reset all permissions for ${id} on Android device.`;
             }
@@ -373,7 +363,9 @@ export const permissionsPlugin = definePlugin({
 
         if (p === 'ios') {
           try {
-            await ctx.exec('xcrun simctl openurl booted app-settings:');
+            const udid = await getBootedIosUdid();
+            if (!udid) return 'No booted iOS simulator found.';
+            await ctx.exec(`xcrun simctl openurl "${udid}" app-settings:`);
             return 'Opened app settings on iOS simulator.';
           } catch (err) {
             return `Failed to open app settings: ${err instanceof Error ? err.message : String(err)}`;
@@ -382,8 +374,10 @@ export const permissionsPlugin = definePlugin({
           const id = bundleId || (await detectBundleId(p));
           if (!id) return 'Package name required for Android. Provide bundleId.';
           try {
+            const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
+            if (!device) return 'No authorized Android device found.';
             await ctx.exec(
-              `adb shell am start -a android.settings.APPLICATION_DETAILS_SETTINGS -d "package:${id}"`
+              `${adbPrefix(device.id)} shell am start -a android.settings.APPLICATION_DETAILS_SETTINGS -d "package:${id}"`
             );
             return `Opened app settings for ${id} on Android device.`;
           } catch (err) {

--- a/src/plugins/permissions.ts
+++ b/src/plugins/permissions.ts
@@ -123,13 +123,18 @@ export const permissionsPlugin = definePlugin({
     async function resolveTarget(
       platform: 'ios' | 'android' | 'auto' | undefined,
       bundleId: string | undefined
-    ): Promise<{ p: 'ios' | 'android'; id: string } | string> {
-      const p = platform === 'auto' || !platform ? await detectPlatform() : platform;
-      if (!p) return 'No simulator/emulator detected.';
+    ): Promise<{ p: 'ios' | 'android'; id: string; deviceId: string } | string> {
+      const device = await resolveDevice(
+        ctx,
+        platform === 'auto' || !platform ? 'auto' : platform,
+        ctx.cdp.getTarget(),
+      );
+      if (!device) return 'No simulator/emulator detected.';
+      const p = device.platform;
       const id = bundleId || (await detectBundleId(p));
       if (!id)
         return 'Bundle ID / package name required. Provide bundleId or ensure the app is running.';
-      return { p, id };
+      return { p, id, deviceId: device.id };
     }
 
     function validateIosService(service: string): string | null {
@@ -298,9 +303,18 @@ export const permissionsPlugin = definePlugin({
           .describe('Bundle ID (iOS) or package name (Android). Auto-detected if omitted.'),
       }),
       handler: async ({ service, platform, bundleId }) => {
-        const resolved = await resolveTarget(platform, bundleId);
+        let resolved: Awaited<ReturnType<typeof resolveTarget>>;
+        try {
+          resolved = await resolveTarget(platform, bundleId);
+        } catch (err) {
+          return `Failed to reset permissions: ${err instanceof Error ? err.message : String(err)}`;
+        }
         if (typeof resolved === 'string') return resolved;
         const { p, id } = resolved;
+        // Resolve the native target once, outside the reset fallback. If
+        // inventory discovery fails, never interpret that as a failed adb
+        // reset and issue a second destructive command.
+        const deviceId = p === 'android' ? resolved.deviceId : null;
 
         if (p === 'ios') {
           const iosTarget = service ?? 'all';
@@ -309,9 +323,7 @@ export const permissionsPlugin = definePlugin({
             if (serviceError) return serviceError;
           }
           try {
-            const udid = await getBootedIosUdid();
-            if (!udid) return 'No booted iOS simulator found.';
-            await ctx.exec(`xcrun simctl privacy "${udid}" reset "${iosTarget}" "${id}"`);
+            await ctx.exec(`xcrun simctl privacy "${resolved.deviceId}" reset "${iosTarget}" "${id}"`);
             return `Reset ${service ? `"${service}"` : 'all'} permissions for ${id} on iOS simulator.`;
           } catch (err) {
             return `Failed to reset permissions: ${err instanceof Error ? err.message : String(err)}`;
@@ -320,20 +332,14 @@ export const permissionsPlugin = definePlugin({
           try {
             if (service) {
               const perm = normalizeAndroidPermission(service);
-              const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
-              if (!device) return 'No authorized Android device found.';
-              await ctx.exec(`${adbPrefix(device.id)} shell pm revoke "${id}" "${perm}"`);
+              await ctx.exec(`${adbPrefix(deviceId!)} shell pm revoke "${id}" "${perm}"`);
               return `Reset "${perm}" for ${id} on Android device.`;
             } else {
               // pm reset-permissions not available on older Android; pm clear resets all app state including permissions
               try {
-                const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
-                if (!device) return 'No authorized Android device found.';
-                await ctx.exec(`${adbPrefix(device.id)} shell pm reset-permissions -p "${id}" 2>/dev/null`);
+                await ctx.exec(`${adbPrefix(deviceId!)} shell pm reset-permissions -p "${id}" 2>/dev/null`);
               } catch {
-                const device = await resolveDevice(ctx, 'android', ctx.cdp.getTarget());
-                if (!device) return 'No authorized Android device found.';
-                await ctx.exec(`${adbPrefix(device.id)} shell pm clear "${id}"`);
+                await ctx.exec(`${adbPrefix(deviceId!)} shell pm clear "${id}"`);
               }
               return `Reset all permissions for ${id} on Android device.`;
             }

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -16,6 +16,7 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { z } from 'zod';
+import type { MetroTarget } from 'metro-bridge';
 import type {
   ComponentNode,
   PluginContext,
@@ -48,6 +49,8 @@ async function createSimulatorHarness(
     execError?: Error;
     captureSize?: number;
     execFileCalls?: Array<{ command: string; args: string[] }>;
+    androidOutput?: string;
+    targetId?: string;
   } = {},
 ) {
   const tools = new Map<string, RegisteredTool>();
@@ -59,13 +62,21 @@ async function createSimulatorHarness(
     });
   };
   const writeCapture = options.writeCapture ?? true;
+  const target: MetroTarget | null = options.targetId ? {
+    id: 'test-target',
+    title: 'Test app',
+    description: 'React Native',
+    type: 'node',
+    deviceName: 'Pixel_8',
+    reactNative: { logicalDeviceId: options.targetId },
+  } : null;
 
   const ctx: PluginContext = {
     cdp: {
       on: () => {},
       off: () => {},
       isConnected: false,
-      getTarget: () => null,
+      getTarget: () => target,
       send: async () => ({}),
     },
     events: {
@@ -92,6 +103,18 @@ async function createSimulatorHarness(
     exec: async () => '',
     execFile: async (command, args) => {
       options.execFileCalls?.push({ command, args });
+      if (command === 'xcrun' && args.slice(0, 4).join(' ') === 'simctl list devices booted') {
+        return Buffer.from(JSON.stringify({
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+              { name: 'iPhone 16', udid: 'SIMULATOR-UDID', state: 'Booted' },
+            ],
+          },
+        }));
+      }
+      if (command === 'adb' && args.join(' ') === 'devices -l') {
+        return Buffer.from(options.androidOutput ?? 'List of devices attached\nemulator-5554\tdevice product:pixel_8 model:Pixel_8 device:husky\n');
+      }
       const path = command === 'xcrun' ? args.at(-1) : undefined;
       if (writeCapture && path) {
         createdFiles.add(path);
@@ -136,17 +159,31 @@ describe('take_screenshot', () => {
     await capture(tool, { platform: 'ios' });
     await capture(tool, { platform: 'android' });
 
-    expect(execFileCalls[0].command).toBe('xcrun');
-    expect(execFileCalls[0].args.slice(0, -1)).toEqual([
+    expect(execFileCalls[1].command).toBe('xcrun');
+    expect(execFileCalls[1].args.slice(0, -1)).toEqual([
       'simctl',
       'io',
-      'booted',
+      'SIMULATOR-UDID',
       'screenshot',
     ]);
-    expect(execFileCalls[0].args.at(-1)?.startsWith(tmpdir())).toBe(true);
-    expect(execFileCalls[1]).toEqual({
+    expect(execFileCalls[1].args.at(-1)?.startsWith(tmpdir())).toBe(true);
+    expect(execFileCalls[3]).toEqual({
       command: 'adb',
-      args: ['exec-out', 'screencap', '-p'],
+      args: ['-s', 'emulator-5554', 'exec-out', 'screencap', '-p'],
+    });
+  });
+
+  test('scopes Android dispatch to the connected serial when several devices are authorized', async () => {
+    const execFileCalls: Array<{ command: string; args: string[] }> = [];
+    const tool = await createSimulatorHarness({
+      execFileCalls,
+      targetId: 'emulator-2',
+      androidOutput: 'List of devices attached\nemulator-1\tdevice model:Pixel_8\nemulator-2\tdevice model:Pixel_9\n',
+    });
+    await capture(tool, { platform: 'android' });
+    expect(execFileCalls.at(-1)).toEqual({
+      command: 'adb',
+      args: ['-s', 'emulator-2', 'exec-out', 'screencap', '-p'],
     });
   });
 

--- a/src/plugins/simulator.test.ts
+++ b/src/plugins/simulator.test.ts
@@ -51,6 +51,7 @@ async function createSimulatorHarness(
     execFileCalls?: Array<{ command: string; args: string[] }>;
     androidOutput?: string;
     targetId?: string;
+    connected?: boolean;
   } = {},
 ) {
   const tools = new Map<string, RegisteredTool>();
@@ -75,7 +76,7 @@ async function createSimulatorHarness(
     cdp: {
       on: () => {},
       off: () => {},
-      isConnected: false,
+      isConnected: options.connected ?? false,
       getTarget: () => target,
       send: async () => ({}),
     },
@@ -152,6 +153,19 @@ async function capture(
 }
 
 describe('take_screenshot', () => {
+  test('resolves a replacement sole simulator when the Metro target is stale', async () => {
+    const tool = await createSimulatorHarness({
+      targetId: 'stale-target-id',
+      androidOutput: 'List of devices attached\n',
+    });
+
+    const result = await capture(tool, { platform: 'auto' });
+
+    expect(result).toMatchObject({
+      structuredContent: { platform: 'ios' },
+    });
+  });
+
   test('uses direct executable arguments instead of shell path quoting', async () => {
     const execFileCalls: Array<{ command: string; args: string[] }> = [];
     const tool = await createSimulatorHarness({ execFileCalls });
@@ -178,6 +192,7 @@ describe('take_screenshot', () => {
     const tool = await createSimulatorHarness({
       execFileCalls,
       targetId: 'emulator-2',
+      connected: true,
       androidOutput: 'List of devices attached\nemulator-1\tdevice model:Pixel_8\nemulator-2\tdevice model:Pixel_9\n',
     });
     await capture(tool, { platform: 'android' });

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -15,7 +15,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 import { definePlugin, nativeToolResult } from '../plugin.js';
-import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
+import {
+  adbPrefix,
+  getConnectedDeviceTarget,
+  resolveDevice,
+} from '../utils/device-discovery.js';
 
 const SCREENSHOT_PREFIX = 'metro-mcp-screenshot-';
 const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -92,7 +96,7 @@ export const simulatorPlugin = definePlugin({
 
   async setup(ctx) {
     const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
-      resolveDevice(ctx, platform, ctx.cdp.getTarget());
+      resolveDevice(ctx, platform, getConnectedDeviceTarget(ctx));
 
     ctx.registerTool('take_screenshot', {
       description: 'Capture a screenshot from the connected iOS simulator or Android device.',

--- a/src/plugins/simulator.ts
+++ b/src/plugins/simulator.ts
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 import { definePlugin, nativeToolResult } from '../plugin.js';
+import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
 
 const SCREENSHOT_PREFIX = 'metro-mcp-screenshot-';
 const SCREENSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -90,17 +91,8 @@ export const simulatorPlugin = definePlugin({
   description: 'Unified iOS simulator / Android emulator device control',
 
   async setup(ctx) {
-    async function detectPlatform(): Promise<'ios' | 'android' | null> {
-      try {
-        await ctx.exec('xcrun simctl list booted 2>/dev/null');
-        return 'ios';
-      } catch {}
-      try {
-        await ctx.exec('adb devices 2>/dev/null');
-        return 'android';
-      } catch {}
-      return null;
-    }
+    const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
+      resolveDevice(ctx, platform, ctx.cdp.getTarget());
 
     ctx.registerTool('take_screenshot', {
       description: 'Capture a screenshot from the connected iOS simulator or Android device.',
@@ -113,8 +105,9 @@ export const simulatorPlugin = definePlugin({
           .describe('Return a retained temporary file path or an inline MCP image'),
       }),
       handler: async ({ platform, delivery }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         await prepareScreenshotDirectory();
         await cleanupOldScreenshots();
@@ -127,13 +120,13 @@ export const simulatorPlugin = definePlugin({
           if (p === 'ios') {
             await ctx.execFile(
               'xcrun',
-              ['simctl', 'io', 'booted', 'screenshot', tmpFile],
+              ['simctl', 'io', target.id, 'screenshot', tmpFile],
               { maxBuffer: SCREENSHOT_MAX_BYTES },
             );
           } else {
             const capture = await ctx.execFile(
               'adb',
-              ['exec-out', 'screencap', '-p'],
+              [ '-s', target.id, 'exec-out', 'screencap', '-p'],
               { maxBuffer: SCREENSHOT_MAX_BYTES },
             );
             await writeFile(tmpFile, capture, { flag: 'wx', mode: 0o600 });
@@ -240,14 +233,15 @@ export const simulatorPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ certPath, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         if (p === 'ios') {
-          await ctx.exec(`xcrun simctl keychain booted add-root-cert "${certPath}"`);
+          await ctx.exec(`xcrun simctl keychain "${target.id}" add-root-cert "${certPath}"`);
           return 'Certificate installed on iOS simulator.';
         } else {
-          await ctx.exec(`adb push "${certPath}" /sdcard/cert.pem`);
+          await ctx.exec(`${adbPrefix(target.id)} push "${certPath}" /sdcard/cert.pem`);
           return 'Certificate pushed to Android device at /sdcard/cert.pem. You may need to install it manually via Settings > Security.';
         }
       },
@@ -262,8 +256,9 @@ export const simulatorPlugin = definePlugin({
         lines: z.number().default(50).describe('Number of log lines to return'),
       }),
       handler: async ({ platform, filter, lines }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         try {
           if (p === 'ios') {
@@ -271,13 +266,13 @@ export const simulatorPlugin = definePlugin({
               ? `--predicate 'processImagePath contains "${filter}"'`
               : '';
             const output = await ctx.exec(
-              `xcrun simctl spawn booted log show --last 1m ${predicate} --style compact 2>/dev/null | tail -${lines}`
+              `xcrun simctl spawn "${target.id}" log show --last 1m ${predicate} --style compact 2>/dev/null | tail -${lines}`
             );
             return output || 'No logs found.';
           } else {
             const tagFilter = filter ? `-s "${filter}:*"` : '';
             const output = await ctx.exec(
-              `adb logcat -d ${tagFilter} -t ${lines} 2>/dev/null`
+              `${adbPrefix(target.id)} logcat -d ${tagFilter} -t ${lines} 2>/dev/null`
             );
             return output || 'No logs found.';
           }
@@ -297,21 +292,22 @@ export const simulatorPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ action, bundleId, appPath, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         const commands: Record<string, Record<string, string>> = {
           ios: {
-            launch: `xcrun simctl launch booted "${bundleId}"`,
-            terminate: `xcrun simctl terminate booted "${bundleId}"`,
-            install: `xcrun simctl install booted "${appPath}"`,
-            uninstall: `xcrun simctl uninstall booted "${bundleId}"`,
+            launch: `xcrun simctl launch "${target.id}" "${bundleId}"`,
+            terminate: `xcrun simctl terminate "${target.id}" "${bundleId}"`,
+            install: `xcrun simctl install "${target.id}" "${appPath}"`,
+            uninstall: `xcrun simctl uninstall "${target.id}" "${bundleId}"`,
           },
           android: {
-            launch: `adb shell am start -n "${bundleId}/.MainActivity"`,
-            terminate: `adb shell am force-stop "${bundleId}"`,
-            install: `adb install "${appPath}"`,
-            uninstall: `adb uninstall "${bundleId}"`,
+            launch: `${adbPrefix(target.id)} shell am start -n "${bundleId}/.MainActivity"`,
+            terminate: `${adbPrefix(target.id)} shell am force-stop "${bundleId}"`,
+            install: `${adbPrefix(target.id)} install "${appPath}"`,
+            uninstall: `${adbPrefix(target.id)} uninstall "${bundleId}"`,
           },
         };
 
@@ -330,11 +326,12 @@ export const simulatorPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         if (p === 'android') {
-          const output = await ctx.exec('adb shell settings get system user_rotation 2>/dev/null');
+          const output = await ctx.exec(`${adbPrefix(target.id)} shell settings get system user_rotation 2>/dev/null`);
           const rotation = parseInt(output.trim());
           const orientations: Record<number, string> = {
             0: 'portrait',

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -16,6 +16,9 @@ type AppEvaluation =
   | {
       renderer: 'paper' | 'fabric';
       value: string;
+      submitBehavior?: 'newline' | 'submit' | 'blurAndSubmit';
+      blurOnSubmit?: boolean;
+      multiline?: boolean;
     }
   | {
       renderer: 'paper' | 'fabric';
@@ -31,6 +34,7 @@ async function createAppOnlyHarness(
   const evaluations: string[] = [];
   const execCommands: string[] = [];
   const reactCalls: Array<{ type: 'submit' | 'change'; value: unknown }> = [];
+  let blurCalls = 0;
   const ctx: PluginContext = {
     cdp: {
       on: () => {}, off: () => {}, isConnected: true,
@@ -81,7 +85,7 @@ async function createAppOnlyHarness(
       }
       if (evaluation === 'unhandled') return false;
       if (typeof evaluation === 'object') {
-        const publicInstance = { isFocused: () => true };
+        const publicInstance = { isFocused: () => true, blur: () => { blurCalls++; } };
         const fabric = evaluation.renderer === 'fabric';
         const controlled = 'value' in evaluation;
         const value = controlled ? evaluation.value : evaluation.defaultValue;
@@ -94,6 +98,12 @@ async function createAppOnlyHarness(
           type: { displayName: 'TextInput' },
           memoizedProps: {
             ...(controlled ? { value } : { defaultValue: value }),
+            ...('submitBehavior' in evaluation && evaluation.submitBehavior !== undefined
+              ? { submitBehavior: evaluation.submitBehavior } : {}),
+            ...('blurOnSubmit' in evaluation && evaluation.blurOnSubmit !== undefined
+              ? { blurOnSubmit: evaluation.blurOnSubmit } : {}),
+            ...('multiline' in evaluation && evaluation.multiline !== undefined
+              ? { multiline: evaluation.multiline } : {}),
             onSubmitEditing: (event: unknown) => reactCalls.push({ type: 'submit', value: event }),
             onChangeText: (text: unknown) => reactCalls.push({ type: 'change', value: text }),
           },
@@ -118,7 +128,8 @@ async function createAppOnlyHarness(
     notifyResourceUpdated: () => {},
   };
   await uiInteractPlugin.setup(ctx);
-  return { tools, getNativeCalls: () => nativeCalls, evaluations, execCommands, reactCalls };
+  return { tools, getNativeCalls: () => nativeCalls, evaluations, execCommands, reactCalls,
+    getBlurCalls: () => blurCalls };
 }
 
 async function pressTextInputKeys(
@@ -206,6 +217,49 @@ describe('UI handler actions without native inventory', () => {
       ]);
       expect(harness.getNativeCalls()).toBe(0);
     }
+  });
+
+  test('matches Android blurAndSubmit semantics for controlled Paper and Fabric inputs', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      const harness = await createAppOnlyHarness({ renderer, value: 'hello', submitBehavior: 'blurAndSubmit' });
+      const press = harness.tools.get('press_button')!;
+      expect(await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'android' }) as Record<string, unknown>));
+      expect(harness.reactCalls).toEqual([
+        { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
+      ]);
+      expect(harness.getBlurCalls()).toBe(1);
+      expect(harness.getNativeCalls()).toBe(0);
+    }
+  });
+
+  test('keeps Android newline and legacy blurOnSubmit=false inputs on native handling', async () => {
+    for (const evaluation of [
+      { renderer: 'paper' as const, value: 'hello', submitBehavior: 'newline' as const },
+      { renderer: 'fabric' as const, value: 'hello', blurOnSubmit: false },
+      { renderer: 'paper' as const, value: 'hello', multiline: true },
+    ]) {
+      const harness = await createAppOnlyHarness(evaluation, true);
+      const press = harness.tools.get('press_button')!;
+      expect(await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'android' }) as Record<string, unknown>))
+        .toBe('Pressed ENTER');
+      expect(harness.reactCalls).toEqual([]);
+      expect(harness.getBlurCalls()).toBe(0);
+      expect(harness.execCommands).toEqual([
+        'adb -s "emulator-42" shell input keyevent 66',
+      ]);
+    }
+  });
+
+  test('blurs after submitting with legacy blurOnSubmit=true', async () => {
+    const harness = await createAppOnlyHarness({ renderer: 'paper', value: 'hello', blurOnSubmit: true });
+    const press = harness.tools.get('press_button')!;
+    expect(await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'android' }) as Record<string, unknown>))
+      .toBe('Pressed ENTER');
+    expect(harness.reactCalls).toEqual([
+      { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
+    ]);
+    expect(harness.getBlurCalls()).toBe(1);
+    expect(harness.getNativeCalls()).toBe(0);
   });
 
   test('leaves uncontrolled Paper and Fabric inputs for native handling', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -100,6 +100,9 @@ async function createAppOnlyHarness(
             : 'emulator-42';
           return Buffer.from(`List of devices attached\n${androidId}\t${androidStatus} model:Pixel_8\n`);
         }
+        if (args[0] === '-s' && args[2] === 'exec-out' && args[3] === 'cat') {
+          return Buffer.from('<node text="Save" content-desc="" bounds="[0,0][100,100]"/>');
+        }
         return Buffer.from('');
       }
       if (nativeAvailable && command === 'idb') {
@@ -241,6 +244,21 @@ describe('UI handler actions without native inventory', () => {
       expect(result).toContain('status=handled');
     }
     expect(harness.reactCalls).toEqual([]);
+  });
+
+  test('routes Android label fallback through bounded native input', async () => {
+    const harness = await createAppOnlyHarness('unhandled', true, {}, 'emulator-42');
+    const tap = harness.tools.get('tap_element')!;
+    const response = await tap.handler(tap.parameters.parse({
+      label: 'Save',
+      platform: 'android',
+    }) as Record<string, unknown>);
+    expect(response).toContain('backend=adb');
+    expect(response).toContain('dispatch=submitted');
+    expect(harness.execFileCalls).toContainEqual({
+      command: 'adb',
+      args: ['-s', 'emulator-42', 'shell', 'input', 'tap', '50', '50'],
+    });
   });
 
   test('invokes focused controlled Paper and Fabric key handlers with exact payloads', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -8,7 +8,10 @@ type Tool = {
   handler: (args: Record<string, unknown>) => Promise<ToolHandlerResult>;
 };
 
-async function createAppOnlyHarness(evaluation: 'success' | 'failure' = 'success') {
+async function createAppOnlyHarness(
+  evaluation: 'success' | 'failure' | 'pre-dispatch' = 'success',
+  nativeAvailable = false,
+) {
   const tools = new Map<string, Tool>();
   let nativeCalls = 0;
   const ctx: PluginContext = {
@@ -26,8 +29,24 @@ async function createAppOnlyHarness(evaluation: 'success' | 'failure' = 'success
     config: {},
     logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
     metro: { host: 'localhost', port: 8081, fetch: async () => new Response() },
-    exec: async () => { nativeCalls++; throw new Error('native inventory unavailable'); },
-    execFile: async () => { nativeCalls++; throw new Error('native inventory unavailable'); },
+    exec: async (command) => {
+      nativeCalls++;
+      if (nativeAvailable) return '';
+      throw new Error('native inventory unavailable');
+    },
+    execFile: async (command, _args) => {
+      nativeCalls++;
+      if (nativeAvailable && command === 'xcrun') {
+        return Buffer.from(JSON.stringify({
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+              { name: 'Acceptance', udid: 'SIMULATOR123', state: 'Booted', isAvailable: true },
+            ],
+          },
+        }));
+      }
+      throw new Error('native inventory unavailable');
+    },
     format: {
       summarize: () => '', compact: (value: unknown) => JSON.stringify(value),
       truncate: (value: string) => value, structureOnly: (value: ComponentNode) => value,
@@ -35,6 +54,9 @@ async function createAppOnlyHarness(evaluation: 'success' | 'failure' = 'success
     // A true result means the app-side handler was found and invoked.
     evalInApp: async () => {
       if (evaluation === 'failure') throw new Error('CDP disconnected');
+      if (evaluation === 'pre-dispatch') {
+        throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+      }
       return true;
     },
     getActiveDeviceKey: () => null, getActiveDeviceName: () => null,
@@ -83,6 +105,38 @@ describe('UI handler actions without native inventory', () => {
   test('does not replay a possibly dispatched action after a CDP rejection', async () => {
     const harness = await createAppOnlyHarness('failure');
     const tool = harness.tools.get('tap_element')!;
+    const result = await tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>);
+    expect(result).toContain('Could not evaluate');
+    expect(harness.getNativeCalls()).toBe(0);
+  });
+
+  test('uses native fallback after a known pre-dispatch connection failure', async () => {
+    const harness = await createAppOnlyHarness('pre-dispatch', true);
+    const tool = harness.tools.get('tap_element')!;
+    const result = await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>);
+    expect(result).toBe('Tapped "Save"');
+    expect(harness.getNativeCalls()).toBeGreaterThan(0);
+  });
+
+  test('uses native fallback for other known pre-dispatch handler failures', async () => {
+    const harness = await createAppOnlyHarness('pre-dispatch', true);
+    const cases = [
+      ['type_text', { text: 'hello', platform: 'ios' }, 'Typed "hello"'],
+      ['long_press', { label: 'Save', x: 1, y: 2, platform: 'ios' }, 'Long pressed at (1, 2) for 1000ms'],
+      ['swipe', { direction: 'up', platform: 'ios' }, 'Swiped up'],
+      ['press_button', { button: 'ENTER', platform: 'ios' }, 'Pressed ENTER'],
+      ['press_button', { button: 'DELETE', platform: 'ios' }, 'Pressed DELETE'],
+    ] as const;
+    for (const [name, args, expected] of cases) {
+      const tool = harness.tools.get(name)!;
+      expect(await tool.handler(tool.parameters.parse(args) as Record<string, unknown>)).toBe(expected);
+    }
+    expect(harness.getNativeCalls()).toBeGreaterThan(0);
+  });
+
+  test('reports a pre-dispatch failure for a label-only long press', async () => {
+    const harness = await createAppOnlyHarness('pre-dispatch', true);
+    const tool = harness.tools.get('long_press')!;
     const result = await tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>);
     expect(result).toContain('Could not evaluate');
     expect(harness.getNativeCalls()).toBe(0);

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -166,11 +166,13 @@ describe('UI handler actions without native inventory', () => {
     expect(harness.getNativeCalls()).toBeGreaterThan(0);
   });
 
-  test('reports a pre-dispatch failure for a label-only long press', async () => {
+  test('uses native fallback for a label-only long press after a pre-dispatch failure', async () => {
     const harness = await createAppOnlyHarness('pre-dispatch', true);
     const tool = harness.tools.get('long_press')!;
-    const result = await tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>);
-    expect(result).toContain('Could not evaluate');
-    expect(harness.getNativeCalls()).toBe(0);
+    const result = await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>);
+    expect(result).toContain('Long pressed "Save"');
+    expect(result).toContain('backend=idb');
+    expect(result).toContain('status=handled');
+    expect(harness.getNativeCalls()).toBeGreaterThan(0);
   });
 });

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -37,6 +37,7 @@ async function createAppOnlyHarness(
   sharedInventoryDeviceId = false,
   unavailablePlatform?: 'ios' | 'android',
   androidStatus: 'device' | 'offline' | 'unauthorized' = 'device',
+  targetChangeAfterInventory?: { id?: string; logicalId?: string; generation?: boolean },
 ) {
   const tools = new Map<string, Tool>();
   let nativeCalls = 0;
@@ -44,15 +45,18 @@ async function createAppOnlyHarness(
   const execCommands: string[] = [];
   const reactCalls: Array<{ type: 'submit' | 'change'; value: unknown }> = [];
   let blurCalls = 0;
+  let runtimeGeneration = 0;
+  let currentTarget = {
+    id: 'metro-target-a',
+    deviceName: 'Connected app',
+    ...(connectedLogicalDeviceId
+      ? { reactNative: { logicalDeviceId: connectedLogicalDeviceId } }
+      : {}),
+  } as Record<string, unknown>;
   const ctx: PluginContext = {
     cdp: {
       on: () => {}, off: () => {}, isConnected: true,
-      getTarget: () => ({
-        deviceName: 'Connected app',
-        ...(connectedLogicalDeviceId
-          ? { reactNative: { logicalDeviceId: connectedLogicalDeviceId } }
-          : {}),
-      } as never),
+      getTarget: () => currentTarget as never,
       send: async () => ({}),
     },
     events: { on: () => {}, off: () => {}, isConnected: () => true },
@@ -97,6 +101,16 @@ async function createAppOnlyHarness(
         const androidId = sharedInventoryDeviceId && connectedLogicalDeviceId
           ? connectedLogicalDeviceId
           : 'emulator-42';
+        if (targetChangeAfterInventory) {
+          currentTarget = {
+            ...currentTarget,
+            ...(targetChangeAfterInventory.id ? { id: targetChangeAfterInventory.id } : {}),
+            ...(targetChangeAfterInventory.logicalId
+              ? { reactNative: { logicalDeviceId: targetChangeAfterInventory.logicalId } }
+              : {}),
+          };
+          if (targetChangeAfterInventory.generation) runtimeGeneration++;
+        }
         return Buffer.from(`List of devices attached\n${androidId}\t${androidStatus} model:Connected_app\n`);
       }
       throw new Error('native inventory unavailable');
@@ -168,6 +182,7 @@ async function createAppOnlyHarness(
       return true;
     },
     getActiveDeviceKey: () => null, getActiveDeviceName: () => null,
+    getRuntimeGeneration: () => runtimeGeneration,
     notifyResourceUpdated: () => {},
   };
   await uiInteractPlugin.setup(ctx);
@@ -549,6 +564,38 @@ describe('UI handler actions without native inventory', () => {
     expect(await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>))
       .toBe('Tapped "Save"');
     expect(harness.evaluations).toHaveLength(1);
+  });
+
+  test('revalidates the Metro target after native inventory before React dispatch', async () => {
+    const harness = await createAppOnlyHarness(
+      'success', true, 'SIMULATOR123', false, undefined, 'device',
+      { id: 'metro-target-b' },
+    );
+    const tool = harness.tools.get('tap_element')!;
+    const result = await tool.handler(tool.parameters.parse({
+      label: 'Save', platform: 'ios',
+    }) as Record<string, unknown>);
+
+    expect(result).toBe('No simulator/emulator detected.');
+    expect(harness.evaluations).toHaveLength(0);
+    expect(harness.execCommands).toHaveLength(0);
+  });
+
+  test('revalidates the runtime generation after native inventory before React dispatch', async () => {
+    const harness = await createAppOnlyHarness(
+      'success', true, 'SIMULATOR123', false, undefined, 'device',
+      { generation: true },
+    );
+    const tool = harness.tools.get('tap_element')!;
+    const result = await tool.handler(tool.parameters.parse({
+      label: 'Save', platform: 'ios',
+    }) as Record<string, unknown>);
+
+    // The native target remains the same, so its fallback is still safe even
+    // though the app runtime generation changed during inventory.
+    expect(result).toBe('Tapped "Save"');
+    expect(harness.evaluations).toHaveLength(0);
+    expect(harness.execCommands).toHaveLength(1);
   });
 
   test('requires the opposite inventory before explicit React-first handling', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -9,11 +9,14 @@ type Tool = {
 };
 
 async function createAppOnlyHarness(
-  evaluation: 'success' | 'failure' | 'pre-dispatch' = 'success',
+  evaluation: 'success' | 'failure' | 'pre-dispatch' | 'unhandled' | 'fabric-focused' = 'success',
   nativeAvailable = false,
 ) {
   const tools = new Map<string, Tool>();
   let nativeCalls = 0;
+  const evaluations: string[] = [];
+  const execCommands: string[] = [];
+  const reactCalls: string[] = [];
   const ctx: PluginContext = {
     cdp: {
       on: () => {}, off: () => {}, isConnected: true,
@@ -31,6 +34,7 @@ async function createAppOnlyHarness(
     metro: { host: 'localhost', port: 8081, fetch: async () => new Response() },
     exec: async (command) => {
       nativeCalls++;
+      execCommands.push(command);
       if (nativeAvailable) return '';
       throw new Error('native inventory unavailable');
     },
@@ -45,6 +49,9 @@ async function createAppOnlyHarness(
           },
         }));
       }
+      if (nativeAvailable && command === 'adb') {
+        return Buffer.from('List of devices attached\nemulator-42\tdevice model:Connected_app\n');
+      }
       throw new Error('native inventory unavailable');
     },
     format: {
@@ -52,10 +59,40 @@ async function createAppOnlyHarness(
       truncate: (value: string) => value, structureOnly: (value: ComponentNode) => value,
     },
     // A true result means the app-side handler was found and invoked.
-    evalInApp: async () => {
+    evalInApp: async (expression) => {
+      evaluations.push(expression);
       if (evaluation === 'failure') throw new Error('CDP disconnected');
       if (evaluation === 'pre-dispatch') {
         throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+      }
+      if (evaluation === 'unhandled') return false;
+      if (evaluation === 'fabric-focused') {
+        const host = {
+          stateNode: { canonical: { publicInstance: { isFocused: () => true } } },
+          child: null,
+          sibling: null,
+        };
+        const textInput = {
+          type: { displayName: 'TextInput' },
+          memoizedProps: {
+            value: 'hello',
+            onSubmitEditing: () => reactCalls.push('submit'),
+            onChangeText: () => reactCalls.push('change'),
+          },
+          stateNode: null,
+          child: host,
+          sibling: null,
+        };
+        const rootFiber = { type: 'Root', child: textInput, sibling: null };
+        const previousHook = (globalThis as Record<string, unknown>).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+        (globalThis as Record<string, unknown>).__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+          getFiberRoots: () => new Set([{ current: rootFiber }]),
+        };
+        try {
+          return Function(`return (${expression});`)();
+        } finally {
+          (globalThis as Record<string, unknown>).__REACT_DEVTOOLS_GLOBAL_HOOK__ = previousHook;
+        }
       }
       return true;
     },
@@ -63,7 +100,7 @@ async function createAppOnlyHarness(
     notifyResourceUpdated: () => {},
   };
   await uiInteractPlugin.setup(ctx);
-  return { tools, getNativeCalls: () => nativeCalls };
+  return { tools, getNativeCalls: () => nativeCalls, evaluations, execCommands, reactCalls };
 }
 
 describe('UI handler actions without native inventory', () => {
@@ -99,6 +136,31 @@ describe('UI handler actions without native inventory', () => {
       expect(await press.handler(press.parameters.parse({ button }) as Record<string, unknown>))
         .toBe(`Pressed ${button}`);
     }
+    expect(harness.getNativeCalls()).toBe(0);
+  });
+
+  test('uses Android key events when no focused app handler accepts the action', async () => {
+    const harness = await createAppOnlyHarness('unhandled', true);
+    for (const button of ['ENTER', 'DELETE'] as const) {
+      const press = harness.tools.get('press_button')!;
+      expect(await press.handler(press.parameters.parse({ button, platform: 'android' }) as Record<string, unknown>))
+        .toBe(`Pressed ${button}`);
+    }
+    expect(harness.evaluations).toHaveLength(2);
+    expect(harness.execCommands).toEqual([
+      'adb -s "emulator-42" shell input keyevent 66',
+      'adb -s "emulator-42" shell input keyevent 67',
+    ]);
+  });
+
+  test('invokes focused Fabric TextInput key handlers without native inventory', async () => {
+    const harness = await createAppOnlyHarness('fabric-focused');
+    const press = harness.tools.get('press_button')!;
+    for (const button of ['ENTER', 'DELETE'] as const) {
+      expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
+        .toBe(`Pressed ${button}`);
+    }
+    expect(harness.reactCalls).toEqual(['submit', 'change']);
     expect(harness.getNativeCalls()).toBe(0);
   });
 

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -9,13 +9,23 @@ type Tool = {
 };
 
 async function createAppOnlyHarness(
-  evaluation: 'success' | 'failure' | 'pre-dispatch' | 'unhandled' | 'fabric-focused' = 'success',
+  evaluation:
+    | 'success'
+    | 'failure'
+    | 'pre-dispatch'
+    | 'unhandled'
+    | 'fabric-focused'
+    | 'paper-focused'
+    | 'fabric-empty'
+    | 'paper-empty'
+    | 'fabric-uncontrolled'
+    | 'paper-uncontrolled' = 'success',
   nativeAvailable = false,
 ) {
   const tools = new Map<string, Tool>();
   let nativeCalls = 0;
   const execFileCalls: Array<{ command: string; args: string[] }> = [];
-  const reactCalls: string[] = [];
+  const reactCalls: Array<{ type: 'submit' | 'change'; value: unknown }> = [];
   const ctx: PluginContext = {
     cdp: {
       on: () => {}, off: () => {}, isConnected: true,
@@ -65,7 +75,7 @@ async function createAppOnlyHarness(
           }));
         }
         if (args[0] === 'ui' && args[1] === '--help') {
-          return Buffer.from('  describe-all\n  tap\n  text\n  swipe\n  button');
+          return Buffer.from('  describe-all\n  tap\n  text\n  key\n  swipe\n  button');
         }
         if (args[0] === 'ui' && args[2] === '--help') {
           return Buffer.from(args[1] === 'button' ? '{HOME}' : '--duration');
@@ -90,18 +100,22 @@ async function createAppOnlyHarness(
         throw new Error('Not connected to Metro. Use list_devices to check connection status.');
       }
       if (evaluation === 'unhandled') return false;
-      if (evaluation === 'fabric-focused') {
+      if (evaluation.endsWith('-focused') || evaluation.endsWith('-empty') || evaluation.endsWith('-uncontrolled')) {
+        const publicInstance = { isFocused: () => true };
+        const fabric = evaluation.startsWith('fabric-');
+        const controlled = !evaluation.endsWith('-uncontrolled');
+        const value = evaluation.endsWith('-empty') ? '' : 'hello';
         const host = {
-          stateNode: { canonical: { publicInstance: { isFocused: () => true } } },
+          stateNode: fabric ? { canonical: { publicInstance } } : publicInstance,
           child: null,
           sibling: null,
         };
         const textInput = {
           type: { displayName: 'TextInput' },
           memoizedProps: {
-            value: 'hello',
-            onSubmitEditing: () => reactCalls.push('submit'),
-            onChangeText: () => reactCalls.push('change'),
+            ...(controlled ? { value } : { defaultValue: value }),
+            onSubmitEditing: (event: unknown) => reactCalls.push({ type: 'submit', value: event }),
+            onChangeText: (text: unknown) => reactCalls.push({ type: 'change', value: text }),
           },
           stateNode: null,
           child: host,
@@ -163,15 +177,43 @@ describe('UI handler actions without native inventory', () => {
     expect(harness.getNativeCalls()).toBe(0);
   });
 
-  test('invokes focused Fabric TextInput key handlers without native inventory', async () => {
-    const harness = await createAppOnlyHarness('fabric-focused');
-    const press = harness.tools.get('press_button')!;
-    for (const button of ['ENTER', 'DELETE'] as const) {
-      expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
-        .toBe(`Pressed ${button}`);
+  test('invokes focused controlled Paper and Fabric key handlers with exact payloads', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      for (const [state, value] of [['focused', 'hello'], ['empty', '']] as const) {
+        const harness = await createAppOnlyHarness(`${renderer}-${state}`);
+        const press = harness.tools.get('press_button')!;
+        for (const button of ['ENTER', 'DELETE'] as const) {
+          expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
+            .toBe(`Pressed ${button}`);
+        }
+        expect(harness.reactCalls).toEqual([
+          { type: 'submit', value: { nativeEvent: { text: value } } },
+          { type: 'change', value: value.slice(0, -1) },
+        ]);
+        expect(harness.getNativeCalls()).toBe(0);
+      }
     }
-    expect(harness.reactCalls).toEqual(['submit', 'change']);
-    expect(harness.getNativeCalls()).toBe(0);
+  });
+
+  test('uses native focused keys for uncontrolled Paper and Fabric inputs', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      const harness = await createAppOnlyHarness(`${renderer}-uncontrolled`, true);
+      const press = harness.tools.get('press_button')!;
+      for (const button of ['ENTER', 'DELETE'] as const) {
+        const result = await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>);
+        expect(result).toContain('backend=idb');
+        expect(result).toContain('status=handled');
+      }
+      expect(harness.reactCalls).toEqual([]);
+      expect(harness.execFileCalls).toContainEqual({
+        command: 'idb',
+        args: ['ui', 'key', '40', '--udid', 'SIMULATOR123'],
+      });
+      expect(harness.execFileCalls).toContainEqual({
+        command: 'idb',
+        args: ['ui', 'key', '42', '--udid', 'SIMULATOR123'],
+      });
+    }
   });
 
   test('uses the verified Android serial when no focused app handler accepts a key', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -9,14 +9,24 @@ type Tool = {
 };
 
 async function createAppOnlyHarness(
-  evaluation: 'success' | 'failure' | 'pre-dispatch' | 'unhandled' | 'fabric-focused' = 'success',
+  evaluation:
+    | 'success'
+    | 'failure'
+    | 'pre-dispatch'
+    | 'unhandled'
+    | 'fabric-focused'
+    | 'paper-focused'
+    | 'fabric-empty'
+    | 'paper-empty'
+    | 'fabric-uncontrolled'
+    | 'paper-uncontrolled' = 'success',
   nativeAvailable = false,
 ) {
   const tools = new Map<string, Tool>();
   let nativeCalls = 0;
   const evaluations: string[] = [];
   const execCommands: string[] = [];
-  const reactCalls: string[] = [];
+  const reactCalls: Array<{ type: 'submit' | 'change'; value: unknown }> = [];
   const ctx: PluginContext = {
     cdp: {
       on: () => {}, off: () => {}, isConnected: true,
@@ -66,18 +76,22 @@ async function createAppOnlyHarness(
         throw new Error('Not connected to Metro. Use list_devices to check connection status.');
       }
       if (evaluation === 'unhandled') return false;
-      if (evaluation === 'fabric-focused') {
+      if (evaluation.endsWith('-focused') || evaluation.endsWith('-empty') || evaluation.endsWith('-uncontrolled')) {
+        const publicInstance = { isFocused: () => true };
+        const fabric = evaluation.startsWith('fabric-');
+        const controlled = !evaluation.endsWith('-uncontrolled');
+        const value = evaluation.endsWith('-empty') ? '' : 'hello';
         const host = {
-          stateNode: { canonical: { publicInstance: { isFocused: () => true } } },
+          stateNode: fabric ? { canonical: { publicInstance } } : publicInstance,
           child: null,
           sibling: null,
         };
         const textInput = {
           type: { displayName: 'TextInput' },
           memoizedProps: {
-            value: 'hello',
-            onSubmitEditing: () => reactCalls.push('submit'),
-            onChangeText: () => reactCalls.push('change'),
+            ...(controlled ? { value } : { defaultValue: value }),
+            onSubmitEditing: (event: unknown) => reactCalls.push({ type: 'submit', value: event }),
+            onChangeText: (text: unknown) => reactCalls.push({ type: 'change', value: text }),
           },
           stateNode: null,
           child: host,
@@ -160,8 +174,38 @@ describe('UI handler actions without native inventory', () => {
       expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
         .toBe(`Pressed ${button}`);
     }
-    expect(harness.reactCalls).toEqual(['submit', 'change']);
+    expect(harness.reactCalls).toEqual([
+      { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
+      { type: 'change', value: 'hell' },
+    ]);
     expect(harness.getNativeCalls()).toBe(0);
+  });
+
+  test('invokes controlled Paper and Fabric handlers with exact empty payloads', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      const harness = await createAppOnlyHarness(`${renderer}-empty`);
+      const press = harness.tools.get('press_button')!;
+      for (const button of ['ENTER', 'DELETE'] as const) {
+        expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
+          .toBe(`Pressed ${button}`);
+      }
+      expect(harness.reactCalls).toEqual([
+        { type: 'submit', value: { nativeEvent: { text: '' } } },
+        { type: 'change', value: '' },
+      ]);
+      expect(harness.getNativeCalls()).toBe(0);
+    }
+  });
+
+  test('leaves uncontrolled Paper and Fabric inputs for native handling', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      const harness = await createAppOnlyHarness(`${renderer}-uncontrolled`, true);
+      const press = harness.tools.get('press_button')!;
+      const result = await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'ios' }) as Record<string, unknown>);
+      expect(result).toBe('Pressed ENTER');
+      expect(harness.reactCalls).toEqual([]);
+      expect(harness.getNativeCalls()).toBeGreaterThan(0);
+    }
   });
 
   test('does not replay a possibly dispatched action after a CDP rejection', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -222,6 +222,20 @@ describe('UI handler actions without native inventory', () => {
     }
   });
 
+  test('uses IDB HID keys for uncontrolled Paper and Fabric inputs on iOS', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      const harness = await pressTextInputKeys(
+        { renderer, defaultValue: 'hello' },
+        { nativeAvailable: true, platform: 'ios' },
+      );
+      expect(harness.reactCalls).toEqual([]);
+      expect(harness.execCommands.filter((command) => command.startsWith('idb ui key'))).toEqual([
+        'idb ui key 40 --udid "SIMULATOR123"',
+        'idb ui key 42 --udid "SIMULATOR123"',
+      ]);
+    }
+  });
+
   test('does not replay a possibly dispatched action after a CDP rejection', async () => {
     const harness = await createAppOnlyHarness('failure');
     const tool = harness.tools.get('tap_element')!;

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -83,8 +83,8 @@ describe('UI handler actions without native inventory', () => {
   test('does not replay a possibly dispatched action after a CDP rejection', async () => {
     const harness = await createAppOnlyHarness('failure');
     const tool = harness.tools.get('tap_element')!;
-    const result = await tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>);
-    expect(result).toContain('Could not evaluate');
+    await expect(tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>))
+      .rejects.toThrow('CDP disconnected');
     expect(harness.getNativeCalls()).toBe(0);
   });
 });

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import type { z } from 'zod';
+import type { ComponentNode, PluginContext, ToolHandlerResult } from '../plugin.js';
+import { uiInteractPlugin } from './ui-interact.js';
+
+type Tool = {
+  parameters: z.ZodType;
+  handler: (args: Record<string, unknown>) => Promise<ToolHandlerResult>;
+};
+
+async function createAppOnlyHarness(evaluation: 'success' | 'failure' = 'success') {
+  const tools = new Map<string, Tool>();
+  let nativeCalls = 0;
+  const ctx: PluginContext = {
+    cdp: {
+      on: () => {}, off: () => {}, isConnected: true,
+      getTarget: () => ({ deviceName: 'Connected app' } as never),
+      send: async () => ({}),
+    },
+    events: { on: () => {}, off: () => {}, isConnected: () => true },
+    registerTool: (name, config) => tools.set(name, {
+      parameters: config.parameters,
+      handler: config.handler as Tool['handler'],
+    }),
+    registerResource: () => {}, registerAppResource: () => {}, registerPrompt: () => {},
+    config: {},
+    logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    metro: { host: 'localhost', port: 8081, fetch: async () => new Response() },
+    exec: async () => { nativeCalls++; throw new Error('native inventory unavailable'); },
+    execFile: async () => { nativeCalls++; throw new Error('native inventory unavailable'); },
+    format: {
+      summarize: () => '', compact: (value: unknown) => JSON.stringify(value),
+      truncate: (value: string) => value, structureOnly: (value: ComponentNode) => value,
+    },
+    // A true result means the app-side handler was found and invoked.
+    evalInApp: async () => {
+      if (evaluation === 'failure') throw new Error('CDP disconnected');
+      return true;
+    },
+    getActiveDeviceKey: () => null, getActiveDeviceName: () => null,
+    notifyResourceUpdated: () => {},
+  };
+  await uiInteractPlugin.setup(ctx);
+  return { tools, getNativeCalls: () => nativeCalls };
+}
+
+describe('UI handler actions without native inventory', () => {
+  test('runs an immediate app handler without probing local devices', async () => {
+    const harness = await createAppOnlyHarness();
+    const tool = harness.tools.get('tap_element')!;
+    const result = await tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>);
+    expect(result).toBe('Tapped "Save"');
+    expect(harness.getNativeCalls()).toBe(0);
+  });
+
+  test('runs text input handler without replaying through native fallback', async () => {
+    const harness = await createAppOnlyHarness();
+    const tool = harness.tools.get('type_text')!;
+    const result = await tool.handler(tool.parameters.parse({ text: 'hello' }) as Record<string, unknown>);
+    expect(result).toBe('Typed "hello"');
+    expect(harness.getNativeCalls()).toBe(0);
+  });
+
+  test('keeps the remaining handler actions usable without native inventory', async () => {
+    const harness = await createAppOnlyHarness();
+
+    const longPress = harness.tools.get('long_press')!;
+    expect(await longPress.handler(longPress.parameters.parse({ label: 'Save' }) as Record<string, unknown>))
+      .toBe('Long pressed "Save"');
+
+    const swipe = harness.tools.get('swipe')!;
+    expect(await swipe.handler(swipe.parameters.parse({ direction: 'up' }) as Record<string, unknown>))
+      .toBe('Swiped up');
+
+    for (const button of ['ENTER', 'DELETE'] as const) {
+      const press = harness.tools.get('press_button')!;
+      expect(await press.handler(press.parameters.parse({ button }) as Record<string, unknown>))
+        .toBe(`Pressed ${button}`);
+    }
+    expect(harness.getNativeCalls()).toBe(0);
+  });
+
+  test('does not replay a possibly dispatched action after a CDP rejection', async () => {
+    const harness = await createAppOnlyHarness('failure');
+    const tool = harness.tools.get('tap_element')!;
+    const result = await tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>);
+    expect(result).toContain('Could not evaluate');
+    expect(harness.getNativeCalls()).toBe(0);
+  });
+});

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -251,12 +251,16 @@ describe('UI handler actions without native inventory', () => {
     }
   });
 
-  test('invokes controlled Paper and Fabric handlers with exact empty payloads', async () => {
+  test('invokes controlled Paper and Fabric submit handlers with exact empty payloads', async () => {
     for (const renderer of ['paper', 'fabric'] as const) {
-      const harness = await pressTextInputKeys({ renderer, value: '' });
+      const harness = await createAppOnlyHarness({ renderer, value: '' });
+      const press = harness.tools.get('press_button')!;
+      expect(await press.handler(press.parameters.parse({
+        button: 'ENTER',
+        platform: 'auto',
+      }) as Record<string, unknown>)).toBe('Pressed ENTER');
       expect(harness.reactCalls).toEqual([
         { type: 'submit', value: { nativeEvent: { text: '' } } },
-        { type: 'change', value: '' },
       ]);
       expect(harness.getNativeCalls()).toBe(0);
     }

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -216,6 +216,30 @@ describe('UI handler actions without native inventory', () => {
     }
   });
 
+  test('uses Android key events for uncontrolled Paper and Fabric inputs', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      const harness = await createAppOnlyHarness(`${renderer}-uncontrolled`, true);
+      const press = harness.tools.get('press_button')!;
+      for (const button of ['ENTER', 'DELETE'] as const) {
+        const result = await press.handler(press.parameters.parse({
+          button,
+          platform: 'android',
+        }) as Record<string, unknown>);
+        expect(result).toContain('backend=adb');
+        expect(result).toContain('status=handled');
+      }
+      expect(harness.reactCalls).toEqual([]);
+      expect(harness.execFileCalls).toContainEqual({
+        command: 'adb',
+        args: ['-s', 'emulator-42', 'shell', 'input', 'keyevent', '66'],
+      });
+      expect(harness.execFileCalls).toContainEqual({
+        command: 'adb',
+        args: ['-s', 'emulator-42', 'shell', 'input', 'keyevent', '67'],
+      });
+    }
+  });
+
   test('uses the verified Android serial when no focused app handler accepts a key', async () => {
     const harness = await createAppOnlyHarness('unhandled', true);
     const press = harness.tools.get('press_button')!;

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -298,6 +298,19 @@ describe('UI handler actions without native inventory', () => {
     expect(unicodeHarness.reactCalls).toEqual([{ type: 'change', value: 'AB' }]);
   });
 
+  test('defers controlled Android DELETE at the start caret to native input', async () => {
+    const harness = await createAppOnlyHarness(
+      { renderer: 'paper', value: 'abcd', selection: { start: 0, end: 0 } },
+      true,
+      'emulator-42',
+    );
+    const press = harness.tools.get('press_button')!;
+    expect(await press.handler(press.parameters.parse({ button: 'DELETE', platform: 'android' }) as Record<string, unknown>))
+      .toBe('Pressed DELETE');
+    expect(harness.reactCalls).toEqual([]);
+    expect(harness.execCommands).toEqual(['adb -s "emulator-42" shell input keyevent 67']);
+  });
+
   test('defers controlled DELETE to Android when selection is unavailable', async () => {
     const harness = await createAppOnlyHarness(
       { renderer: 'paper', value: 'abcd', selection: undefined },

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -30,6 +30,10 @@ type AppEvaluation =
 async function createAppOnlyHarness(
   evaluation: AppEvaluation = 'success',
   nativeAvailable = false,
+  connectedLogicalDeviceId?: string,
+  sharedInventoryDeviceId = false,
+  unavailablePlatform?: 'ios' | 'android',
+  androidStatus: 'device' | 'offline' | 'unauthorized' = 'device',
 ) {
   const tools = new Map<string, Tool>();
   let nativeCalls = 0;
@@ -40,7 +44,12 @@ async function createAppOnlyHarness(
   const ctx: PluginContext = {
     cdp: {
       on: () => {}, off: () => {}, isConnected: true,
-      getTarget: () => ({ deviceName: 'Connected app' } as never),
+      getTarget: () => ({
+        deviceName: 'Connected app',
+        ...(connectedLogicalDeviceId
+          ? { reactNative: { logicalDeviceId: connectedLogicalDeviceId } }
+          : {}),
+      } as never),
       send: async () => ({}),
     },
     events: { on: () => {}, off: () => {}, isConnected: () => true },
@@ -55,22 +64,37 @@ async function createAppOnlyHarness(
     exec: async (command) => {
       nativeCalls++;
       execCommands.push(command);
+      if (command.includes('pull /sdcard/uidump.xml')) {
+        await Bun.write('/tmp/metro-mcp-uidump.xml', '<node text="Save" content-desc="Save" bounds="[0,0][100,100]"/>');
+      }
       if (nativeAvailable) return '';
       throw new Error('native inventory unavailable');
     },
     execFile: async (command, _args) => {
       nativeCalls++;
+      if (nativeAvailable && unavailablePlatform === 'ios' && command === 'xcrun') {
+        throw new Error('simctl inventory unavailable');
+      }
+      if (nativeAvailable && unavailablePlatform === 'android' && command === 'adb') {
+        throw new Error('adb inventory unavailable');
+      }
       if (nativeAvailable && command === 'xcrun') {
+        const simulatorId = sharedInventoryDeviceId && connectedLogicalDeviceId
+          ? connectedLogicalDeviceId
+          : 'SIMULATOR123';
         return Buffer.from(JSON.stringify({
           devices: {
             'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
-              { name: 'Acceptance', udid: 'SIMULATOR123', state: 'Booted', isAvailable: true },
+              { name: 'Acceptance', udid: simulatorId, state: 'Booted', isAvailable: true },
             ],
           },
         }));
       }
       if (nativeAvailable && command === 'adb') {
-        return Buffer.from('List of devices attached\nemulator-42\tdevice model:Connected_app\n');
+        const androidId = sharedInventoryDeviceId && connectedLogicalDeviceId
+          ? connectedLogicalDeviceId
+          : 'emulator-42';
+        return Buffer.from(`List of devices attached\n${androidId}\t${androidStatus} model:Connected_app\n`);
       }
       throw new Error('native inventory unavailable');
     },
@@ -140,14 +164,14 @@ async function createAppOnlyHarness(
 
 async function pressTextInputKeys(
   evaluation: Extract<AppEvaluation, object>,
-  options: { nativeAvailable?: boolean; platform?: 'ios' | 'android' } = {},
+  options: { nativeAvailable?: boolean; platform?: 'ios' | 'android' | 'auto' } = {},
 ) {
   const harness = await createAppOnlyHarness(evaluation, options.nativeAvailable);
   const press = harness.tools.get('press_button')!;
   for (const button of ['ENTER', 'DELETE'] as const) {
     expect(await press.handler(press.parameters.parse({
       button,
-      platform: options.platform ?? 'ios',
+      platform: options.platform ?? 'auto',
     }) as Record<string, unknown>)).toBe(`Pressed ${button}`);
   }
   return harness;
@@ -190,7 +214,7 @@ describe('UI handler actions without native inventory', () => {
   });
 
   test('uses Android key events when no focused app handler accepts the action', async () => {
-    const harness = await createAppOnlyHarness('unhandled', true);
+    const harness = await createAppOnlyHarness('unhandled', true, 'emulator-42');
     for (const button of ['ENTER', 'DELETE'] as const) {
       const press = harness.tools.get('press_button')!;
       expect(await press.handler(press.parameters.parse({ button, platform: 'android' }) as Record<string, unknown>))
@@ -229,7 +253,7 @@ describe('UI handler actions without native inventory', () => {
     for (const renderer of ['paper', 'fabric'] as const) {
       const harness = await createAppOnlyHarness({ renderer, value: 'hello', submitBehavior: 'blurAndSubmit' });
       const press = harness.tools.get('press_button')!;
-      expect(await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'android' }) as Record<string, unknown>));
+      expect(await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'auto' }) as Record<string, unknown>));
       expect(harness.reactCalls).toEqual([
         { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
       ]);
@@ -259,7 +283,7 @@ describe('UI handler actions without native inventory', () => {
   test('blurs after submitting with legacy blurOnSubmit=true', async () => {
     const harness = await createAppOnlyHarness({ renderer: 'paper', value: 'hello', blurOnSubmit: true });
     const press = harness.tools.get('press_button')!;
-    expect(await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'android' }) as Record<string, unknown>))
+    expect(await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'auto' }) as Record<string, unknown>))
       .toBe('Pressed ENTER');
     expect(harness.reactCalls).toEqual([
       { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
@@ -305,7 +329,7 @@ describe('UI handler actions without native inventory', () => {
   });
 
   test('uses native fallback after a known pre-dispatch connection failure', async () => {
-    const harness = await createAppOnlyHarness('pre-dispatch', true);
+    const harness = await createAppOnlyHarness('pre-dispatch', true, 'SIMULATOR123');
     const tool = harness.tools.get('tap_element')!;
     const result = await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>);
     expect(result).toBe('Tapped "Save"');
@@ -313,7 +337,7 @@ describe('UI handler actions without native inventory', () => {
   });
 
   test('uses native fallback for other known pre-dispatch handler failures', async () => {
-    const harness = await createAppOnlyHarness('pre-dispatch', true);
+    const harness = await createAppOnlyHarness('pre-dispatch', true, 'SIMULATOR123');
     const cases = [
       ['type_text', { text: 'hello', platform: 'ios' }, 'Typed "hello"'],
       ['long_press', { label: 'Save', x: 1, y: 2, platform: 'ios' }, 'Long pressed at (1, 2) for 1000ms'],
@@ -329,7 +353,7 @@ describe('UI handler actions without native inventory', () => {
   });
 
   test('uses native fallback for the exact pre-dispatch evaluation timeout', async () => {
-    const harness = await createAppOnlyHarness('timeout', true);
+    const harness = await createAppOnlyHarness('timeout', true, 'SIMULATOR123');
     const cases = [
       ['tap_element', { label: 'Save', platform: 'ios' }, 'Tapped "Save"'],
       ['type_text', { text: 'hello', platform: 'ios' }, 'Typed "hello"'],
@@ -344,16 +368,144 @@ describe('UI handler actions without native inventory', () => {
     expect(harness.getNativeCalls()).toBeGreaterThan(0);
   });
 
+  test('requires a verified iOS target before explicit React-first actions', async () => {
+    const harness = await createAppOnlyHarness('success', true, 'emulator-42');
+    const cases = [
+      ['tap_element', { label: 'Save', platform: 'ios' }],
+      ['type_text', { text: 'hello', platform: 'ios' }],
+      ['long_press', { label: 'Save', platform: 'ios' }],
+      ['swipe', { direction: 'up', platform: 'ios' }],
+      ['press_button', { button: 'ENTER', platform: 'ios' }],
+      ['press_button', { button: 'DELETE', platform: 'ios' }],
+    ] as const;
+    for (const [name, args] of cases) {
+      const tool = harness.tools.get(name)!;
+      await tool.handler(tool.parameters.parse(args) as Record<string, unknown>);
+    }
+    expect(harness.evaluations).toHaveLength(0);
+  });
+
+  test('requires a verified Android target before explicit React-first actions', async () => {
+    const harness = await createAppOnlyHarness('success', true, 'SIMULATOR123');
+    const cases = [
+      ['tap_element', { label: 'Save', platform: 'android' }],
+      ['type_text', { text: 'hello', platform: 'android' }],
+      ['long_press', { label: 'Save', platform: 'android' }],
+      ['swipe', { direction: 'up', platform: 'android' }],
+      ['press_button', { button: 'ENTER', platform: 'android' }],
+      ['press_button', { button: 'DELETE', platform: 'android' }],
+    ] as const;
+    for (const [name, args] of cases) {
+      const tool = harness.tools.get(name)!;
+      await tool.handler(tool.parameters.parse(args) as Record<string, unknown>);
+    }
+    expect(harness.evaluations).toHaveLength(0);
+  });
+
+  test('never dispatches React handlers when the connected ID is shared across platforms', async () => {
+    for (const platform of ['ios', 'android'] as const) {
+      const harness = await createAppOnlyHarness('success', true, 'SHARED-DEVICE', true);
+      const cases = [
+        ['tap_element', { label: 'Save', platform }],
+        ['type_text', { text: 'hello', platform }],
+        ['long_press', { label: 'Save', platform }],
+        ['swipe', { direction: 'up', platform }],
+        ['press_button', { button: 'ENTER', platform }],
+        ['press_button', { button: 'DELETE', platform }],
+      ] as const;
+      for (const [name, args] of cases) {
+        const tool = harness.tools.get(name)!;
+        await tool.handler(tool.parameters.parse(args) as Record<string, unknown>);
+      }
+      expect(harness.evaluations).toHaveLength(0);
+    }
+  });
+
+  test('treats offline and unauthorized opposite Android IDs as collisions', async () => {
+    for (const androidStatus of ['offline', 'unauthorized'] as const) {
+      const harness = await createAppOnlyHarness(
+        'success',
+        true,
+        'SHARED-DEVICE',
+        true,
+        undefined,
+        androidStatus,
+      );
+      const cases = [
+        ['tap_element', { label: 'Save', platform: 'ios' }],
+        ['type_text', { text: 'hello', platform: 'ios' }],
+        ['long_press', { label: 'Save', platform: 'ios' }],
+        ['swipe', { direction: 'up', platform: 'ios' }],
+        ['press_button', { button: 'ENTER', platform: 'ios' }],
+        ['press_button', { button: 'DELETE', platform: 'ios' }],
+      ] as const;
+      for (const [name, args] of cases) {
+        const tool = harness.tools.get(name)!;
+        await tool.handler(tool.parameters.parse(args) as Record<string, unknown>);
+      }
+      expect(harness.evaluations).toHaveLength(0);
+    }
+  });
+
+  test('keeps explicit React-first handling for a verified same-platform target', async () => {
+    const harness = await createAppOnlyHarness('success', true, 'SIMULATOR123');
+    const tool = harness.tools.get('tap_element')!;
+    expect(await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>))
+      .toBe('Tapped "Save"');
+    expect(harness.evaluations).toHaveLength(1);
+  });
+
+  test('requires the opposite inventory before explicit React-first handling', async () => {
+    for (const [platform, logicalId, unavailablePlatform] of [
+      ['ios', 'SIMULATOR123', 'android'],
+      ['android', 'emulator-42', 'ios'],
+    ] as const) {
+      const harness = await createAppOnlyHarness(
+        'success',
+        true,
+        logicalId,
+        false,
+        unavailablePlatform,
+      );
+      const tool = harness.tools.get('tap_element')!;
+      await tool.handler(tool.parameters.parse({ label: 'Save', platform }) as Record<string, unknown>);
+      expect(harness.evaluations).toHaveLength(0);
+      expect(harness.getNativeCalls()).toBeGreaterThan(0);
+    }
+  });
+
+  test('keeps explicit coordinate actions native-direct', async () => {
+    const harness = await createAppOnlyHarness('success', true, 'SIMULATOR123');
+    const tool = harness.tools.get('tap_element')!;
+    expect(await tool.handler(tool.parameters.parse({
+      x: 10, y: 20, platform: 'ios',
+    }) as Record<string, unknown>)).toBe('Tapped at (10, 20)');
+    expect(harness.evaluations).toHaveLength(0);
+  });
+
+  test('keeps label React handling when long press has only one coordinate', async () => {
+    for (const args of [
+      { label: 'Save', x: 10, platform: 'auto' as const },
+      { label: 'Save', y: 20, platform: 'auto' as const },
+    ]) {
+      const harness = await createAppOnlyHarness();
+      const tool = harness.tools.get('long_press')!;
+      expect(await tool.handler(tool.parameters.parse(args) as Record<string, unknown>))
+        .toBe('Long pressed "Save"');
+      expect(harness.evaluations).toHaveLength(1);
+    }
+  });
+
   test('does not use native fallback for a timed out evaluation with an ambiguous dispatch', async () => {
-    const harness = await createAppOnlyHarness('ambiguous-timeout', true);
+    const harness = await createAppOnlyHarness('ambiguous-timeout', true, 'SIMULATOR123');
     const tool = harness.tools.get('tap_element')!;
     const result = await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>);
     expect(result).toContain('Could not evaluate');
-    expect(harness.getNativeCalls()).toBe(0);
+    expect(harness.execCommands).toHaveLength(0);
   });
 
   test('reports a pre-dispatch failure for a label-only long press', async () => {
-    const harness = await createAppOnlyHarness('pre-dispatch', true);
+    const harness = await createAppOnlyHarness('pre-dispatch', true, 'SIMULATOR123');
     const tool = harness.tools.get('long_press')!;
     const result = await tool.handler(tool.parameters.parse({ label: 'Save' }) as Record<string, unknown>);
     expect(result).toContain('Could not evaluate');

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -229,14 +229,12 @@ describe('UI handler actions without native inventory', () => {
         expect(result).toContain('status=handled');
       }
       expect(harness.reactCalls).toEqual([]);
-      expect(harness.execFileCalls).toContainEqual({
-        command: 'adb',
-        args: ['-s', 'emulator-42', 'shell', 'input', 'keyevent', '66'],
-      });
-      expect(harness.execFileCalls).toContainEqual({
-        command: 'adb',
-        args: ['-s', 'emulator-42', 'shell', 'input', 'keyevent', '67'],
-      });
+      expect(harness.execFileCalls.filter(({ command, args }) =>
+        command === 'adb' && args[4] === 'keyevent',
+      )).toEqual([
+        { command: 'adb', args: ['-s', 'emulator-42', 'shell', 'input', 'keyevent', '66'] },
+        { command: 'adb', args: ['-s', 'emulator-42', 'shell', 'input', 'keyevent', '67'] },
+      ]);
     }
   });
 

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -254,6 +254,16 @@ describe('UI handler actions without native inventory', () => {
     }
   });
 
+  test('deletes a complete non-BMP code point from controlled inputs', async () => {
+    const harness = await createAppOnlyHarness({ renderer: 'paper', value: 'A😀' });
+    const press = harness.tools.get('press_button')!;
+    expect(await press.handler(press.parameters.parse({ button: 'DELETE' }) as Record<string, unknown>))
+      .toBe('Pressed DELETE');
+    expect(harness.reactCalls).toEqual([
+      { type: 'change', value: 'A' },
+    ]);
+  });
+
   test('matches Android blurAndSubmit semantics for controlled Paper and Fabric inputs', async () => {
     for (const renderer of ['paper', 'fabric'] as const) {
       const harness = await createAppOnlyHarness({ renderer, value: 'hello', submitBehavior: 'blurAndSubmit' });

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -20,6 +20,7 @@ type AppEvaluation =
   | {
       renderer: 'paper' | 'fabric';
       value: string;
+      selection?: { start: number; end: number };
       submitBehavior?: 'newline' | 'submit' | 'blurAndSubmit';
       blurOnSubmit?: boolean;
       multiline?: boolean;
@@ -133,6 +134,13 @@ async function createAppOnlyHarness(
           type: { displayName: 'TextInput' },
           memoizedProps: {
             ...(controlled ? { value } : { defaultValue: value }),
+            ...(controlled
+              ? {
+                  selection: 'selection' in evaluation
+                    ? evaluation.selection
+                    : { start: value.length, end: value.length },
+                }
+              : {}),
             ...('submitBehavior' in evaluation && evaluation.submitBehavior !== undefined
               ? { submitBehavior: evaluation.submitBehavior } : {}),
             ...('blurOnSubmit' in evaluation && evaluation.blurOnSubmit !== undefined
@@ -262,6 +270,45 @@ describe('UI handler actions without native inventory', () => {
     expect(harness.reactCalls).toEqual([
       { type: 'change', value: 'A' },
     ]);
+  });
+
+  test('deletes at the controlled Android caret and selection', async () => {
+    const caretHarness = await createAppOnlyHarness({
+      renderer: 'paper', value: 'abcd', selection: { start: 2, end: 2 },
+    });
+    const press = caretHarness.tools.get('press_button')!;
+    const caret = await press.handler(press.parameters.parse({ button: 'DELETE' }) as Record<string, unknown>);
+    expect(caret).toBe('Pressed DELETE');
+    expect(caretHarness.reactCalls).toEqual([{ type: 'change', value: 'acd' }]);
+
+    const rangeHarness = await createAppOnlyHarness({
+      renderer: 'paper', value: 'abcd', selection: { start: 1, end: 3 },
+    });
+    const rangePress = rangeHarness.tools.get('press_button')!;
+    expect(await rangePress.handler(rangePress.parameters.parse({ button: 'DELETE' }) as Record<string, unknown>))
+      .toBe('Pressed DELETE');
+    expect(rangeHarness.reactCalls).toEqual([{ type: 'change', value: 'ad' }]);
+
+    const unicodeHarness = await createAppOnlyHarness({
+      renderer: 'paper', value: 'A😀B', selection: { start: 3, end: 3 },
+    });
+    const unicodePress = unicodeHarness.tools.get('press_button')!;
+    expect(await unicodePress.handler(unicodePress.parameters.parse({ button: 'DELETE' }) as Record<string, unknown>))
+      .toBe('Pressed DELETE');
+    expect(unicodeHarness.reactCalls).toEqual([{ type: 'change', value: 'AB' }]);
+  });
+
+  test('defers controlled DELETE to Android when selection is unavailable', async () => {
+    const harness = await createAppOnlyHarness(
+      { renderer: 'paper', value: 'abcd', selection: undefined },
+      true,
+      'emulator-42',
+    );
+    const press = harness.tools.get('press_button')!;
+    expect(await press.handler(press.parameters.parse({ button: 'DELETE', platform: 'android' }) as Record<string, unknown>))
+      .toBe('Pressed DELETE');
+    expect(harness.reactCalls).toEqual([]);
+    expect(harness.execCommands.at(-1)).toBe('adb -s "emulator-42" shell input keyevent 67');
   });
 
   test('matches Android blurAndSubmit semantics for controlled Paper and Fabric inputs', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -12,6 +12,8 @@ type AppEvaluation =
   | 'success'
   | 'failure'
   | 'pre-dispatch'
+  | 'timeout'
+  | 'ambiguous-timeout'
   | 'unhandled'
   | {
       renderer: 'paper' | 'fabric';
@@ -82,6 +84,10 @@ async function createAppOnlyHarness(
       if (evaluation === 'failure') throw new Error('CDP disconnected');
       if (evaluation === 'pre-dispatch') {
         throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+      }
+      if (evaluation === 'timeout') throw new Error('App evaluation timed out');
+      if (evaluation === 'ambiguous-timeout') {
+        throw new Error('App evaluation timed out after 30ms');
       }
       if (evaluation === 'unhandled') return false;
       if (typeof evaluation === 'object') {
@@ -320,6 +326,30 @@ describe('UI handler actions without native inventory', () => {
       expect(await tool.handler(tool.parameters.parse(args) as Record<string, unknown>)).toBe(expected);
     }
     expect(harness.getNativeCalls()).toBeGreaterThan(0);
+  });
+
+  test('uses native fallback for the exact pre-dispatch evaluation timeout', async () => {
+    const harness = await createAppOnlyHarness('timeout', true);
+    const cases = [
+      ['tap_element', { label: 'Save', platform: 'ios' }, 'Tapped "Save"'],
+      ['type_text', { text: 'hello', platform: 'ios' }, 'Typed "hello"'],
+      ['long_press', { label: 'Save', x: 1, y: 2, platform: 'ios' }, 'Long pressed at (1, 2) for 1000ms'],
+      ['swipe', { direction: 'up', platform: 'ios' }, 'Swiped up'],
+      ['press_button', { button: 'ENTER', platform: 'ios' }, 'Pressed ENTER'],
+    ] as const;
+    for (const [name, args, expected] of cases) {
+      const tool = harness.tools.get(name)!;
+      expect(await tool.handler(tool.parameters.parse(args) as Record<string, unknown>)).toBe(expected);
+    }
+    expect(harness.getNativeCalls()).toBeGreaterThan(0);
+  });
+
+  test('does not use native fallback for a timed out evaluation with an ambiguous dispatch', async () => {
+    const harness = await createAppOnlyHarness('ambiguous-timeout', true);
+    const tool = harness.tools.get('tap_element')!;
+    const result = await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>);
+    expect(result).toContain('Could not evaluate');
+    expect(harness.getNativeCalls()).toBe(0);
   });
 
   test('reports a pre-dispatch failure for a label-only long press', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -167,18 +167,20 @@ describe('UI handler actions without native inventory', () => {
     ]);
   });
 
-  test('invokes focused Fabric TextInput key handlers without native inventory', async () => {
-    const harness = await createAppOnlyHarness('fabric-focused');
-    const press = harness.tools.get('press_button')!;
-    for (const button of ['ENTER', 'DELETE'] as const) {
-      expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
-        .toBe(`Pressed ${button}`);
+  test('invokes controlled Paper and Fabric handlers with exact non-empty payloads', async () => {
+    for (const renderer of ['paper', 'fabric'] as const) {
+      const harness = await createAppOnlyHarness(`${renderer}-focused`);
+      const press = harness.tools.get('press_button')!;
+      for (const button of ['ENTER', 'DELETE'] as const) {
+        expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
+          .toBe(`Pressed ${button}`);
+      }
+      expect(harness.reactCalls).toEqual([
+        { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
+        { type: 'change', value: 'hell' },
+      ]);
+      expect(harness.getNativeCalls()).toBe(0);
     }
-    expect(harness.reactCalls).toEqual([
-      { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
-      { type: 'change', value: 'hell' },
-    ]);
-    expect(harness.getNativeCalls()).toBe(0);
   });
 
   test('invokes controlled Paper and Fabric handlers with exact empty payloads', async () => {
@@ -201,10 +203,15 @@ describe('UI handler actions without native inventory', () => {
     for (const renderer of ['paper', 'fabric'] as const) {
       const harness = await createAppOnlyHarness(`${renderer}-uncontrolled`, true);
       const press = harness.tools.get('press_button')!;
-      const result = await press.handler(press.parameters.parse({ button: 'ENTER', platform: 'ios' }) as Record<string, unknown>);
-      expect(result).toBe('Pressed ENTER');
+      for (const button of ['ENTER', 'DELETE'] as const) {
+        expect(await press.handler(press.parameters.parse({ button, platform: 'android' }) as Record<string, unknown>))
+          .toBe(`Pressed ${button}`);
+      }
       expect(harness.reactCalls).toEqual([]);
-      expect(harness.getNativeCalls()).toBeGreaterThan(0);
+      expect(harness.execCommands).toEqual([
+        'adb -s "emulator-42" shell input keyevent 66',
+        'adb -s "emulator-42" shell input keyevent 67',
+      ]);
     }
   });
 

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { z } from 'zod';
 import type { ComponentNode, PluginContext, ToolHandlerResult } from '../plugin.js';
+import { AppEvaluationError } from '../utils/evaluate-app.js';
 import { uiInteractPlugin } from './ui-interact.js';
 
 type Tool = {
@@ -14,6 +15,7 @@ type AppEvaluation =
   | 'pre-dispatch'
   | 'timeout'
   | 'ambiguous-timeout'
+  | 'app-error'
   | 'unhandled'
   | {
       renderer: 'paper' | 'fabric';
@@ -112,6 +114,9 @@ async function createAppOnlyHarness(
       if (evaluation === 'timeout') throw new Error('App evaluation timed out');
       if (evaluation === 'ambiguous-timeout') {
         throw new Error('App evaluation timed out after 30ms');
+      }
+      if (evaluation === 'app-error') {
+        throw new AppEvaluationError('Not connected to CDP target');
       }
       if (evaluation === 'unhandled') return false;
       if (typeof evaluation === 'object') {
@@ -334,6 +339,23 @@ describe('UI handler actions without native inventory', () => {
     const result = await tool.handler(tool.parameters.parse({ label: 'Save', platform: 'ios' }) as Record<string, unknown>);
     expect(result).toBe('Tapped "Save"');
     expect(harness.getNativeCalls()).toBeGreaterThan(0);
+  });
+
+  test('does not replay native actions after an app-originated connection-looking error', async () => {
+    const harness = await createAppOnlyHarness('app-error', true, 'SIMULATOR123');
+    const cases = [
+      ['tap_element', { label: 'Save', platform: 'ios' }],
+      ['type_text', { text: 'hello', platform: 'ios' }],
+      ['long_press', { label: 'Save', platform: 'ios' }],
+      ['swipe', { direction: 'up', platform: 'ios' }],
+      ['press_button', { button: 'ENTER', platform: 'ios' }],
+    ] as const;
+    for (const [name, args] of cases) {
+      const tool = harness.tools.get(name)!;
+      const result = await tool.handler(tool.parameters.parse(args) as Record<string, unknown>);
+      expect(result).toContain('Could not evaluate');
+    }
+    expect(harness.execCommands).toEqual([]);
   });
 
   test('uses native fallback for other known pre-dispatch handler failures', async () => {

--- a/src/plugins/ui-interact.test.ts
+++ b/src/plugins/ui-interact.test.ts
@@ -8,18 +8,22 @@ type Tool = {
   handler: (args: Record<string, unknown>) => Promise<ToolHandlerResult>;
 };
 
+type AppEvaluation =
+  | 'success'
+  | 'failure'
+  | 'pre-dispatch'
+  | 'unhandled'
+  | {
+      renderer: 'paper' | 'fabric';
+      value: string;
+    }
+  | {
+      renderer: 'paper' | 'fabric';
+      defaultValue: string;
+    };
+
 async function createAppOnlyHarness(
-  evaluation:
-    | 'success'
-    | 'failure'
-    | 'pre-dispatch'
-    | 'unhandled'
-    | 'fabric-focused'
-    | 'paper-focused'
-    | 'fabric-empty'
-    | 'paper-empty'
-    | 'fabric-uncontrolled'
-    | 'paper-uncontrolled' = 'success',
+  evaluation: AppEvaluation = 'success',
   nativeAvailable = false,
 ) {
   const tools = new Map<string, Tool>();
@@ -76,11 +80,11 @@ async function createAppOnlyHarness(
         throw new Error('Not connected to Metro. Use list_devices to check connection status.');
       }
       if (evaluation === 'unhandled') return false;
-      if (evaluation.endsWith('-focused') || evaluation.endsWith('-empty') || evaluation.endsWith('-uncontrolled')) {
+      if (typeof evaluation === 'object') {
         const publicInstance = { isFocused: () => true };
-        const fabric = evaluation.startsWith('fabric-');
-        const controlled = !evaluation.endsWith('-uncontrolled');
-        const value = evaluation.endsWith('-empty') ? '' : 'hello';
+        const fabric = evaluation.renderer === 'fabric';
+        const controlled = 'value' in evaluation;
+        const value = controlled ? evaluation.value : evaluation.defaultValue;
         const host = {
           stateNode: fabric ? { canonical: { publicInstance } } : publicInstance,
           child: null,
@@ -115,6 +119,21 @@ async function createAppOnlyHarness(
   };
   await uiInteractPlugin.setup(ctx);
   return { tools, getNativeCalls: () => nativeCalls, evaluations, execCommands, reactCalls };
+}
+
+async function pressTextInputKeys(
+  evaluation: Extract<AppEvaluation, object>,
+  options: { nativeAvailable?: boolean; platform?: 'ios' | 'android' } = {},
+) {
+  const harness = await createAppOnlyHarness(evaluation, options.nativeAvailable);
+  const press = harness.tools.get('press_button')!;
+  for (const button of ['ENTER', 'DELETE'] as const) {
+    expect(await press.handler(press.parameters.parse({
+      button,
+      platform: options.platform ?? 'ios',
+    }) as Record<string, unknown>)).toBe(`Pressed ${button}`);
+  }
+  return harness;
 }
 
 describe('UI handler actions without native inventory', () => {
@@ -169,12 +188,7 @@ describe('UI handler actions without native inventory', () => {
 
   test('invokes controlled Paper and Fabric handlers with exact non-empty payloads', async () => {
     for (const renderer of ['paper', 'fabric'] as const) {
-      const harness = await createAppOnlyHarness(`${renderer}-focused`);
-      const press = harness.tools.get('press_button')!;
-      for (const button of ['ENTER', 'DELETE'] as const) {
-        expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
-          .toBe(`Pressed ${button}`);
-      }
+      const harness = await pressTextInputKeys({ renderer, value: 'hello' });
       expect(harness.reactCalls).toEqual([
         { type: 'submit', value: { nativeEvent: { text: 'hello' } } },
         { type: 'change', value: 'hell' },
@@ -185,12 +199,7 @@ describe('UI handler actions without native inventory', () => {
 
   test('invokes controlled Paper and Fabric handlers with exact empty payloads', async () => {
     for (const renderer of ['paper', 'fabric'] as const) {
-      const harness = await createAppOnlyHarness(`${renderer}-empty`);
-      const press = harness.tools.get('press_button')!;
-      for (const button of ['ENTER', 'DELETE'] as const) {
-        expect(await press.handler(press.parameters.parse({ button, platform: 'ios' }) as Record<string, unknown>))
-          .toBe(`Pressed ${button}`);
-      }
+      const harness = await pressTextInputKeys({ renderer, value: '' });
       expect(harness.reactCalls).toEqual([
         { type: 'submit', value: { nativeEvent: { text: '' } } },
         { type: 'change', value: '' },
@@ -201,12 +210,10 @@ describe('UI handler actions without native inventory', () => {
 
   test('leaves uncontrolled Paper and Fabric inputs for native handling', async () => {
     for (const renderer of ['paper', 'fabric'] as const) {
-      const harness = await createAppOnlyHarness(`${renderer}-uncontrolled`, true);
-      const press = harness.tools.get('press_button')!;
-      for (const button of ['ENTER', 'DELETE'] as const) {
-        expect(await press.handler(press.parameters.parse({ button, platform: 'android' }) as Record<string, unknown>))
-          .toBe(`Pressed ${button}`);
-      }
+      const harness = await pressTextInputKeys(
+        { renderer, defaultValue: 'hello' },
+        { nativeAvailable: true, platform: 'android' },
+      );
       expect(harness.reactCalls).toEqual([]);
       expect(harness.execCommands).toEqual([
         'adb -s "emulator-42" shell input keyevent 66',

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -605,10 +605,11 @@ export const uiInteractPlugin = definePlugin({
                     val.charCodeAt(end - 1) >= 0xd800 && val.charCodeAt(end - 1) <= 0xdbff &&
                     val.charCodeAt(end) >= 0xdc00 && val.charCodeAt(end) <= 0xdfff)) return false;
                 if (start === end) {
-                  if (start === 0) {
-                    targetProps.onChangeText(val);
-                    return true;
-                  }
+                  // There is no deletion to synthesize at the start of the
+                  // value. Let Android receive the key so the native input
+                  // keeps its actual caret semantics without a redundant
+                  // controlled-value callback.
+                  if (start === 0) return false;
                   start -= 1;
                   // Remove one complete Unicode code point. Hermes supports
                   // these primitive string operations, while String spread and

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -14,6 +14,8 @@ import {
 } from '../utils/fiber.js';
 import {
   adbPrefix,
+  discoverAndroidDevices,
+  discoverBootedSimulators,
   getConnectedDeviceTarget,
   resolveDevice,
 } from '../utils/device-discovery.js';
@@ -45,6 +47,40 @@ export const uiInteractPlugin = definePlugin({
   async setup(ctx) {
     const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
       resolveDevice(ctx, platform, getConnectedDeviceTarget(ctx));
+    const prepareExplicitTarget = async (platform: 'ios' | 'android') => {
+      const connected = getConnectedDeviceTarget(ctx);
+      const logicalId = connected?.reactNative?.logicalDeviceId?.trim();
+      const target = await resolveDevice(ctx, platform, connected);
+      const sameId = (left: string, right: string, idPlatform: 'ios' | 'android') =>
+        idPlatform === 'ios'
+          ? left.toLowerCase() === right.toLowerCase()
+          : left === right;
+      if (!target || !logicalId || !sameId(target.id, logicalId, platform)) {
+        return { target, canUseReact: false };
+      }
+      const verifiedLogicalId = logicalId;
+
+      // A requested-platform match alone cannot prove which runtime owns a
+      // connected logical ID. The opposite inventory must also be available
+      // and must not contain that ID before app-side dispatch is permitted.
+      try {
+        let oppositeHasId = false;
+        if (platform === 'ios') {
+          const opposite = await discoverAndroidDevices(ctx);
+          oppositeHasId = opposite.some(
+            (device) => sameId(device.id, verifiedLogicalId, 'android'),
+          );
+        } else {
+          const opposite = await discoverBootedSimulators(ctx);
+          oppositeHasId = opposite.some((device) => sameId(device.udid, verifiedLogicalId, 'ios'));
+        }
+        return { target, canUseReact: !oppositeHasId };
+      } catch {
+        // Without a successful opposite inventory, the ID's platform is not
+        // proven. Keep the requested target for native fallback.
+        return { target, canUseReact: false };
+      }
+    };
 
     async function isIDBAvailable(): Promise<boolean> {
       if (idbAvailableCache !== null) return idbAvailableCache;
@@ -141,9 +177,10 @@ export const uiInteractPlugin = definePlugin({
         if (!label) return 'Provide a label/testID or x,y coordinates.';
 
         // ── Label/testID tap: CDP fiber tree (works on both platforms) ───────
+        const prepared = platform === 'auto' ? undefined : await prepareExplicitTarget(platform);
         const jsLabel = JSON.stringify(label);
         let evaluationError: unknown;
-        const tapped = await ctx.evalInApp(`
+        const tapped = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             ${FIND_AND_INVOKE_JS}
@@ -158,7 +195,7 @@ export const uiInteractPlugin = definePlugin({
           return `Could not evaluate the connected app while tapping "${label}".`;
         }
 
-        const target = await resolveTarget(platform);
+        const target = prepared ? prepared.target : await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
         const p = target.platform;
 
@@ -221,10 +258,11 @@ export const uiInteractPlugin = definePlugin({
       }),
       handler: async ({ text, testID, platform }) => {
         // ── CDP: find TextInput and call onChangeText ─────────────────────────
+        const prepared = platform === 'auto' ? undefined : await prepareExplicitTarget(platform);
         const jsText = JSON.stringify(text);
         const jsTestID = testID ? JSON.stringify(testID) : 'null';
         let evaluationError: unknown;
-        const typed = await ctx.evalInApp(`
+        const typed = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             var targetID = ${jsTestID};
@@ -265,7 +303,7 @@ export const uiInteractPlugin = definePlugin({
           return 'Could not evaluate the connected app while typing text.';
         }
 
-        const target = await resolveTarget(platform);
+        const target = prepared ? prepared.target : await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
         const p = target.platform;
 
@@ -307,10 +345,14 @@ export const uiInteractPlugin = definePlugin({
       }),
       handler: async ({ label, x, y, duration, platform }) => {
         // ── CDP: find element by label/testID and call onLongPress ────────────
-        if (label) {
+        const hasCoordinates = x !== undefined && y !== undefined;
+        const prepared = label && !hasCoordinates && platform !== 'auto'
+          ? await prepareExplicitTarget(platform)
+          : undefined;
+        if (label && !hasCoordinates) {
           const jsLabel = JSON.stringify(label);
           let evaluationError: unknown;
-          const pressed = await ctx.evalInApp(`
+          const pressed = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
               ${FIND_AND_INVOKE_JS}
@@ -323,7 +365,7 @@ export const uiInteractPlugin = definePlugin({
           if (pressed) return `Long pressed "${label}"`;
           if (
             evaluationError &&
-            (!isPreDispatchConnectionFailure(evaluationError) || x === undefined || y === undefined)
+            (!isPreDispatchConnectionFailure(evaluationError) || !hasCoordinates)
           ) {
             return `Could not evaluate the connected app while long pressing "${label}".`;
           }
@@ -361,11 +403,12 @@ export const uiInteractPlugin = definePlugin({
       }),
       handler: async ({ direction, platform }) => {
         let result: string | null = null;
+        const prepared = platform === 'auto' ? undefined : await prepareExplicitTarget(platform);
 
         // ── CDP: find ScrollView and invoke scrollTo on its native node ────────
         const jsDir = JSON.stringify(direction);
         let evaluationError: unknown;
-        const scrolled = await ctx.evalInApp(`
+        const scrolled = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             var dir = ${jsDir};
@@ -417,7 +460,7 @@ export const uiInteractPlugin = definePlugin({
         }
 
         if (!result) {
-          const target = await resolveTarget(platform);
+          const target = prepared ? prepared.target : await resolveTarget(platform);
           if (!target) return 'No simulator/emulator detected.';
           const p = target.platform;
           // ── Native fallbacks (fixed midpoint coordinates) ───────────────────
@@ -435,7 +478,7 @@ export const uiInteractPlugin = definePlugin({
         }
 
         // ── Log to test recorder if a recording is active ─────────────────────
-        await ctx.evalInApp(`
+        if (prepared?.canUseReact ?? true) await ctx.evalInApp(`
           (function() {
             if (!globalThis.__METRO_MCP_REC_ACTIVE__) return;
             ${GET_ROUTE_FUNC_JS}
@@ -464,10 +507,13 @@ export const uiInteractPlugin = definePlugin({
           HOME: 3, BACK: 4, VOLUME_UP: 24, VOLUME_DOWN: 25,
           POWER: 26, ENTER: 66, DELETE: 67,
         };
+        const prepared = (button === 'ENTER' || button === 'DELETE') && platform !== 'auto'
+          ? await prepareExplicitTarget(platform)
+          : undefined;
 
         if (button === 'ENTER' || button === 'DELETE') {
           let evaluationError: unknown;
-          const handled = await ctx.evalInApp(`
+          const handled = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
               var handlerName = ${JSON.stringify(button === 'ENTER' ? 'onSubmitEditing' : 'onChangeText')};
@@ -547,7 +593,7 @@ export const uiInteractPlugin = definePlugin({
           }
         }
 
-        const target = await resolveTarget(platform);
+        const target = prepared ? prepared.target : await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
         const p = target.platform;
 

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -468,6 +468,7 @@ export const uiInteractPlugin = definePlugin({
               ${FIBER_ROOT_JS}
               var handlerName = ${JSON.stringify(button === 'ENTER' ? 'onSubmitEditing' : 'onChangeText')};
               var target = null;
+              var targetInstance = null;
               var stack = [{ f: rootFiber, d: 0 }];
               while (stack.length && !target) {
                 var item = stack.pop();
@@ -500,7 +501,10 @@ export const uiInteractPlugin = definePlugin({
                 // inputs have no current value to preserve; let the native
                 // backend deliver the key event instead.
                 if (name === 'TextInput' && focused && typeof props.value === 'string' &&
-                  typeof props[handlerName] === 'function') target = fiber;
+                  typeof props[handlerName] === 'function') {
+                  target = fiber;
+                  targetInstance = instance;
+                }
                 if (!target) {
                   if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
                   if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
@@ -509,7 +513,20 @@ export const uiInteractPlugin = definePlugin({
               if (!target) return false;
               var targetProps = target.memoizedProps || {};
               if (handlerName === 'onSubmitEditing') {
+                // Match React Native's Android TextInput submit behavior before
+                // invoking the controlled input's handler. A newline must be
+                // delivered as a native key event so the text is preserved;
+                // blurAndSubmit also blurs the native input after submission.
+                var submitBehavior = targetProps.submitBehavior;
+                if (typeof submitBehavior !== 'string') {
+                  if (targetProps.blurOnSubmit === true) submitBehavior = 'blurAndSubmit';
+                  else if (targetProps.blurOnSubmit === false) submitBehavior = 'newline';
+                  else submitBehavior = targetProps.multiline === true ? 'newline' : 'blurAndSubmit';
+                }
+                if (submitBehavior === 'newline') return false;
                 targetProps.onSubmitEditing({ nativeEvent: { text: targetProps.value } });
+                if (submitBehavior === 'blurAndSubmit' && targetInstance &&
+                  typeof targetInstance.blur === 'function') targetInstance.blur();
               } else {
                 var val = targetProps.value.slice(0, -1);
                 targetProps.onChangeText(val);

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -17,6 +17,18 @@ import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let idbAvailableCache: boolean | null = null;
 
+// A failed CDP request is ambiguous once Runtime.evaluate may have been
+// dispatched: retrying a native action could duplicate the app-side event.
+// These errors are raised before dispatch, while the connection is being
+// established, so the native backend is still safe to try.
+function isPreDispatchConnectionFailure(error: unknown): boolean {
+  return error instanceof Error && (
+    error.message === 'Not connected to CDP target' ||
+    error.message ===
+      'Not connected to Metro. Use list_devices to check connection status.'
+  );
+}
+
 export const uiInteractPlugin = definePlugin({
   name: 'ui-interact',
 
@@ -122,19 +134,21 @@ export const uiInteractPlugin = definePlugin({
 
         // ── Label/testID tap: CDP fiber tree (works on both platforms) ───────
         const jsLabel = JSON.stringify(label);
-        let evaluationFailed = false;
+        let evaluationError: unknown;
         const tapped = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             ${FIND_AND_INVOKE_JS}
             return findAndInvoke(${jsLabel}, 'onPress');
           })()
-        `).catch(() => {
-          evaluationFailed = true;
+        `).catch((error) => {
+          evaluationError = error;
           return false;
         });
         if (tapped) return `Tapped "${label}"`;
-        if (evaluationFailed) return `Could not evaluate the connected app while tapping "${label}".`;
+        if (evaluationError && !isPreDispatchConnectionFailure(evaluationError)) {
+          return `Could not evaluate the connected app while tapping "${label}".`;
+        }
 
         const target = await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
@@ -201,7 +215,7 @@ export const uiInteractPlugin = definePlugin({
         // ── CDP: find TextInput and call onChangeText ─────────────────────────
         const jsText = JSON.stringify(text);
         const jsTestID = testID ? JSON.stringify(testID) : 'null';
-        let evaluationFailed = false;
+        let evaluationError: unknown;
         const typed = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
@@ -234,12 +248,14 @@ export const uiInteractPlugin = definePlugin({
             }
             return false;
           })()
-        `).catch(() => {
-          evaluationFailed = true;
+        `).catch((error) => {
+          evaluationError = error;
           return false;
         });
         if (typed) return `Typed "${text}"`;
-        if (evaluationFailed) return 'Could not evaluate the connected app while typing text.';
+        if (evaluationError && !isPreDispatchConnectionFailure(evaluationError)) {
+          return 'Could not evaluate the connected app while typing text.';
+        }
 
         const target = await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
@@ -285,19 +301,24 @@ export const uiInteractPlugin = definePlugin({
         // ── CDP: find element by label/testID and call onLongPress ────────────
         if (label) {
           const jsLabel = JSON.stringify(label);
-          let evaluationFailed = false;
+          let evaluationError: unknown;
           const pressed = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
               ${FIND_AND_INVOKE_JS}
               return findAndInvoke(${jsLabel}, 'onLongPress');
             })()
-          `).catch(() => {
-            evaluationFailed = true;
+          `).catch((error) => {
+            evaluationError = error;
             return false;
           });
           if (pressed) return `Long pressed "${label}"`;
-          if (evaluationFailed) return `Could not evaluate the connected app while long pressing "${label}".`;
+          if (
+            evaluationError &&
+            (!isPreDispatchConnectionFailure(evaluationError) || x === undefined || y === undefined)
+          ) {
+            return `Could not evaluate the connected app while long pressing "${label}".`;
+          }
         }
 
         // ── Coordinate fallbacks ──────────────────────────────────────────────
@@ -335,7 +356,7 @@ export const uiInteractPlugin = definePlugin({
 
         // ── CDP: find ScrollView and invoke scrollTo on its native node ────────
         const jsDir = JSON.stringify(direction);
-        let evaluationFailed = false;
+        let evaluationError: unknown;
         const scrolled = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
@@ -378,12 +399,14 @@ export const uiInteractPlugin = definePlugin({
             } catch(e) {}
             return false;
           })()
-        `).catch(() => {
-          evaluationFailed = true;
+        `).catch((error) => {
+          evaluationError = error;
           return false;
         });
         if (scrolled) result = `Swiped ${direction}`;
-        if (evaluationFailed) return 'Could not evaluate the connected app while swiping.';
+        if (evaluationError && !isPreDispatchConnectionFailure(evaluationError)) {
+          return 'Could not evaluate the connected app while swiping.';
+        }
 
         if (!result) {
           const target = await resolveTarget(platform);
@@ -432,7 +455,7 @@ export const uiInteractPlugin = definePlugin({
         // ENTER and DELETE first try the connected app handler. This path only
         // needs CDP and must work when no local native inventory is available.
         if (button === 'ENTER') {
-          let evaluationFailed = false;
+          let evaluationError: unknown;
           const submitted = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
@@ -454,16 +477,18 @@ export const uiInteractPlugin = definePlugin({
               target.memoizedProps.onSubmitEditing({ nativeEvent: { text: target.memoizedProps.value || '' } });
               return true;
             })()
-          `).catch(() => {
-            evaluationFailed = true;
+          `).catch((error) => {
+            evaluationError = error;
             return false;
           });
           if (submitted) return 'Pressed ENTER';
-          if (evaluationFailed) return 'Could not evaluate the connected app while pressing ENTER.';
+          if (evaluationError && !isPreDispatchConnectionFailure(evaluationError)) {
+            return 'Could not evaluate the connected app while pressing ENTER.';
+          }
         }
 
         if (button === 'DELETE') {
-          let evaluationFailed = false;
+          let evaluationError: unknown;
           const deleted = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
@@ -486,12 +511,14 @@ export const uiInteractPlugin = definePlugin({
               target.memoizedProps.onChangeText(val);
               return true;
             })()
-          `).catch(() => {
-            evaluationFailed = true;
+          `).catch((error) => {
+            evaluationError = error;
             return false;
           });
           if (deleted) return 'Pressed DELETE';
-          if (evaluationFailed) return 'Could not evaluate the connected app while pressing DELETE.';
+          if (evaluationError && !isPreDispatchConnectionFailure(evaluationError)) {
+            return 'Could not evaluate the connected app while pressing DELETE.';
+          }
         }
 
         const target = await resolveTarget(platform);

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -29,7 +29,11 @@ function isPreDispatchConnectionFailure(error: unknown): boolean {
   return error instanceof Error && (
     error.message === 'Not connected to CDP target' ||
     error.message ===
-      'Not connected to Metro. Use list_devices to check connection status.'
+      'Not connected to Metro. Use list_devices to check connection status.' ||
+    // ensureConnected raises this exact error before Runtime.evaluate is
+    // submitted. Duration-bearing timeout errors may follow dispatch and
+    // must not trigger a duplicate native action.
+    error.message === 'App evaluation timed out'
   );
 }
 

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -97,12 +97,11 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ label, x, y, platform }) => {
-        const target = await resolveTarget(platform);
-        if (!target) return 'No simulator/emulator detected.';
-        const p = target.platform;
-
         // ── Coordinate tap ──────────────────────────────────────────────────
         if (x !== undefined && y !== undefined) {
+          const target = await resolveTarget(platform);
+          if (!target) return 'No simulator/emulator detected.';
+          const p = target.platform;
           if (p === 'android') {
             await ctx.exec(`${adbPrefix(target.id)} shell input tap ${x} ${y}`);
             return `Tapped at (${x}, ${y})`;
@@ -123,14 +122,23 @@ export const uiInteractPlugin = definePlugin({
 
         // ── Label/testID tap: CDP fiber tree (works on both platforms) ───────
         const jsLabel = JSON.stringify(label);
+        let evaluationFailed = false;
         const tapped = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             ${FIND_AND_INVOKE_JS}
             return findAndInvoke(${jsLabel}, 'onPress');
           })()
-        `).catch(() => false);
+        `).catch(() => {
+          evaluationFailed = true;
+          return false;
+        });
         if (tapped) return `Tapped "${label}"`;
+        if (evaluationFailed) return `Could not evaluate the connected app while tapping "${label}".`;
+
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         // ── Android fallback: adb uiautomator ───────────────────────────────
         if (p === 'android') {
@@ -190,13 +198,10 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ text, testID, platform }) => {
-        const target = await resolveTarget(platform);
-        if (!target) return 'No simulator/emulator detected.';
-        const p = target.platform;
-
         // ── CDP: find TextInput and call onChangeText ─────────────────────────
         const jsText = JSON.stringify(text);
         const jsTestID = testID ? JSON.stringify(testID) : 'null';
+        let evaluationFailed = false;
         const typed = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
@@ -229,8 +234,16 @@ export const uiInteractPlugin = definePlugin({
             }
             return false;
           })()
-        `).catch(() => false);
+        `).catch(() => {
+          evaluationFailed = true;
+          return false;
+        });
         if (typed) return `Typed "${text}"`;
+        if (evaluationFailed) return 'Could not evaluate the connected app while typing text.';
+
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         // ── Android fallback: adb input text ─────────────────────────────────
         if (p === 'android') {
@@ -269,25 +282,29 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ label, x, y, duration, platform }) => {
-        const target = await resolveTarget(platform);
-        if (!target) return 'No simulator/emulator detected.';
-        const p = target.platform;
-
         // ── CDP: find element by label/testID and call onLongPress ────────────
         if (label) {
           const jsLabel = JSON.stringify(label);
+          let evaluationFailed = false;
           const pressed = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
               ${FIND_AND_INVOKE_JS}
               return findAndInvoke(${jsLabel}, 'onLongPress');
             })()
-          `).catch(() => false);
+          `).catch(() => {
+            evaluationFailed = true;
+            return false;
+          });
           if (pressed) return `Long pressed "${label}"`;
+          if (evaluationFailed) return `Could not evaluate the connected app while long pressing "${label}".`;
         }
 
         // ── Coordinate fallbacks ──────────────────────────────────────────────
         if (x !== undefined && y !== undefined) {
+          const target = await resolveTarget(platform);
+          if (!target) return 'No simulator/emulator detected.';
+          const p = target.platform;
           if (p === 'android') {
             await ctx.exec(`${adbPrefix(target.id)} shell input swipe ${x} ${y} ${x} ${y} ${duration}`);
             return `Long pressed at (${x}, ${y}) for ${duration}ms`;
@@ -314,14 +331,11 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ direction, platform }) => {
-        const target = await resolveTarget(platform);
-        if (!target) return 'No simulator/emulator detected.';
-        const p = target.platform;
-
         let result: string | null = null;
 
         // ── CDP: find ScrollView and invoke scrollTo on its native node ────────
         const jsDir = JSON.stringify(direction);
+        let evaluationFailed = false;
         const scrolled = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
@@ -364,10 +378,17 @@ export const uiInteractPlugin = definePlugin({
             } catch(e) {}
             return false;
           })()
-        `).catch(() => false);
+        `).catch(() => {
+          evaluationFailed = true;
+          return false;
+        });
         if (scrolled) result = `Swiped ${direction}`;
+        if (evaluationFailed) return 'Could not evaluate the connected app while swiping.';
 
         if (!result) {
+          const target = await resolveTarget(platform);
+          if (!target) return 'No simulator/emulator detected.';
+          const p = target.platform;
           // ── Native fallbacks (fixed midpoint coordinates) ───────────────────
           const [sx, sy, ex, ey] = SWIPE_COORDS[direction];
 
@@ -408,6 +429,71 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ button, platform }) => {
+        // ENTER and DELETE first try the connected app handler. This path only
+        // needs CDP and must work when no local native inventory is available.
+        if (button === 'ENTER') {
+          let evaluationFailed = false;
+          const submitted = await ctx.evalInApp(`
+            (function() {
+              ${FIBER_ROOT_JS}
+              var target = null;
+              var stack = [{ f: rootFiber, d: 0 }];
+              while (stack.length && !target) {
+                var item = stack.pop();
+                var fiber = item.f; var depth = item.d;
+                if (!fiber || depth > 200) continue;
+                var name = typeof fiber.type === 'string' ? fiber.type :
+                           (fiber.type && (fiber.type.displayName || fiber.type.name));
+                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onSubmitEditing) target = fiber;
+                if (!target) {
+                  if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
+                  if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
+                }
+              }
+              if (!target) return false;
+              target.memoizedProps.onSubmitEditing({ nativeEvent: { text: target.memoizedProps.value || '' } });
+              return true;
+            })()
+          `).catch(() => {
+            evaluationFailed = true;
+            return false;
+          });
+          if (submitted) return 'Pressed ENTER';
+          if (evaluationFailed) return 'Could not evaluate the connected app while pressing ENTER.';
+        }
+
+        if (button === 'DELETE') {
+          let evaluationFailed = false;
+          const deleted = await ctx.evalInApp(`
+            (function() {
+              ${FIBER_ROOT_JS}
+              var target = null;
+              var stack = [{ f: rootFiber, d: 0 }];
+              while (stack.length && !target) {
+                var item = stack.pop();
+                var fiber = item.f; var depth = item.d;
+                if (!fiber || depth > 200) continue;
+                var name = typeof fiber.type === 'string' ? fiber.type :
+                           (fiber.type && (fiber.type.displayName || fiber.type.name));
+                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onChangeText) target = fiber;
+                if (!target) {
+                  if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
+                  if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
+                }
+              }
+              if (!target) return false;
+              var val = (target.memoizedProps.value || '').slice(0, -1);
+              target.memoizedProps.onChangeText(val);
+              return true;
+            })()
+          `).catch(() => {
+            evaluationFailed = true;
+            return false;
+          });
+          if (deleted) return 'Pressed DELETE';
+          if (evaluationFailed) return 'Could not evaluate the connected app while pressing DELETE.';
+        }
+
         const target = await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
         const p = target.platform;
@@ -430,64 +516,6 @@ export const uiInteractPlugin = definePlugin({
             );
             return 'Pressed HOME';
           } catch {}
-        }
-
-        // ── iOS ENTER/DELETE: CDP on focused TextInput ─────────────────────────
-        if (p === 'ios' && button === 'ENTER') {
-          const submitted = await ctx.evalInApp(`
-            (function() {
-              ${FIBER_ROOT_JS}
-              var target = null;
-              var stack = [{ f: rootFiber, d: 0 }];
-              while (stack.length && !target) {
-                var item = stack.pop();
-                var fiber = item.f; var depth = item.d;
-                if (!fiber || depth > 200) continue;
-                var name = typeof fiber.type === 'string' ? fiber.type :
-                           (fiber.type && (fiber.type.displayName || fiber.type.name));
-                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onSubmitEditing) {
-                  target = fiber;
-                }
-                if (!target) {
-                  if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
-                  if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
-                }
-              }
-              if (!target) return false;
-              target.memoizedProps.onSubmitEditing({ nativeEvent: { text: target.memoizedProps.value || '' } });
-              return true;
-            })()
-          `).catch(() => false);
-          if (submitted) return 'Pressed ENTER';
-        }
-
-        if (p === 'ios' && button === 'DELETE') {
-          const deleted = await ctx.evalInApp(`
-            (function() {
-              ${FIBER_ROOT_JS}
-              var target = null;
-              var stack = [{ f: rootFiber, d: 0 }];
-              while (stack.length && !target) {
-                var item = stack.pop();
-                var fiber = item.f; var depth = item.d;
-                if (!fiber || depth > 200) continue;
-                var name = typeof fiber.type === 'string' ? fiber.type :
-                           (fiber.type && (fiber.type.displayName || fiber.type.name));
-                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onChangeText) {
-                  target = fiber;
-                }
-                if (!target) {
-                  if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
-                  if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
-                }
-              }
-              if (!target) return false;
-              var val = (target.memoizedProps.value || '').slice(0, -1);
-              target.memoizedProps.onChangeText(val);
-              return true;
-            })()
-          `).catch(() => false);
-          if (deleted) return 'Pressed DELETE';
         }
 
         // ── iOS fallback: IDB ─────────────────────────────────────────────────

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -581,16 +581,42 @@ export const uiInteractPlugin = definePlugin({
                   typeof targetInstance.blur === 'function') targetInstance.blur();
               } else {
                 var val = targetProps.value;
-                var end = val.length;
-                var last = end > 0 ? val.charCodeAt(end - 1) : 0;
-                var previous = end > 1 ? val.charCodeAt(end - 2) : 0;
-                // Remove one complete Unicode code point. Hermes supports
-                // these primitive string operations, while String spread and
-                // Array.from are not available in every React Native runtime.
-                if (last >= 0xdc00 && last <= 0xdfff &&
-                  previous >= 0xd800 && previous <= 0xdbff) end -= 2;
-                else if (end > 0) end -= 1;
-                targetProps.onChangeText(val.slice(0, end));
+                // The native DELETE key acts at the current caret/selection,
+                // while a controlled value alone does not tell us where that
+                // caret is. Only synthesize the change when React has exposed
+                // a valid UTF-16 selection; otherwise return false so the
+                // platform backend can preserve the native selection.
+                var selection = targetProps.selection;
+                if (!selection || typeof selection !== 'object' ||
+                  typeof selection.start !== 'number' || typeof selection.end !== 'number' ||
+                  selection.start !== selection.start || selection.end !== selection.end ||
+                  selection.start % 1 !== 0 || selection.end % 1 !== 0 ||
+                  selection.start < 0 || selection.end < selection.start ||
+                  selection.end > val.length) return false;
+                var start = selection.start;
+                var end = selection.end;
+                // Never manufacture an invalid surrogate pair when a stale or
+                // malformed selection splits a code point. Native input can
+                // resolve the same selection safely.
+                if ((start > 0 && start < val.length &&
+                    val.charCodeAt(start - 1) >= 0xd800 && val.charCodeAt(start - 1) <= 0xdbff &&
+                    val.charCodeAt(start) >= 0xdc00 && val.charCodeAt(start) <= 0xdfff) ||
+                  (end > 0 && end < val.length &&
+                    val.charCodeAt(end - 1) >= 0xd800 && val.charCodeAt(end - 1) <= 0xdbff &&
+                    val.charCodeAt(end) >= 0xdc00 && val.charCodeAt(end) <= 0xdfff)) return false;
+                if (start === end) {
+                  if (start === 0) {
+                    targetProps.onChangeText(val);
+                    return true;
+                  }
+                  start -= 1;
+                  // Remove one complete Unicode code point. Hermes supports
+                  // these primitive string operations, while String spread and
+                  // Array.from are not available in every React Native runtime.
+                  if (start > 0 && val.charCodeAt(start) >= 0xdc00 && val.charCodeAt(start) <= 0xdfff &&
+                    val.charCodeAt(start - 1) >= 0xd800 && val.charCodeAt(start - 1) <= 0xdbff) start -= 1;
+                }
+                targetProps.onChangeText(val.slice(0, start) + val.slice(end));
               }
               return true;
             })()

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -12,7 +12,11 @@ import {
   SWIPE_COORDS,
   buildFiberReadExpression,
 } from '../utils/fiber.js';
-import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
+import {
+  adbPrefix,
+  getConnectedDeviceTarget,
+  resolveDevice,
+} from '../utils/device-discovery.js';
 
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let idbAvailableCache: boolean | null = null;
@@ -36,7 +40,7 @@ export const uiInteractPlugin = definePlugin({
 
   async setup(ctx) {
     const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
-      resolveDevice(ctx, platform, ctx.cdp.getTarget());
+      resolveDevice(ctx, platform, getConnectedDeviceTarget(ctx));
 
     async function isIDBAvailable(): Promise<boolean> {
       if (idbAvailableCache !== null) return idbAvailableCache;

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -546,14 +546,14 @@ export const uiInteractPlugin = definePlugin({
         if (!(await isIDBAvailable())) {
           return `Button ${button} requires IDB on iOS. ${IDB_INSTALL}`;
         }
-        const idbMap: Record<string, string> = {
-          HOME: 'HOME', VOLUME_UP: 'VOLUME_UP', VOLUME_DOWN: 'VOLUME_DOWN', POWER: 'LOCK', BACK: 'HOME',
-        };
         if (button === 'ENTER' || button === 'DELETE') {
           const hidCode = button === 'ENTER' ? 40 : 42;
           await ctx.exec(`idb ui key ${hidCode} --udid "${target.id}"`);
           return `Pressed ${button}`;
         }
+        const idbMap: Record<string, string> = {
+          HOME: 'HOME', VOLUME_UP: 'VOLUME_UP', VOLUME_DOWN: 'VOLUME_DOWN', POWER: 'LOCK', BACK: 'HOME',
+        };
         await ctx.exec(`idb ui button ${idbMap[button] || button} --udid "${target.id}"`);
         return `Pressed ${button}`;
       },

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -12,11 +12,10 @@ import {
   SWIPE_COORDS,
   buildFiberReadExpression,
 } from '../utils/fiber.js';
+import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
 
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let idbAvailableCache: boolean | null = null;
-let platformCache: { value: 'ios' | 'android' | null; ts: number } | null = null;
-const PLATFORM_TTL_MS = 5000;
 
 export const uiInteractPlugin = definePlugin({
   name: 'ui-interact',
@@ -24,23 +23,8 @@ export const uiInteractPlugin = definePlugin({
   description: 'UI automation via fiber tree, simctl, adb, and IDB',
 
   async setup(ctx) {
-    async function detectPlatform(): Promise<'ios' | 'android' | null> {
-      const now = Date.now();
-      if (platformCache && now - platformCache.ts < PLATFORM_TTL_MS) return platformCache.value;
-      const [iosResult, androidResult] = await Promise.allSettled([
-        ctx.exec('xcrun simctl list booted 2>/dev/null | grep -q Booted'),
-        ctx.exec('adb devices 2>/dev/null'),
-      ]);
-      let platform: 'ios' | 'android' | null = null;
-      if (iosResult.status === 'fulfilled') {
-        platform = 'ios';
-      } else if (androidResult.status === 'fulfilled') {
-        const output = (androidResult as PromiseFulfilledResult<string>).value;
-        if (output.trim().split('\n').length > 1) platform = 'android';
-      }
-      platformCache = { value: platform, ts: now };
-      return platform;
-    }
+    const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
+      resolveDevice(ctx, platform, ctx.cdp.getTarget());
 
     async function isIDBAvailable(): Promise<boolean> {
       if (idbAvailableCache !== null) return idbAvailableCache;
@@ -113,24 +97,25 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ label, x, y, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         // ── Coordinate tap ──────────────────────────────────────────────────
         if (x !== undefined && y !== undefined) {
           if (p === 'android') {
-            await ctx.exec(`adb shell input tap ${x} ${y}`);
+            await ctx.exec(`${adbPrefix(target.id)} shell input tap ${x} ${y}`);
             return `Tapped at (${x}, ${y})`;
           }
           // iOS: simctl first (Xcode 14+), then IDB
           try {
-            await ctx.exec(`xcrun simctl io booted tap ${x} ${y}`);
+            await ctx.exec(`xcrun simctl io "${target.id}" tap ${x} ${y}`);
             return `Tapped at (${x}, ${y})`;
           } catch {}
           if (!(await isIDBAvailable())) {
             return `Coordinate tap failed. ${IDB_INSTALL}`;
           }
-          await ctx.exec(`idb ui tap ${x} ${y} --udid booted`);
+          await ctx.exec(`idb ui tap ${x} ${y} --udid "${target.id}"`);
           return `Tapped at (${x}, ${y})`;
         }
 
@@ -153,7 +138,7 @@ export const uiInteractPlugin = definePlugin({
           let content = '';
           try {
             await ctx.exec(
-              `adb shell uiautomator dump /sdcard/uidump.xml && adb pull /sdcard/uidump.xml ${tmpFile} 2>/dev/null`
+              `${adbPrefix(target.id)} shell uiautomator dump /sdcard/uidump.xml && ${adbPrefix(target.id)} pull /sdcard/uidump.xml ${tmpFile} 2>/dev/null`
             );
             content = await readFile(tmpFile, 'utf8');
           } finally {
@@ -168,7 +153,7 @@ export const uiInteractPlugin = definePlugin({
             if (match) {
               const cx = Math.round((parseInt(match[1]) + parseInt(match[3])) / 2);
               const cy = Math.round((parseInt(match[2]) + parseInt(match[4])) / 2);
-              await ctx.exec(`adb shell input tap ${cx} ${cy}`);
+              await ctx.exec(`${adbPrefix(target.id)} shell input tap ${cx} ${cy}`);
               return `Tapped "${label}" at (${cx}, ${cy})`;
             }
           } catch {}
@@ -180,12 +165,12 @@ export const uiInteractPlugin = definePlugin({
           return `Element "${label}" not found via fiber tree. ${IDB_INSTALL}`;
         }
         try {
-          await ctx.exec(`idb ui tap --by-label "${label}" --udid booted`);
+          await ctx.exec(`idb ui tap --by-label "${label}" --udid "${target.id}"`);
           return `Tapped "${label}"`;
         } catch (err) {
           const msg = err instanceof Error ? err.message : '';
           if (msg.includes('117')) {
-            return `IDB exit 117: companion not running. Try: idb_companion --udid booted &`;
+            return `IDB exit 117: companion not running. Try: idb_companion --udid ${target.id} &`;
           }
           return `Element "${label}" not found.`;
         }
@@ -205,8 +190,9 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ text, testID, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         // ── CDP: find TextInput and call onChangeText ─────────────────────────
         const jsText = JSON.stringify(text);
@@ -258,7 +244,7 @@ export const uiInteractPlugin = definePlugin({
             .replace(/;/g, '\\;')
             .replace(/\$/g, '\\$')
             .replace(/`/g, '\\`');
-          await ctx.exec(`adb shell input text "${escaped}"`);
+          await ctx.exec(`${adbPrefix(target.id)} shell input text "${escaped}"`);
           return `Typed "${text}"`;
         }
 
@@ -266,7 +252,7 @@ export const uiInteractPlugin = definePlugin({
         if (!(await isIDBAvailable())) {
           return `Could not find a TextInput via fiber tree. ${IDB_INSTALL}`;
         }
-        await ctx.exec(`idb ui text "${text}" --udid booted`);
+        await ctx.exec(`idb ui text "${text}" --udid "${target.id}"`);
         return `Typed "${text}"`;
       },
     });
@@ -283,8 +269,9 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ label, x, y, duration, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         // ── CDP: find element by label/testID and call onLongPress ────────────
         if (label) {
@@ -302,13 +289,13 @@ export const uiInteractPlugin = definePlugin({
         // ── Coordinate fallbacks ──────────────────────────────────────────────
         if (x !== undefined && y !== undefined) {
           if (p === 'android') {
-            await ctx.exec(`adb shell input swipe ${x} ${y} ${x} ${y} ${duration}`);
+            await ctx.exec(`${adbPrefix(target.id)} shell input swipe ${x} ${y} ${x} ${y} ${duration}`);
             return `Long pressed at (${x}, ${y}) for ${duration}ms`;
           }
           if (!(await isIDBAvailable())) {
             return `Coordinate long press requires IDB on iOS. ${IDB_INSTALL}`;
           }
-          await ctx.exec(`idb ui long-press ${x} ${y} --duration ${duration / 1000} --udid booted`);
+          await ctx.exec(`idb ui long-press ${x} ${y} --duration ${duration / 1000} --udid "${target.id}"`);
           return `Long pressed at (${x}, ${y}) for ${duration}ms`;
         }
 
@@ -327,8 +314,9 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ direction, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         let result: string | null = null;
 
@@ -384,12 +372,12 @@ export const uiInteractPlugin = definePlugin({
           const [sx, sy, ex, ey] = SWIPE_COORDS[direction];
 
           if (p === 'android') {
-            await ctx.exec(`adb shell input swipe ${sx} ${sy} ${ex} ${ey} 300`);
+            await ctx.exec(`${adbPrefix(target.id)} shell input swipe ${sx} ${sy} ${ex} ${ey} 300`);
             result = `Swiped ${direction}`;
           } else if (!(await isIDBAvailable())) {
             return `Swipe requires IDB on iOS. ${IDB_INSTALL}`;
           } else {
-            await ctx.exec(`idb ui swipe ${sx} ${sy} ${ex} ${ey} --udid booted`);
+            await ctx.exec(`idb ui swipe ${sx} ${sy} ${ex} ${ey} --udid "${target.id}"`);
             result = `Swiped ${direction}`;
           }
         }
@@ -420,8 +408,9 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ button, platform }) => {
-        const p = platform === 'auto' ? await detectPlatform() : platform;
-        if (!p) return 'No simulator/emulator detected.';
+        const target = await resolveTarget(platform);
+        if (!target) return 'No simulator/emulator detected.';
+        const p = target.platform;
 
         // ── Android: adb keycodes ─────────────────────────────────────────────
         if (p === 'android') {
@@ -429,7 +418,7 @@ export const uiInteractPlugin = definePlugin({
             HOME: 3, BACK: 4, VOLUME_UP: 24, VOLUME_DOWN: 25,
             POWER: 26, ENTER: 66, DELETE: 67,
           };
-          await ctx.exec(`adb shell input keyevent ${keycodes[button]}`);
+          await ctx.exec(`${adbPrefix(target.id)} shell input keyevent ${keycodes[button]}`);
           return `Pressed ${button}`;
         }
 
@@ -437,7 +426,7 @@ export const uiInteractPlugin = definePlugin({
         if (button === 'HOME') {
           try {
             await ctx.exec(
-              'xcrun simctl spawn booted launchctl kickstart -k system/com.apple.SpringBoard 2>/dev/null'
+              `xcrun simctl spawn "${target.id}" launchctl kickstart -k system/com.apple.SpringBoard 2>/dev/null`
             );
             return 'Pressed HOME';
           } catch {}
@@ -508,7 +497,7 @@ export const uiInteractPlugin = definePlugin({
         const idbMap: Record<string, string> = {
           HOME: 'HOME', VOLUME_UP: 'VOLUME_UP', VOLUME_DOWN: 'VOLUME_DOWN', POWER: 'LOCK', BACK: 'HOME',
         };
-        await ctx.exec(`idb ui button ${idbMap[button] || button} --udid booted`);
+        await ctx.exec(`idb ui button ${idbMap[button] || button} --udid "${target.id}"`);
         return `Pressed ${button}`;
       },
     });

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -492,7 +492,11 @@ export const uiInteractPlugin = definePlugin({
                   } catch (e) {}
                   current = current.child;
                 }
-                if (name === 'TextInput' && focused && typeof props[handlerName] === 'function') target = fiber;
+                // Only synthesize key events for controlled inputs. Uncontrolled
+                // inputs have no current value to preserve; let the native
+                // backend deliver the key event instead.
+                if (name === 'TextInput' && focused && typeof props.value === 'string' &&
+                  typeof props[handlerName] === 'function') target = fiber;
                 if (!target) {
                   if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
                   if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
@@ -501,9 +505,9 @@ export const uiInteractPlugin = definePlugin({
               if (!target) return false;
               var targetProps = target.memoizedProps || {};
               if (handlerName === 'onSubmitEditing') {
-                targetProps.onSubmitEditing({ nativeEvent: { text: targetProps.value || '' } });
+                targetProps.onSubmitEditing({ nativeEvent: { text: targetProps.value } });
               } else {
-                var val = (targetProps.value || '').slice(0, -1);
+                var val = targetProps.value.slice(0, -1);
                 targetProps.onChangeText(val);
               }
               return true;

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -19,6 +19,7 @@ import {
   getConnectedDeviceTarget,
   resolveDevice,
 } from '../utils/device-discovery.js';
+import { isAppEvaluationError } from '../utils/evaluate-app.js';
 
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let idbAvailableCache: boolean | null = null;
@@ -28,6 +29,7 @@ let idbAvailableCache: boolean | null = null;
 // These errors are raised before dispatch, while the connection is being
 // established, so the native backend is still safe to try.
 function isPreDispatchConnectionFailure(error: unknown): boolean {
+  if (isAppEvaluationError(error)) return false;
   return error instanceof Error && (
     error.message === 'Not connected to CDP target' ||
     error.message ===

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -580,8 +580,17 @@ export const uiInteractPlugin = definePlugin({
                 if (submitBehavior === 'blurAndSubmit' && targetInstance &&
                   typeof targetInstance.blur === 'function') targetInstance.blur();
               } else {
-                var val = targetProps.value.slice(0, -1);
-                targetProps.onChangeText(val);
+                var val = targetProps.value;
+                var end = val.length;
+                var last = end > 0 ? val.charCodeAt(end - 1) : 0;
+                var previous = end > 1 ? val.charCodeAt(end - 2) : 0;
+                // Remove one complete Unicode code point. Hermes supports
+                // these primitive string operations, while String spread and
+                // Array.from are not available in every React Native runtime.
+                if (last >= 0xdc00 && last <= 0xdfff &&
+                  previous >= 0xd800 && previous <= 0xdbff) end -= 2;
+                else if (end > 0) end -= 1;
+                targetProps.onChangeText(val.slice(0, end));
               }
               return true;
             })()

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -549,6 +549,11 @@ export const uiInteractPlugin = definePlugin({
         const idbMap: Record<string, string> = {
           HOME: 'HOME', VOLUME_UP: 'VOLUME_UP', VOLUME_DOWN: 'VOLUME_DOWN', POWER: 'LOCK', BACK: 'HOME',
         };
+        if (button === 'ENTER' || button === 'DELETE') {
+          const hidCode = button === 'ENTER' ? 40 : 42;
+          await ctx.exec(`idb ui key ${hidCode} --udid "${target.id}"`);
+          return `Pressed ${button}`;
+        }
         await ctx.exec(`idb ui button ${idbMap[button] || button} --udid "${target.id}"`);
         return `Pressed ${button}`;
       },

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -18,11 +18,20 @@ import {
   discoverBootedSimulators,
   getConnectedDeviceTarget,
   resolveDevice,
+  snapshotConnectedDeviceTarget,
+  type ResolvedDevice,
 } from '../utils/device-discovery.js';
 import { isAppEvaluationError } from '../utils/evaluate-app.js';
 
 // Module-level caches — persist across tool handler calls for the lifetime of the server.
 let idbAvailableCache: boolean | null = null;
+
+interface PreparedTarget {
+  target: ResolvedDevice | null;
+  canUseReact: boolean;
+  isCurrent(): boolean;
+  isTargetCurrent(): boolean;
+}
 
 // A failed CDP request is ambiguous once Runtime.evaluate may have been
 // dispatched: retrying a native action could duplicate the app-side event.
@@ -49,16 +58,39 @@ export const uiInteractPlugin = definePlugin({
   async setup(ctx) {
     const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
       resolveDevice(ctx, platform, getConnectedDeviceTarget(ctx));
-    const prepareExplicitTarget = async (platform: 'ios' | 'android') => {
-      const connected = getConnectedDeviceTarget(ctx);
-      const logicalId = connected?.reactNative?.logicalDeviceId?.trim();
-      const target = await resolveDevice(ctx, platform, connected);
+    const prepareExplicitTarget = async (platform: 'ios' | 'android'): Promise<PreparedTarget> => {
+      const connectedSnapshot = snapshotConnectedDeviceTarget(getConnectedDeviceTarget(ctx));
+      const hasConnectedSnapshot = connectedSnapshot !== undefined;
+      const targetId = connectedSnapshot?.id?.trim();
+      const logicalId = connectedSnapshot?.reactNative?.logicalDeviceId?.trim();
+      const generation = ctx.getRuntimeGeneration?.();
+      const target = await resolveDevice(ctx, platform, connectedSnapshot);
       const sameId = (left: string, right: string, idPlatform: 'ios' | 'android') =>
         idPlatform === 'ios'
           ? left.toLowerCase() === right.toLowerCase()
           : left === right;
+      const isTargetCurrent = () => {
+        // An explicit platform request may legitimately have no CDP target
+        // yet. In that case inventory resolution is the native target source;
+        // there is no prior target to become stale.
+        if (!hasConnectedSnapshot) return true;
+        const current = getConnectedDeviceTarget(ctx);
+        if (!current) return false;
+        if (targetId && current.id?.trim() !== targetId) return false;
+        const currentLogicalId = current.reactNative?.logicalDeviceId?.trim();
+        if (logicalId && (!currentLogicalId || !sameId(currentLogicalId, logicalId, platform))) {
+          return false;
+        }
+        return true;
+      };
+      const isCurrent = () => {
+        if (!isTargetCurrent()) return false;
+        const currentGeneration = ctx.getRuntimeGeneration?.();
+        return generation === undefined || currentGeneration === undefined ||
+          currentGeneration === generation;
+      };
       if (!target || !logicalId || !sameId(target.id, logicalId, platform)) {
-        return { target, canUseReact: false };
+        return { target, canUseReact: false, isCurrent, isTargetCurrent };
       }
       const verifiedLogicalId = logicalId;
 
@@ -76,13 +108,20 @@ export const uiInteractPlugin = definePlugin({
           const opposite = await discoverBootedSimulators(ctx);
           oppositeHasId = opposite.some((device) => sameId(device.udid, verifiedLogicalId, 'ios'));
         }
-        return { target, canUseReact: !oppositeHasId };
+        return { target, canUseReact: !oppositeHasId, isCurrent, isTargetCurrent };
       } catch {
         // Without a successful opposite inventory, the ID's platform is not
         // proven. Keep the requested target for native fallback.
-        return { target, canUseReact: false };
+        return { target, canUseReact: false, isCurrent, isTargetCurrent };
       }
     };
+
+    const canUsePreparedReact = (prepared: PreparedTarget | undefined) =>
+      !prepared || (prepared.canUseReact && prepared.isCurrent());
+
+    const preparedNativeTarget = (
+      prepared: PreparedTarget,
+    ) => prepared.isTargetCurrent() ? prepared.target : null;
 
     async function isIDBAvailable(): Promise<boolean> {
       if (idbAvailableCache !== null) return idbAvailableCache;
@@ -182,7 +221,7 @@ export const uiInteractPlugin = definePlugin({
         const prepared = platform === 'auto' ? undefined : await prepareExplicitTarget(platform);
         const jsLabel = JSON.stringify(label);
         let evaluationError: unknown;
-        const tapped = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
+        const tapped = canUsePreparedReact(prepared) && await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             ${FIND_AND_INVOKE_JS}
@@ -197,7 +236,7 @@ export const uiInteractPlugin = definePlugin({
           return `Could not evaluate the connected app while tapping "${label}".`;
         }
 
-        const target = prepared ? prepared.target : await resolveTarget(platform);
+        const target = prepared ? preparedNativeTarget(prepared) : await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
         const p = target.platform;
 
@@ -264,7 +303,7 @@ export const uiInteractPlugin = definePlugin({
         const jsText = JSON.stringify(text);
         const jsTestID = testID ? JSON.stringify(testID) : 'null';
         let evaluationError: unknown;
-        const typed = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
+        const typed = canUsePreparedReact(prepared) && await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             var targetID = ${jsTestID};
@@ -305,7 +344,7 @@ export const uiInteractPlugin = definePlugin({
           return 'Could not evaluate the connected app while typing text.';
         }
 
-        const target = prepared ? prepared.target : await resolveTarget(platform);
+        const target = prepared ? preparedNativeTarget(prepared) : await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
         const p = target.platform;
 
@@ -354,7 +393,7 @@ export const uiInteractPlugin = definePlugin({
         if (label && !hasCoordinates) {
           const jsLabel = JSON.stringify(label);
           let evaluationError: unknown;
-          const pressed = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
+          const pressed = canUsePreparedReact(prepared) && await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
               ${FIND_AND_INVOKE_JS}
@@ -410,7 +449,7 @@ export const uiInteractPlugin = definePlugin({
         // ── CDP: find ScrollView and invoke scrollTo on its native node ────────
         const jsDir = JSON.stringify(direction);
         let evaluationError: unknown;
-        const scrolled = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
+        const scrolled = canUsePreparedReact(prepared) && await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             var dir = ${jsDir};
@@ -462,7 +501,7 @@ export const uiInteractPlugin = definePlugin({
         }
 
         if (!result) {
-          const target = prepared ? prepared.target : await resolveTarget(platform);
+          const target = prepared ? preparedNativeTarget(prepared) : await resolveTarget(platform);
           if (!target) return 'No simulator/emulator detected.';
           const p = target.platform;
           // ── Native fallbacks (fixed midpoint coordinates) ───────────────────
@@ -480,7 +519,7 @@ export const uiInteractPlugin = definePlugin({
         }
 
         // ── Log to test recorder if a recording is active ─────────────────────
-        if (prepared?.canUseReact ?? true) await ctx.evalInApp(`
+        if (canUsePreparedReact(prepared)) await ctx.evalInApp(`
           (function() {
             if (!globalThis.__METRO_MCP_REC_ACTIVE__) return;
             ${GET_ROUTE_FUNC_JS}
@@ -515,7 +554,7 @@ export const uiInteractPlugin = definePlugin({
 
         if (button === 'ENTER' || button === 'DELETE') {
           let evaluationError: unknown;
-          const handled = (prepared?.canUseReact ?? true) && await ctx.evalInApp(`
+          const handled = canUsePreparedReact(prepared) && await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
               var handlerName = ${JSON.stringify(button === 'ENTER' ? 'onSubmitEditing' : 'onChangeText')};
@@ -631,7 +670,7 @@ export const uiInteractPlugin = definePlugin({
           }
         }
 
-        const target = prepared ? prepared.target : await resolveTarget(platform);
+        const target = prepared ? preparedNativeTarget(prepared) : await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
         const p = target.platform;
 

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -213,7 +213,7 @@ export const uiInteractPlugin = definePlugin({
 
     ctx.registerTool('long_press', {
       description:
-        'Long press using a React handler by label/testID, or native input at logical device-point coordinates. Native results identify the backend and dispatch state.',
+        'Long press using a React handler by label/testID, then semantic native input through SimView or IDB when the handler is unavailable. Explicit coordinates use native input directly; native results identify the backend and dispatch state.',
       annotations: { destructiveHint: false },
       parameters: z.object({
         label: z.string().optional().describe('Accessibility label or testID of the element to long press'),
@@ -226,7 +226,6 @@ export const uiInteractPlugin = definePlugin({
         // ── CDP: find element by label/testID and call onLongPress ────────────
         if (label && x === undefined && y === undefined) {
           const jsLabel = JSON.stringify(label);
-          let evaluationError: unknown;
           const pressed = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
@@ -235,13 +234,9 @@ export const uiInteractPlugin = definePlugin({
             })()
           `).catch((error) => {
             if (!isPreDispatchConnectionFailure(error)) throw error;
-            evaluationError = error;
             return false;
           });
           if (pressed) return `Long pressed "${label}"`;
-          if (evaluationError) {
-            return `Could not evaluate the connected app while long pressing "${label}".`;
-          }
         }
 
         // ── Coordinate fallbacks ──────────────────────────────────────────────
@@ -252,9 +247,14 @@ export const uiInteractPlugin = definePlugin({
           return nativeResult(`Long pressed at (${x}, ${y}) for ${duration}ms`, dispatch);
         }
 
-        return label
-          ? `Element "${label}" not found or has no onLongPress handler. Provide x,y coordinates as fallback.`
-          : 'Provide a label/testID or x,y coordinates.';
+        if (label) {
+          const target = await resolveTarget(platform);
+          if (!target) return 'No simulator/emulator detected.';
+          const dispatch = await nativeInput.longPressLabel(target, label, duration);
+          return nativeResult(`Long pressed "${label}"`, dispatch);
+        }
+
+        return 'Provide a label/testID or x,y coordinates.';
       },
     });
 

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -452,46 +452,17 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ button, platform }) => {
-        // ENTER and DELETE first try the connected app handler. This path only
-        // needs CDP and must work when no local native inventory is available.
-        if (button === 'ENTER') {
-          let evaluationError: unknown;
-          const submitted = await ctx.evalInApp(`
-            (function() {
-              ${FIBER_ROOT_JS}
-              var target = null;
-              var stack = [{ f: rootFiber, d: 0 }];
-              while (stack.length && !target) {
-                var item = stack.pop();
-                var fiber = item.f; var depth = item.d;
-                if (!fiber || depth > 200) continue;
-                var name = typeof fiber.type === 'string' ? fiber.type :
-                           (fiber.type && (fiber.type.displayName || fiber.type.name));
-                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onSubmitEditing) target = fiber;
-                if (!target) {
-                  if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
-                  if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
-                }
-              }
-              if (!target) return false;
-              target.memoizedProps.onSubmitEditing({ nativeEvent: { text: target.memoizedProps.value || '' } });
-              return true;
-            })()
-          `).catch((error) => {
-            evaluationError = error;
-            return false;
-          });
-          if (submitted) return 'Pressed ENTER';
-          if (evaluationError && !isPreDispatchConnectionFailure(evaluationError)) {
-            return 'Could not evaluate the connected app while pressing ENTER.';
-          }
-        }
+        const keycodes: Record<string, number> = {
+          HOME: 3, BACK: 4, VOLUME_UP: 24, VOLUME_DOWN: 25,
+          POWER: 26, ENTER: 66, DELETE: 67,
+        };
 
-        if (button === 'DELETE') {
+        if (button === 'ENTER' || button === 'DELETE') {
           let evaluationError: unknown;
-          const deleted = await ctx.evalInApp(`
+          const handled = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
+              var handlerName = ${JSON.stringify(button === 'ENTER' ? 'onSubmitEditing' : 'onChangeText')};
               var target = null;
               var stack = [{ f: rootFiber, d: 0 }];
               while (stack.length && !target) {
@@ -500,24 +471,50 @@ export const uiInteractPlugin = definePlugin({
                 if (!fiber || depth > 200) continue;
                 var name = typeof fiber.type === 'string' ? fiber.type :
                            (fiber.type && (fiber.type.displayName || fiber.type.name));
-                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onChangeText) target = fiber;
+                var props = fiber.memoizedProps || {};
+                var current = fiber;
+                var focused = false;
+                var inspected = 0;
+                while (name === 'TextInput' && current && inspected++ < 32) {
+                  var node = current.stateNode;
+                  var instance = node && node.canonical && node.canonical.publicInstance ||
+                                 node && node.publicInstance ||
+                                 node && node.__internalInstanceHandle &&
+                                   node.__internalInstanceHandle.stateNode &&
+                                   node.__internalInstanceHandle.stateNode.canonical &&
+                                   node.__internalInstanceHandle.stateNode.canonical.publicInstance ||
+                                 node;
+                  try {
+                    if (instance && typeof instance.isFocused === 'function' && instance.isFocused() === true) {
+                      focused = true;
+                      break;
+                    }
+                  } catch (e) {}
+                  current = current.child;
+                }
+                if (name === 'TextInput' && focused && typeof props[handlerName] === 'function') target = fiber;
                 if (!target) {
                   if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
                   if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
                 }
               }
               if (!target) return false;
-              var val = (target.memoizedProps.value || '').slice(0, -1);
-              target.memoizedProps.onChangeText(val);
+              var targetProps = target.memoizedProps || {};
+              if (handlerName === 'onSubmitEditing') {
+                targetProps.onSubmitEditing({ nativeEvent: { text: targetProps.value || '' } });
+              } else {
+                var val = (targetProps.value || '').slice(0, -1);
+                targetProps.onChangeText(val);
+              }
               return true;
             })()
           `).catch((error) => {
             evaluationError = error;
             return false;
           });
-          if (deleted) return 'Pressed DELETE';
+          if (handled) return `Pressed ${button}`;
           if (evaluationError && !isPreDispatchConnectionFailure(evaluationError)) {
-            return 'Could not evaluate the connected app while pressing DELETE.';
+            return `Could not evaluate the connected app while pressing ${button}.`;
           }
         }
 
@@ -527,10 +524,6 @@ export const uiInteractPlugin = definePlugin({
 
         // ── Android: adb keycodes ─────────────────────────────────────────────
         if (p === 'android') {
-          const keycodes: Record<string, number> = {
-            HOME: 3, BACK: 4, VOLUME_UP: 24, VOLUME_DOWN: 25,
-            POWER: 26, ENTER: 66, DELETE: 67,
-          };
           await ctx.exec(`${adbPrefix(target.id)} shell input keyevent ${keycodes[button]}`);
           return `Pressed ${button}`;
         }

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -9,35 +9,30 @@ import {
   GET_ROUTE_FUNC_JS,
   MAX_FIBER_DEPTH,
   MAX_FIBER_NODES,
-  SWIPE_COORDS,
   buildFiberReadExpression,
 } from '../utils/fiber.js';
 import { adbPrefix, resolveDevice } from '../utils/device-discovery.js';
-
-// Module-level caches — persist across tool handler calls for the lifetime of the server.
-let idbAvailableCache: boolean | null = null;
+import { NativeInputController, type NativeDispatchResult, type NativeInputConfig } from '../utils/native-input.js';
 
 export const uiInteractPlugin = definePlugin({
   name: 'ui-interact',
 
-  description: 'UI automation via fiber tree, simctl, adb, and IDB',
+  description: 'UI automation via React handlers, SimView, IDB, and adb',
 
   async setup(ctx) {
     const resolveTarget = (platform: 'ios' | 'android' | 'auto') =>
       resolveDevice(ctx, platform, ctx.cdp.getTarget());
-
-    async function isIDBAvailable(): Promise<boolean> {
-      if (idbAvailableCache !== null) return idbAvailableCache;
-      try {
-        await ctx.exec('which idb 2>/dev/null');
-        idbAvailableCache = true;
-      } catch {
-        idbAvailableCache = false;
-      }
-      return idbAvailableCache;
-    }
-
-    const IDB_INSTALL = 'Install IDB with: brew install idb-companion';
+    const nativeInput = new NativeInputController({
+      projectRoot: typeof ctx.config.projectRoot === 'string' ? ctx.config.projectRoot : undefined,
+      config: (ctx.config.input ?? {}) as NativeInputConfig,
+      runner: { execFile: ctx.execFile, exec: ctx.exec },
+      registerCleanup: ctx.registerCleanup,
+      logger: ctx.logger,
+    });
+    const nativeResult = (action: string, dispatch: NativeDispatchResult): string => {
+      const outcome = dispatch.status === 'handled' ? action : `${action} failed`;
+      return `${outcome} [backend=${dispatch.backend}, dispatch=${dispatch.dispatch}, dispatched=${dispatch.dispatched}, status=${dispatch.status}]${dispatch.message ? `: ${dispatch.message}` : ''}`;
+    };
 
     ctx.registerTool('list_elements', {
       description:
@@ -88,7 +83,7 @@ export const uiInteractPlugin = definePlugin({
 
     ctx.registerTool('tap_element', {
       description:
-        'Tap an element by label, testID, or coordinates. Uses CDP fiber tree, then simctl/adb, then IDB.',
+        'Tap by label, testID, or logical device-point coordinates. Uses React handlers, then installed SimView or IDB on iOS and adb on Android. Coordinates use native input directly; native results identify the backend and dispatch state.',
       annotations: { destructiveHint: false },
       parameters: z.object({
         label: z.string().optional().describe('Accessibility label, aria-label, or testID to tap'),
@@ -101,47 +96,28 @@ export const uiInteractPlugin = definePlugin({
         if (x !== undefined && y !== undefined) {
           const target = await resolveTarget(platform);
           if (!target) return 'No simulator/emulator detected.';
-          const p = target.platform;
-          if (p === 'android') {
-            await ctx.exec(`${adbPrefix(target.id)} shell input tap ${x} ${y}`);
-            return `Tapped at (${x}, ${y})`;
-          }
-          // iOS: simctl first (Xcode 14+), then IDB
-          try {
-            await ctx.exec(`xcrun simctl io "${target.id}" tap ${x} ${y}`);
-            return `Tapped at (${x}, ${y})`;
-          } catch {}
-          if (!(await isIDBAvailable())) {
-            return `Coordinate tap failed. ${IDB_INSTALL}`;
-          }
-          await ctx.exec(`idb ui tap ${x} ${y} --udid "${target.id}"`);
-          return `Tapped at (${x}, ${y})`;
+          const dispatch = await nativeInput.tap(target, x, y);
+          return nativeResult(`Tapped at (${x}, ${y})`, dispatch);
         }
 
         if (!label) return 'Provide a label/testID or x,y coordinates.';
 
         // ── Label/testID tap: CDP fiber tree (works on both platforms) ───────
         const jsLabel = JSON.stringify(label);
-        let evaluationFailed = false;
         const tapped = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
             ${FIND_AND_INVOKE_JS}
             return findAndInvoke(${jsLabel}, 'onPress');
           })()
-        `).catch(() => {
-          evaluationFailed = true;
-          return false;
-        });
+        `);
         if (tapped) return `Tapped "${label}"`;
-        if (evaluationFailed) return `Could not evaluate the connected app while tapping "${label}".`;
 
         const target = await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
-        const p = target.platform;
 
         // ── Android fallback: adb uiautomator ───────────────────────────────
-        if (p === 'android') {
+        if (target.platform === 'android') {
           const tmpFile = '/tmp/metro-mcp-uidump.xml';
           let content = '';
           try {
@@ -168,26 +144,14 @@ export const uiInteractPlugin = definePlugin({
           return `Element "${label}" not found.`;
         }
 
-        // ── iOS fallback: IDB --by-label ─────────────────────────────────────
-        if (!(await isIDBAvailable())) {
-          return `Element "${label}" not found via fiber tree. ${IDB_INSTALL}`;
-        }
-        try {
-          await ctx.exec(`idb ui tap --by-label "${label}" --udid "${target.id}"`);
-          return `Tapped "${label}"`;
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : '';
-          if (msg.includes('117')) {
-            return `IDB exit 117: companion not running. Try: idb_companion --udid ${target.id} &`;
-          }
-          return `Element "${label}" not found.`;
-        }
+        const dispatch = await nativeInput.tapLabel(target, label);
+        return nativeResult(`Tapped "${label}"`, dispatch);
       },
     });
 
     ctx.registerTool('type_text', {
       description:
-        'Type text into an input field. Targets a specific input by testID/label, or the first visible TextInput. Uses CDP fiber tree, then adb/IDB.',
+        'Type text into an input field. Targets a specific input by testID/label, or the first visible TextInput. Uses the React handler first, then SimView or IDB on iOS and the selected ADB serial on Android.',
       annotations: { destructiveHint: false },
       parameters: z.object({
         text: z.string().describe('Text to type'),
@@ -201,78 +165,38 @@ export const uiInteractPlugin = definePlugin({
         // ── CDP: find TextInput and call onChangeText ─────────────────────────
         const jsText = JSON.stringify(text);
         const jsTestID = testID ? JSON.stringify(testID) : 'null';
-        let evaluationFailed = false;
-        const typed = await ctx.evalInApp(`
-          (function() {
-            ${FIBER_ROOT_JS}
-            var targetID = ${jsTestID};
-            var target = null;
-            var stack = [{ f: rootFiber, d: 0 }];
-            while (stack.length && !target) {
-              var item = stack.pop();
-              var fiber = item.f; var depth = item.d;
-              if (!fiber || depth > 200) continue;
-              var name = typeof fiber.type === 'string' ? fiber.type :
-                         (fiber.type && (fiber.type.displayName || fiber.type.name));
-              if (name === 'TextInput') {
-                var props = fiber.memoizedProps || {};
-                if (!targetID || props.testID === targetID || props.accessibilityLabel === targetID) {
-                  target = fiber;
-                }
-              }
-              if (!target) {
-                if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
-                if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
-              }
-            }
-            if (!target) return false;
-            var props = target.memoizedProps || {};
-            if (props.onChangeText) { props.onChangeText(${jsText}); return true; }
-            if (props.onChange) {
-              props.onChange({ nativeEvent: { text: ${jsText}, target: 0, eventCount: 1 } });
-              return true;
-            }
-            return false;
-          })()
-        `).catch(() => {
-          evaluationFailed = true;
+        const typed = await ctx.evalInApp(buildFiberReadExpression(`
+          ${FIBER_ROOT_JS}
+          var targetID = ${jsTestID};
+          var target = null;
+          metroWalkFibers(FIBER_OPTIONS, function(fiber) {
+            if (target) return { prune: true };
+            if (metroFiberName(fiber) !== 'TextInput') return;
+            var props = fiber.memoizedProps || {};
+            if (!targetID || props.testID === targetID || props.accessibilityLabel === targetID) target = fiber;
+            return target ? { prune: true } : undefined;
+          });
+          if (!target) return false;
+          var props = target.memoizedProps || {};
+          if (props.onChangeText) { props.onChangeText(${jsText}); return true; }
+          if (props.onChange) {
+            props.onChange({ nativeEvent: { text: ${jsText}, target: 0, eventCount: 1 } });
+            return true;
+          }
           return false;
-        });
+        `, { maxDepth: MAX_FIBER_DEPTH, maxNodes: MAX_FIBER_NODES }));
         if (typed) return `Typed "${text}"`;
-        if (evaluationFailed) return 'Could not evaluate the connected app while typing text.';
 
         const target = await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
-        const p = target.platform;
-
-        // ── Android fallback: adb input text ─────────────────────────────────
-        if (p === 'android') {
-          // adb shell input text uses %s for spaces; other shell metacharacters need escaping.
-          const escaped = text
-            .replace(/\\/g, '\\\\')
-            .replace(/ /g, '%s')
-            .replace(/"/g, '\\"')
-            .replace(/&/g, '\\&')
-            .replace(/\|/g, '\\|')
-            .replace(/;/g, '\\;')
-            .replace(/\$/g, '\\$')
-            .replace(/`/g, '\\`');
-          await ctx.exec(`${adbPrefix(target.id)} shell input text "${escaped}"`);
-          return `Typed "${text}"`;
-        }
-
-        // ── iOS fallback: IDB ─────────────────────────────────────────────────
-        if (!(await isIDBAvailable())) {
-          return `Could not find a TextInput via fiber tree. ${IDB_INSTALL}`;
-        }
-        await ctx.exec(`idb ui text "${text}" --udid "${target.id}"`);
-        return `Typed "${text}"`;
+        const dispatch = await nativeInput.typeText(target, text);
+        return nativeResult(`Typed "${text}"`, dispatch);
       },
     });
 
     ctx.registerTool('long_press', {
       description:
-        'Long press an element by label/testID, or at coordinates. Uses CDP fiber tree, then adb/IDB.',
+        'Long press using a React handler by label/testID, or native input at logical device-point coordinates. Native results identify the backend and dispatch state.',
       annotations: { destructiveHint: false },
       parameters: z.object({
         label: z.string().optional().describe('Accessibility label or testID of the element to long press'),
@@ -283,37 +207,24 @@ export const uiInteractPlugin = definePlugin({
       }),
       handler: async ({ label, x, y, duration, platform }) => {
         // ── CDP: find element by label/testID and call onLongPress ────────────
-        if (label) {
+        if (label && x === undefined && y === undefined) {
           const jsLabel = JSON.stringify(label);
-          let evaluationFailed = false;
           const pressed = await ctx.evalInApp(`
             (function() {
               ${FIBER_ROOT_JS}
               ${FIND_AND_INVOKE_JS}
               return findAndInvoke(${jsLabel}, 'onLongPress');
             })()
-          `).catch(() => {
-            evaluationFailed = true;
-            return false;
-          });
+          `);
           if (pressed) return `Long pressed "${label}"`;
-          if (evaluationFailed) return `Could not evaluate the connected app while long pressing "${label}".`;
         }
 
         // ── Coordinate fallbacks ──────────────────────────────────────────────
         if (x !== undefined && y !== undefined) {
           const target = await resolveTarget(platform);
           if (!target) return 'No simulator/emulator detected.';
-          const p = target.platform;
-          if (p === 'android') {
-            await ctx.exec(`${adbPrefix(target.id)} shell input swipe ${x} ${y} ${x} ${y} ${duration}`);
-            return `Long pressed at (${x}, ${y}) for ${duration}ms`;
-          }
-          if (!(await isIDBAvailable())) {
-            return `Coordinate long press requires IDB on iOS. ${IDB_INSTALL}`;
-          }
-          await ctx.exec(`idb ui long-press ${x} ${y} --duration ${duration / 1000} --udid "${target.id}"`);
-          return `Long pressed at (${x}, ${y}) for ${duration}ms`;
+          const dispatch = await nativeInput.longPress(target, x, y, duration);
+          return nativeResult(`Long pressed at (${x}, ${y}) for ${duration}ms`, dispatch);
         }
 
         return label
@@ -324,7 +235,7 @@ export const uiInteractPlugin = definePlugin({
 
     ctx.registerTool('swipe', {
       description:
-        'Swipe or scroll in a direction. Tries CDP ScrollView scrollTo, then adb/IDB.',
+        'Scroll through React, then use installed SimView or IDB on iOS and the selected ADB serial on Android. Native results identify the backend and dispatch state.',
       annotations: { destructiveHint: false },
       parameters: z.object({
         direction: z.enum(['up', 'down', 'left', 'right']).describe('Swipe direction'),
@@ -335,7 +246,6 @@ export const uiInteractPlugin = definePlugin({
 
         // ── CDP: find ScrollView and invoke scrollTo on its native node ────────
         const jsDir = JSON.stringify(direction);
-        let evaluationFailed = false;
         const scrolled = await ctx.evalInApp(`
           (function() {
             ${FIBER_ROOT_JS}
@@ -362,45 +272,30 @@ export const uiInteractPlugin = definePlugin({
             if (!hf || !hf.stateNode) return false;
             var node = hf.stateNode;
             var delta = 400;
-            try {
-              if (typeof node.scrollTo === 'function') {
-                node.scrollTo({
-                  x: dir === 'left' ? delta : dir === 'right' ? -delta : 0,
-                  y: dir === 'up' ? delta : dir === 'down' ? -delta : 0,
-                  animated: true,
-                });
-                return true;
-              }
-              if (typeof node.scrollToOffset === 'function') {
-                node.scrollToOffset({ offset: dir === 'up' ? delta : 0, animated: true });
-                return true;
-              }
-            } catch(e) {}
+            if (typeof node.scrollTo === 'function') {
+              node.scrollTo({
+                x: dir === 'left' ? delta : dir === 'right' ? -delta : 0,
+                y: dir === 'up' ? delta : dir === 'down' ? -delta : 0,
+                animated: true,
+              });
+              return true;
+            }
+            if (typeof node.scrollToOffset === 'function') {
+              node.scrollToOffset({ offset: dir === 'up' ? delta : 0, animated: true });
+              return true;
+            }
             return false;
           })()
-        `).catch(() => {
-          evaluationFailed = true;
-          return false;
-        });
+        `);
         if (scrolled) result = `Swiped ${direction}`;
-        if (evaluationFailed) return 'Could not evaluate the connected app while swiping.';
 
         if (!result) {
           const target = await resolveTarget(platform);
           if (!target) return 'No simulator/emulator detected.';
-          const p = target.platform;
-          // ── Native fallbacks (fixed midpoint coordinates) ───────────────────
-          const [sx, sy, ex, ey] = SWIPE_COORDS[direction];
-
-          if (p === 'android') {
-            await ctx.exec(`${adbPrefix(target.id)} shell input swipe ${sx} ${sy} ${ex} ${ey} 300`);
-            result = `Swiped ${direction}`;
-          } else if (!(await isIDBAvailable())) {
-            return `Swipe requires IDB on iOS. ${IDB_INSTALL}`;
-          } else {
-            await ctx.exec(`idb ui swipe ${sx} ${sy} ${ex} ${ey} --udid "${target.id}"`);
-            result = `Swiped ${direction}`;
-          }
+          // ── Native fallback using current device geometry ───────────────────
+          const dispatch = await nativeInput.swipeDirection(target, direction, 300);
+          result = nativeResult(`Swiped ${direction}`, dispatch);
+          if (dispatch.status !== 'handled') return result;
         }
 
         // ── Log to test recorder if a recording is active ─────────────────────
@@ -429,104 +324,33 @@ export const uiInteractPlugin = definePlugin({
         platform: z.enum(['ios', 'android', 'auto']).default('auto'),
       }),
       handler: async ({ button, platform }) => {
-        // ENTER and DELETE first try the connected app handler. This path only
-        // needs CDP and must work when no local native inventory is available.
-        if (button === 'ENTER') {
-          let evaluationFailed = false;
-          const submitted = await ctx.evalInApp(`
-            (function() {
-              ${FIBER_ROOT_JS}
-              var target = null;
-              var stack = [{ f: rootFiber, d: 0 }];
-              while (stack.length && !target) {
-                var item = stack.pop();
-                var fiber = item.f; var depth = item.d;
-                if (!fiber || depth > 200) continue;
-                var name = typeof fiber.type === 'string' ? fiber.type :
-                           (fiber.type && (fiber.type.displayName || fiber.type.name));
-                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onSubmitEditing) target = fiber;
-                if (!target) {
-                  if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
-                  if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
-                }
+        // ── ENTER/DELETE: bounded CDP handler on every platform ───────────────
+        if (button === 'ENTER' || button === 'DELETE') {
+          const handler = button === 'ENTER' ? 'onSubmitEditing' : 'onChangeText';
+          const handled = await ctx.evalInApp(buildFiberReadExpression(`
+            var handled = false;
+            metroWalkFibers(FIBER_OPTIONS, function(fiber) {
+              if (handled || metroFiberName(fiber) !== 'TextInput') return;
+              var props = fiber.memoizedProps || {};
+              if (typeof props[${JSON.stringify(handler)}] !== 'function') return;
+              if (${JSON.stringify(button)} === 'ENTER') {
+                props.onSubmitEditing({ nativeEvent: { text: props.value || '' } });
+              } else {
+                props.onChangeText(String(props.value || '').slice(0, -1));
               }
-              if (!target) return false;
-              target.memoizedProps.onSubmitEditing({ nativeEvent: { text: target.memoizedProps.value || '' } });
-              return true;
-            })()
-          `).catch(() => {
-            evaluationFailed = true;
-            return false;
-          });
-          if (submitted) return 'Pressed ENTER';
-          if (evaluationFailed) return 'Could not evaluate the connected app while pressing ENTER.';
-        }
-
-        if (button === 'DELETE') {
-          let evaluationFailed = false;
-          const deleted = await ctx.evalInApp(`
-            (function() {
-              ${FIBER_ROOT_JS}
-              var target = null;
-              var stack = [{ f: rootFiber, d: 0 }];
-              while (stack.length && !target) {
-                var item = stack.pop();
-                var fiber = item.f; var depth = item.d;
-                if (!fiber || depth > 200) continue;
-                var name = typeof fiber.type === 'string' ? fiber.type :
-                           (fiber.type && (fiber.type.displayName || fiber.type.name));
-                if (name === 'TextInput' && fiber.memoizedProps && fiber.memoizedProps.onChangeText) target = fiber;
-                if (!target) {
-                  if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
-                  if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
-                }
-              }
-              if (!target) return false;
-              var val = (target.memoizedProps.value || '').slice(0, -1);
-              target.memoizedProps.onChangeText(val);
-              return true;
-            })()
-          `).catch(() => {
-            evaluationFailed = true;
-            return false;
-          });
-          if (deleted) return 'Pressed DELETE';
-          if (evaluationFailed) return 'Could not evaluate the connected app while pressing DELETE.';
+              handled = true;
+              return { prune: true };
+            });
+            return handled;
+          `, { maxDepth: MAX_FIBER_DEPTH, maxNodes: MAX_FIBER_NODES }));
+          if (handled) return `Pressed ${button}`;
         }
 
         const target = await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
-        const p = target.platform;
 
-        // ── Android: adb keycodes ─────────────────────────────────────────────
-        if (p === 'android') {
-          const keycodes: Record<string, number> = {
-            HOME: 3, BACK: 4, VOLUME_UP: 24, VOLUME_DOWN: 25,
-            POWER: 26, ENTER: 66, DELETE: 67,
-          };
-          await ctx.exec(`${adbPrefix(target.id)} shell input keyevent ${keycodes[button]}`);
-          return `Pressed ${button}`;
-        }
-
-        // ── iOS HOME: simctl (no IDB needed) ──────────────────────────────────
-        if (button === 'HOME') {
-          try {
-            await ctx.exec(
-              `xcrun simctl spawn "${target.id}" launchctl kickstart -k system/com.apple.SpringBoard 2>/dev/null`
-            );
-            return 'Pressed HOME';
-          } catch {}
-        }
-
-        // ── iOS fallback: IDB ─────────────────────────────────────────────────
-        if (!(await isIDBAvailable())) {
-          return `Button ${button} requires IDB on iOS. ${IDB_INSTALL}`;
-        }
-        const idbMap: Record<string, string> = {
-          HOME: 'HOME', VOLUME_UP: 'VOLUME_UP', VOLUME_DOWN: 'VOLUME_DOWN', POWER: 'LOCK', BACK: 'HOME',
-        };
-        await ctx.exec(`idb ui button ${idbMap[button] || button} --udid "${target.id}"`);
-        return `Pressed ${button}`;
+        const dispatch = await nativeInput.button(target, button);
+        return nativeResult(`Pressed ${button}`, dispatch);
       },
     });
   },

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -361,6 +361,10 @@ export const uiInteractPlugin = definePlugin({
               if (handled || metroFiberName(fiber) !== 'TextInput') return;
               var props = fiber.memoizedProps || {};
               if (typeof props[${JSON.stringify(handler)}] !== 'function') return;
+              // Uncontrolled inputs keep their authoritative text natively;
+              // their props.value may be absent or stale, so a synthetic
+              // handler would submit or delete the wrong value.
+              if (typeof props.value !== 'string') return;
               var current = fiber;
               var focused = false;
               var inspected = 0;
@@ -383,9 +387,9 @@ export const uiInteractPlugin = definePlugin({
               }
               if (!focused) return;
               if (${JSON.stringify(button)} === 'ENTER') {
-                props.onSubmitEditing({ nativeEvent: { text: props.value || '' } });
+                props.onSubmitEditing({ nativeEvent: { text: props.value } });
               } else {
-                props.onChangeText(String(props.value || '').slice(0, -1));
+                props.onChangeText(props.value.slice(0, -1));
               }
               handled = true;
               return { prune: true };

--- a/src/plugins/ui-interact.ts
+++ b/src/plugins/ui-interact.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'fs/promises';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 import {
@@ -12,7 +11,6 @@ import {
   buildFiberReadExpression,
 } from '../utils/fiber.js';
 import {
-  adbPrefix,
   discoverAndroidDevices,
   discoverBootedSimulators,
   getConnectedDeviceTarget,
@@ -165,34 +163,6 @@ export const uiInteractPlugin = definePlugin({
 
         const target = prepared ? prepared.target : await resolveTarget(platform);
         if (!target) return 'No simulator/emulator detected.';
-
-        // ── Android fallback: adb uiautomator ───────────────────────────────
-        if (target.platform === 'android') {
-          const tmpFile = '/tmp/metro-mcp-uidump.xml';
-          let content = '';
-          try {
-            await ctx.exec(
-              `${adbPrefix(target.id)} shell uiautomator dump /sdcard/uidump.xml && ${adbPrefix(target.id)} pull /sdcard/uidump.xml ${tmpFile} 2>/dev/null`
-            );
-            content = await readFile(tmpFile, 'utf8');
-          } finally {
-            await ctx.exec(`rm -f ${tmpFile}`).catch(() => {});
-          }
-          try {
-            const esc = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            const bounds = `"\\[(\\d+),(\\d+)\\]\\[(\\d+),(\\d+)\\]"`;
-            const match =
-              content.match(new RegExp(`text="${esc}"[^>]*bounds=${bounds}`, 'i')) ||
-              content.match(new RegExp(`content-desc="${esc}"[^>]*bounds=${bounds}`, 'i'));
-            if (match) {
-              const cx = Math.round((parseInt(match[1]) + parseInt(match[3])) / 2);
-              const cy = Math.round((parseInt(match[2]) + parseInt(match[4])) / 2);
-              await ctx.exec(`${adbPrefix(target.id)} shell input tap ${cx} ${cy}`);
-              return `Tapped "${label}" at (${cx}, ${cy})`;
-            }
-          } catch {}
-          return `Element "${label}" not found.`;
-        }
 
         const dispatch = await nativeInput.tapLabel(target, label);
         return nativeResult(`Tapped "${label}"`, dispatch);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -177,6 +177,44 @@ describe('scheduled reconnect takeover', () => {
     expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
   });
 
+  test('schedules a retry when the connection drops before a successful attempt settles', async () => {
+    type FakeTimer = { callback: () => void; delay: number; cancelled: boolean };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let resolveAttempt: ((connected: boolean) => void) | undefined;
+    let isConnected = true;
+    const controller = createReconnectController({
+      connect: () => new Promise<boolean>((resolve) => { resolveAttempt = resolve; }),
+      isConnected: () => isConnected,
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [500],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    const attempt = controller.connectNow();
+    await Promise.resolve();
+    // Model connectToTarget opening the socket, then CDP emitting
+    // `disconnected` before performConnectToMetro settles.
+    isConnected = false;
+    controller.schedule();
+    resolveAttempt?.(true);
+
+    await expect(attempt).resolves.toBe(false);
+    expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
+    expect(timers.find((timer) => !timer.cancelled)?.delay).toBe(500);
+  });
+
   test('keeps escalated backoff when a reconnect flaps before stability', async () => {
     type FakeTimer = {
       callback: () => void;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { createAppEvaluator } from './utils/evaluate-app.js';
+import { waitForConnectionUntil } from './server.js';
+
+describe('server connection deadlines', () => {
+  test('bounds an initial disconnected awaitPromise wait before source dispatch', async () => {
+    const methods: string[] = [];
+    let waits = 0;
+    const evaluate = createAppEvaluator({
+      send: async (method) => {
+        methods.push(method);
+        return { result: { value: undefined } };
+      },
+    }, {
+      ensureConnected: async (deadline) => {
+        const connected = await waitForConnectionUntil(
+          () => waits++ === 0
+            ? Promise.resolve(false)
+            : new Promise<boolean>(() => {}),
+          deadline,
+        );
+        if (!connected) {
+          await waitForConnectionUntil(
+            () => {
+              waits += 1;
+              return new Promise<boolean>(() => {});
+            },
+            deadline,
+          );
+        }
+      },
+      waitForReconnect: async () => {},
+      reconnect: async () => {},
+      isReconnecting: () => false,
+    });
+
+    const started = Date.now();
+    await expect(evaluate('globalThis.shouldNotRun = true;', {
+      awaitPromise: true,
+      timeout: 30,
+    })).rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(waits).toBe(2);
+    expect(methods.filter((method) => method === 'Runtime.evaluate')).toHaveLength(0);
+  });
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { createAppEvaluator } from './utils/evaluate-app.js';
-import { waitForConnectionUntil } from './server.js';
+import {
+  cancelScheduledReconnect,
+  createReconnectController,
+  waitForConnectionUntil,
+} from './server.js';
 
 describe('server connection deadlines', () => {
   test('bounds an initial disconnected awaitPromise wait before source dispatch', async () => {
@@ -42,5 +46,223 @@ describe('server connection deadlines', () => {
     expect(Date.now() - started).toBeLessThan(500);
     expect(waits).toBe(2);
     expect(methods.filter((method) => method === 'Runtime.evaluate')).toHaveLength(0);
+  });
+});
+
+describe('scheduled reconnect takeover', () => {
+  test('preempts a long backoff for a tool request and is idempotent', () => {
+    let scheduledCallback: (() => void) | undefined;
+    let scheduledDelay = 0;
+    let scheduledCancelled = false;
+    let attempts = 0;
+    const timers = {
+      clearTimeout() {
+        scheduledCancelled = true;
+      },
+    };
+    const state = { timer: null as ReturnType<typeof setTimeout> | null };
+    const timer = { callback: () => { attempts += 1; }, delay: 30_000 };
+    scheduledCallback = timer.callback;
+    scheduledDelay = timer.delay;
+    state.timer = timer as unknown as ReturnType<typeof setTimeout>;
+
+    expect(cancelScheduledReconnect(state, timers)).toBe(true);
+    expect(state.timer).toBeNull();
+    expect(scheduledCancelled).toBe(true);
+
+    // A concurrent tool request observes that the first request already
+    // claimed the scheduled retry and must not cancel or dispatch another one.
+    expect(cancelScheduledReconnect(state, timers)).toBe(false);
+    expect(scheduledDelay).toBe(30_000);
+
+    // Model a direct lifecycle.reconnect that starts immediately. The timer's
+    // callback is still present in the harness, but cancellation prevents it
+    // from starting a duplicate attempt after the on-demand one succeeds.
+    attempts += 1;
+    if (!scheduledCancelled) scheduledCallback?.();
+    expect(attempts).toBe(1);
+  });
+
+  test('retains one background retry when the tool deadline expires first', async () => {
+    type FakeTimer = {
+      callback: () => void;
+      delay: number;
+      cancelled: boolean;
+    };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let resolveAttempt: ((connected: boolean) => void) | undefined;
+    let attempts = 0;
+    const controller = createReconnectController({
+      connect: () => {
+        attempts += 1;
+        return new Promise<boolean>((resolve) => {
+          resolveAttempt = resolve;
+        });
+      },
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [30_000],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    controller.schedule();
+    const queued = timers[0]!;
+    expect(queued.delay).toBe(30_000);
+    const takeover = controller.connectNow();
+    expect(queued.cancelled).toBe(true);
+    // The caller can time out while the runtime-owned attempt continues.
+    const callerDeadline = Promise.race([
+      takeover,
+      Promise.resolve().then(() => {
+        throw new Error('App evaluation timed out');
+      }),
+    ]);
+    await expect(callerDeadline).rejects.toThrow('timed out');
+    resolveAttempt?.(false);
+    await expect(takeover).resolves.toBe(false);
+
+    expect(attempts).toBe(1);
+    expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
+    expect(timers.find((timer) => !timer.cancelled)?.delay).toBe(30_000);
+  });
+
+  test('shares a direct reconnect and schedules only one retry after failure', async () => {
+    type FakeTimer = { callback: () => void; delay: number; cancelled: boolean };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let resolveAttempt: ((connected: boolean) => void) | undefined;
+    let attempts = 0;
+    const controller = createReconnectController({
+      connect: () => {
+        attempts += 1;
+        return new Promise<boolean>((resolve) => {
+          resolveAttempt = resolve;
+        });
+      },
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [30_000],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    controller.schedule();
+    const first = controller.connectNow();
+    const second = controller.connectNow();
+    expect(first).toBe(second);
+    await Promise.resolve();
+    resolveAttempt?.(false);
+    await expect(first).resolves.toBe(false);
+    expect(attempts).toBe(1);
+    expect(timers.filter((timer) => !timer.cancelled)).toHaveLength(1);
+  });
+
+  test('keeps escalated backoff when a reconnect flaps before stability', async () => {
+    type FakeTimer = {
+      callback: () => void;
+      delay: number;
+      cancelled: boolean;
+    };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    const outcomes = [false, false, true];
+    const controller = createReconnectController({
+      connect: async () => outcomes.shift() ?? false,
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [500, 1000, 2000, 4000],
+      maxBurstAttempts: 4,
+      backgroundDelay: 30_000,
+    });
+
+    const fireNext = async (): Promise<void> => {
+      const timer = timers.find((candidate) => !candidate.cancelled);
+      expect(timer).toBeDefined();
+      timer!.cancelled = true;
+      timer!.callback();
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    };
+
+    controller.schedule();
+    expect(timers[0]?.delay).toBe(500);
+    await fireNext();
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(1000);
+    await fireNext();
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(2000);
+    await fireNext();
+
+    // The target reconnected, then flapped before the 5-second stability
+    // timer could reset the backoff. The next disconnect remains escalated.
+    controller.schedule();
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(4000);
+  });
+
+  test('does not reset escalated backoff for repeated foreground reconnects', async () => {
+    type FakeTimer = { callback: () => void; delay: number; cancelled: boolean };
+    const timers: FakeTimer[] = [];
+    const timerApi = {
+      setTimeout(callback: () => void, delay: number) {
+        const timer = { callback, delay, cancelled: false };
+        timers.push(timer);
+        return timer as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout(handle: ReturnType<typeof setTimeout>) {
+        (handle as unknown as FakeTimer).cancelled = true;
+      },
+    };
+    let attempts = 0;
+    const controller = createReconnectController({
+      connect: async () => {
+        attempts += 1;
+        return false;
+      },
+      isClosed: () => false,
+      timers: timerApi,
+      delays: [500],
+      maxBurstAttempts: 1,
+      backgroundDelay: 30_000,
+    });
+
+    controller.schedule();
+    const firstTimer = timers[0]!;
+    firstTimer.cancelled = true;
+    firstTimer.callback();
+    for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    expect(attempts).toBe(1);
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(30_000);
+
+    await expect(controller.connectNow()).resolves.toBe(false);
+    await expect(controller.connectNow()).resolves.toBe(false);
+    expect(attempts).toBe(3);
+    expect(timers.filter((timer) => !timer.cancelled).at(-1)?.delay).toBe(30_000);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -694,6 +694,7 @@ export async function createMetroRuntime(
         const { stdout } = await execFileAsync(command, args, {
           encoding: 'buffer',
           maxBuffer: options?.maxBuffer,
+          timeout: options?.timeout,
         });
         return Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout);
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -800,6 +800,7 @@ export async function createMetroRuntime(
       },
       format: formatUtils,
       getActiveDeviceKey: () => activeDeviceKey,
+      getRuntimeGeneration: () => runtimeGeneration,
       getActiveDeviceName: () => activeDeviceName,
       notifyResourceUpdated,
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -243,6 +243,7 @@ export async function createMetroRuntime(
   const MAX_BURST_ATTEMPTS = 15; // fast retries; after this, switch to slow background probe
   let reconnectAttempts = 0;
   let isReconnecting = false;
+  let runtimeGeneration = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectStabilityTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -309,6 +310,7 @@ export async function createMetroRuntime(
 
   // Enable required CDP domains on every connection (initial and reconnect).
   cdpSession.on('reconnected', async () => {
+    runtimeGeneration++;
     isReconnecting = false;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
@@ -327,6 +329,7 @@ export async function createMetroRuntime(
 
   // Drive all reconnection through connectToMetro() so we always get a fresh target URL.
   cdpSession.on('disconnected', () => {
+    runtimeGeneration++;
     clearReconnectStabilityTimer();
     cleanProxyLock();
     scheduleReconnect();
@@ -338,6 +341,7 @@ export async function createMetroRuntime(
   // Metro fires 'bundle_build_done' once the new bundle is ready to run.
   eventsClient.on('bundle_build_done', async () => {
     if (!cdpSession.isConnected) return;
+    runtimeGeneration++;
     logger.info('Metro bundle rebuilt — re-enabling CDP domains');
     await enableCDPDomains();
   });
@@ -392,6 +396,7 @@ export async function createMetroRuntime(
       },
       waitForReconnect,
       isReconnecting: () => isReconnecting,
+      getGeneration: () => runtimeGeneration,
       reconnect: async () => {
         reconnectAttempts = 0;
         await connectToMetro();

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,12 +136,117 @@ export interface ReconnectWaitTimers {
   clearTimeout(handle: ReturnType<typeof setTimeout>): void;
 }
 
+export interface ReconnectTimerState {
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+export interface ReconnectController {
+  schedule(): void;
+  connectNow(): Promise<boolean>;
+  cancelScheduled(): boolean;
+  isReconnecting(): boolean;
+  resetBackoff(): void;
+}
+
+interface ReconnectControllerOptions {
+  connect: () => Promise<boolean>;
+  isClosed: () => boolean;
+  timers?: Pick<ReconnectWaitTimers, 'setTimeout' | 'clearTimeout'>;
+  delays?: readonly number[];
+  maxBurstAttempts?: number;
+  backgroundDelay?: number;
+  onSchedule?: (delay: number, attempt: number) => void;
+}
+
 const reconnectWaitTimers: ReconnectWaitTimers = {
   setInterval,
   clearInterval,
   setTimeout,
   clearTimeout,
 };
+
+/**
+ * Cancel a background reconnect that has not started connecting yet.
+ *
+ * Keeping the timer separate from the active-attempt state lets an on-demand
+ * tool request take over a long backoff immediately. The null check also makes
+ * concurrent callers idempotent: only the first caller can claim the timer.
+ */
+export function cancelScheduledReconnect(
+  state: ReconnectTimerState,
+  timers: Pick<ReconnectWaitTimers, 'clearTimeout'> = reconnectWaitTimers,
+): boolean {
+  if (state.timer === null) return false;
+  timers.clearTimeout(state.timer);
+  state.timer = null;
+  return true;
+}
+
+/**
+ * Own reconnect scheduling independently of any caller waiting on an attempt.
+ * A deadline-bounded caller may stop awaiting connectNow(), but the runtime
+ * still observes the result and keeps background recovery alive.
+ */
+export function createReconnectController(
+  options: ReconnectControllerOptions,
+): ReconnectController {
+  const timers = options.timers ?? reconnectWaitTimers;
+  const delays = options.delays ?? [500, 1000, 2000, 4000, 8000, 16000];
+  const maxBurstAttempts = options.maxBurstAttempts ?? 15;
+  const backgroundDelay = options.backgroundDelay ?? 30000;
+  const timerState: ReconnectTimerState = { timer: null };
+  let attempts = 0;
+  let activeAttempt: Promise<boolean> | null = null;
+
+  const cancelScheduled = (): boolean =>
+    cancelScheduledReconnect(timerState, timers);
+
+  const schedule = (): void => {
+    if (options.isClosed() || timerState.timer !== null || activeAttempt) return;
+    const delay = attempts < maxBurstAttempts
+      ? delays[Math.min(attempts, delays.length - 1)]!
+      : backgroundDelay;
+    attempts++;
+    options.onSchedule?.(delay, attempts);
+    timerState.timer = timers.setTimeout(() => {
+      timerState.timer = null;
+      void connectNow().catch(() => {});
+    }, delay);
+  };
+
+  const connectNow = (): Promise<boolean> => {
+    cancelScheduled();
+    if (activeAttempt) return activeAttempt;
+    const rawAttempt = Promise.resolve().then(options.connect);
+    let ownedAttempt!: Promise<boolean>;
+    ownedAttempt = rawAttempt.then(
+      (connected) => {
+        // Clear active ownership before scheduling the next background retry;
+        // schedule() must be able to claim the newly available slot.
+        if (activeAttempt === ownedAttempt) activeAttempt = null;
+        if (!connected) schedule();
+        return connected;
+      },
+      (error) => {
+        if (activeAttempt === ownedAttempt) activeAttempt = null;
+        schedule();
+        throw error;
+      },
+    );
+    activeAttempt = ownedAttempt;
+    return ownedAttempt;
+  };
+
+  return {
+    schedule,
+    connectNow,
+    cancelScheduled,
+    isReconnecting: () => activeAttempt !== null,
+    resetBackoff: () => {
+      attempts = 0;
+    },
+  };
+}
 
 export function waitForReconnect(
   isReconnecting: () => boolean,
@@ -332,20 +437,16 @@ export async function createMetroRuntime(
   let activeDeviceName: string | null = null;
   let targetPin: MetroTargetPin | null = null;
 
-  // Server-side reconnect state — single source of truth for all reconnect logic.
-  // Start with a very short delay (500ms) to recover quickly from brief disconnects
-  // like hot reloads, then ramp up for longer outages.
-  const RECONNECT_DELAYS = [500, 1000, 2000, 4000, 8000, 16000];
   const RECONNECT_STABLE_MS = 5000;
-  const MAX_BURST_ATTEMPTS = 15; // fast retries; after this, switch to slow background probe
-  let reconnectAttempts = 0;
-  let isReconnecting = false;
+  let reconnectController: ReconnectController | null = null;
   let runtimeGeneration = 0;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectStabilityTimer: ReturnType<typeof setTimeout> | null = null;
 
   const waitForCurrentReconnect = (deadline?: number): Promise<void> =>
-    waitForReconnect(() => isReconnecting, deadline);
+    waitForReconnect(
+      () => reconnectController?.isReconnecting() ?? false,
+      deadline,
+    );
 
   function clearReconnectStabilityTimer(): void {
     if (reconnectStabilityTimer) {
@@ -396,17 +497,13 @@ export async function createMetroRuntime(
   // Enable required CDP domains on every connection (initial and reconnect).
   cdpSession.on('reconnected', async () => {
     runtimeGeneration++;
-    isReconnecting = false;
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    reconnectController?.cancelScheduled();
     await enableCDPDomains();
     clearReconnectStabilityTimer();
     reconnectStabilityTimer = setTimeout(() => {
       reconnectStabilityTimer = null;
       if (!runtimeClosed && cdpSession.isConnected) {
-        reconnectAttempts = 0;
+        reconnectController?.resetBackoff();
         logger.debug('CDP connection stable; reset reconnect backoff');
       }
     }, RECONNECT_STABLE_MS);
@@ -461,14 +558,20 @@ export async function createMetroRuntime(
     const evalInApp = createAppEvaluator(cdpSession, {
       ensureConnected: async (deadline?: number) => {
         if (!cdpSession.isConnected) {
-          if (isReconnecting) {
+          if (reconnectController?.isReconnecting()) {
             // A reconnect is already in flight — wait for it rather than
             // starting another one.
             await waitForCurrentReconnect(deadline);
+          } else if (reconnectController?.cancelScheduled()) {
+            // A background retry may be waiting behind a long backoff. An
+            // on-demand tool request should claim that retry and connect now,
+            // rather than consuming its shorter deadline waiting for the timer.
+            const connected = await waitForConnectionUntil(
+              () => connectToMetro(),
+              deadline,
+            );
+            if (!connected) scheduleReconnect();
           } else {
-            // Reset the attempt counter so the background scheduler can resume
-            // after this tool-triggered reconnect, rather than staying capped.
-            reconnectAttempts = 0;
             const connected = await waitForConnectionUntil(
               () => cdpSession.waitForConnection(),
               deadline,
@@ -488,10 +591,9 @@ export async function createMetroRuntime(
         }
       },
       waitForReconnect: waitForCurrentReconnect,
-      isReconnecting: () => isReconnecting,
+      isReconnecting: () => reconnectController?.isReconnecting() ?? false,
       getGeneration: () => runtimeGeneration,
       reconnect: async () => {
-        reconnectAttempts = 0;
         await connectToMetro();
       },
     });
@@ -840,12 +942,7 @@ export async function createMetroRuntime(
 
   // Connect to Metro — always re-discovers targets to get a fresh webSocketDebuggerUrl.
   // Idempotent: concurrent callers wait for the in-flight attempt to finish.
-  async function connectToMetro(): Promise<boolean> {
-    if (isReconnecting) {
-      await waitForCurrentReconnect();
-      return cdpSession.isConnected;
-    }
-    isReconnecting = true;
+  async function performConnectToMetro(): Promise<boolean> {
     try {
       const proxyEnabled = config.proxy?.enabled !== false;
 
@@ -932,40 +1029,25 @@ export async function createMetroRuntime(
     } catch (err) {
       logger.warn('Could not connect to Metro:', err);
       return false;
-    } finally {
-      isReconnecting = false;
     }
+  }
+
+  reconnectController = createReconnectController({
+    connect: performConnectToMetro,
+    isClosed: () => runtimeClosed,
+    onSchedule: (delay, attempt) => {
+      logger.info(`Reconnecting to Metro in ${delay}ms (attempt ${attempt})`);
+    },
+  });
+
+  async function connectToMetro(): Promise<boolean> {
+    return reconnectController!.connectNow();
   }
 
   // Schedule a reconnect with exponential backoff, driven from server.ts so we always
   // re-fetch a fresh target URL from Metro's /json endpoint.
   function scheduleReconnect(): void {
-    if (runtimeClosed) return;
-    if (reconnectTimer !== null || isReconnecting) return; // already scheduled or in progress
-
-    // Use exponential backoff for the initial burst, then fall back to a slow
-    // background probe so the server keeps trying indefinitely (e.g. app started
-    // long after the MCP server).
-    const delay =
-      reconnectAttempts < MAX_BURST_ATTEMPTS
-        ? RECONNECT_DELAYS[
-            Math.min(reconnectAttempts, RECONNECT_DELAYS.length - 1)
-          ]
-        : 30000;
-    reconnectAttempts++;
-    logger.info(
-      `Reconnecting to Metro in ${delay}ms (attempt ${reconnectAttempts})`,
-    );
-
-    isReconnecting = true;
-    reconnectTimer = setTimeout(async () => {
-      reconnectTimer = null;
-      isReconnecting = false;
-      const success = await connectToMetro();
-      if (!success) {
-        scheduleReconnect();
-      }
-    }, delay);
+    reconnectController?.schedule();
   }
 
   // CDP proxy for Chrome DevTools coexistence — started lazily on first connect.
@@ -1094,10 +1176,7 @@ export async function createMetroRuntime(
   function closeRuntime(): Promise<void> {
     if (runtimeClosePromise) return runtimeClosePromise;
     runtimeClosed = true;
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    reconnectController?.cancelScheduled();
     clearReconnectStabilityTimer();
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);

--- a/src/server.ts
+++ b/src/server.ts
@@ -302,6 +302,9 @@ export async function createMetroRuntime(
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectStabilityTimer: ReturnType<typeof setTimeout> | null = null;
 
+  const waitForCurrentReconnect = (deadline?: number): Promise<void> =>
+    waitForReconnect(() => isReconnecting, deadline);
+
   function clearReconnectStabilityTimer(): void {
     if (reconnectStabilityTimer) {
       clearTimeout(reconnectStabilityTimer);
@@ -419,7 +422,7 @@ export async function createMetroRuntime(
           if (isReconnecting) {
             // A reconnect is already in flight — wait for it rather than
             // starting another one.
-            await waitForReconnect(() => isReconnecting, deadline);
+            await waitForCurrentReconnect(deadline);
           } else {
             // Reset the attempt counter so the background scheduler can resume
             // after this tool-triggered reconnect, rather than staying capped.
@@ -434,8 +437,7 @@ export async function createMetroRuntime(
           );
         }
       },
-      waitForReconnect: (deadline?: number) =>
-        waitForReconnect(() => isReconnecting, deadline),
+      waitForReconnect: waitForCurrentReconnect,
       isReconnecting: () => isReconnecting,
       getGeneration: () => runtimeGeneration,
       reconnect: async () => {
@@ -790,7 +792,7 @@ export async function createMetroRuntime(
   // Idempotent: concurrent callers wait for the in-flight attempt to finish.
   async function connectToMetro(): Promise<boolean> {
     if (isReconnecting) {
-      await waitForReconnect(() => isReconnecting);
+      await waitForCurrentReconnect();
       return cdpSession.isConnected;
     }
     isReconnecting = true;

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,6 @@ import type {
   ResourceConfig,
   AppResourceConfig,
   PromptConfig,
-  EvalOptions,
 } from './plugin.js';
 import {
   CDPSession,
@@ -47,7 +46,7 @@ import type { MetroTarget } from 'metro-bridge';
 import { MetroEventsClient } from './metro/events.js';
 import { createLogger } from './utils/logger.js';
 import { createFormatUtils } from './utils/format.js';
-import { extractCDPExceptionMessage } from './utils/cdp.js';
+import { createAppEvaluator } from './utils/evaluate-app.js';
 import { createPreferredFrameSizeMeta, withAppSizing } from './utils/apps.js';
 import { ResourceSubscriptionManager } from './utils/resource-subscriptions.js';
 import { createResourceUpdateScheduler } from './utils/resource-updates.js';
@@ -370,6 +369,34 @@ export async function createMetroRuntime(
     cfg: Required<MetroMCPConfig>,
   ): PluginContext {
     const pluginLogger = createLogger(plugin.name);
+    const evalInApp = createAppEvaluator(cdpSession, {
+      ensureConnected: async () => {
+        if (!cdpSession.isConnected) {
+          if (isReconnecting) {
+            // A reconnect is already in flight — wait for it rather than
+            // starting another one.
+            await waitForReconnect();
+          } else {
+            // Reset the attempt counter so the background scheduler can resume
+            // after this tool-triggered reconnect, rather than staying capped.
+            reconnectAttempts = 0;
+            const connected = await cdpSession.waitForConnection();
+            if (!connected) await connectToMetro();
+          }
+        }
+        if (!cdpSession.isConnected) {
+          throw new Error(
+            'Not connected to Metro. Use list_devices to check connection status.',
+          );
+        }
+      },
+      waitForReconnect,
+      isReconnecting: () => isReconnecting,
+      reconnect: async () => {
+        reconnectAttempts = 0;
+        await connectToMetro();
+      },
+    });
     return {
       cdp: cdpSession,
       events: eventsClient,
@@ -541,61 +568,7 @@ export async function createMetroRuntime(
           pluginLogger.error(`Failed to register prompt ${name}:`, err);
         }
       },
-      evalInApp: async (expression: string, options?: EvalOptions) => {
-        async function tryEval() {
-          if (!cdpSession.isConnected) {
-            if (isReconnecting) {
-              // A reconnect is already in flight — wait for it rather than starting another
-              await waitForReconnect();
-            } else {
-              // Reset the attempt counter so the background scheduler can resume
-              // after this tool-triggered reconnect, rather than staying capped out.
-              reconnectAttempts = 0;
-              const connected = await cdpSession.waitForConnection();
-              if (!connected) await connectToMetro();
-            }
-          }
-          if (!cdpSession.isConnected) {
-            throw new Error(
-              'Not connected to Metro. Use list_devices to check connection status.',
-            );
-          }
-          const result = (await cdpSession.send('Runtime.evaluate', {
-            expression,
-            returnByValue: true,
-            awaitPromise: options?.awaitPromise ?? false,
-            timeout: options?.timeout,
-          })) as Record<string, unknown>;
-          if (result.exceptionDetails) {
-            throw new Error(
-              extractCDPExceptionMessage(
-                result.exceptionDetails as Record<string, unknown>,
-              ),
-            );
-          }
-          return (result.result as Record<string, unknown>).value;
-        }
-        try {
-          return await tryEval();
-        } catch (err) {
-          if (
-            err instanceof Error &&
-            (err.message === 'WebSocket closed' ||
-              err.message === 'Not connected to CDP target' ||
-              err.message ===
-                'Not connected to Metro. Use list_devices to check connection status.')
-          ) {
-            if (isReconnecting) {
-              await waitForReconnect();
-            } else {
-              reconnectAttempts = 0;
-              await connectToMetro();
-            }
-            return await tryEval();
-          }
-          throw err;
-        }
-      },
+      evalInApp,
       config: cfg as unknown as Record<string, unknown>,
       logger: pluginLogger,
       metro: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -184,6 +184,48 @@ export function waitForReconnect(
   });
 }
 
+/**
+ * Wait for an in-flight CDP connection without allowing it to outlive the
+ * caller's evaluation deadline. The underlying connection attempt cannot be
+ * cancelled, so consume its eventual result while clearing the only timer we
+ * own when either side settles.
+ */
+export function waitForConnectionUntil(
+  waitForConnection: () => Promise<boolean>,
+  deadline?: number,
+  timers: ReconnectWaitTimers = reconnectWaitTimers,
+): Promise<boolean> {
+  if (deadline === undefined) return waitForConnection();
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return Promise.reject(new Error('App evaluation timed out'));
+
+  return new Promise<boolean>((resolve, reject) => {
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = timers.setTimeout(
+      () => {
+        deadlineTimer = null;
+        reject(new Error('App evaluation timed out'));
+      },
+      remaining,
+    );
+    void waitForConnection().then(
+      (connected) => {
+        if (deadlineTimer) {
+          timers.clearTimeout(deadlineTimer);
+          deadlineTimer = null;
+        }
+        resolve(connected);
+      },
+      (error) => {
+        if (deadlineTimer) {
+          timers.clearTimeout(deadlineTimer);
+          deadlineTimer = null;
+        }
+        reject(error);
+      },
+    );
+  });
+}
+
 type RuntimeRegistration = (server: McpServer) => { remove: () => void };
 
 interface McpSession {
@@ -427,8 +469,16 @@ export async function createMetroRuntime(
             // Reset the attempt counter so the background scheduler can resume
             // after this tool-triggered reconnect, rather than staying capped.
             reconnectAttempts = 0;
-            const connected = await cdpSession.waitForConnection();
-            if (!connected) await connectToMetro();
+            const connected = await waitForConnectionUntil(
+              () => cdpSession.waitForConnection(),
+              deadline,
+            );
+            if (!connected) {
+              await waitForConnectionUntil(() => connectToMetro(), deadline);
+            }
+          }
+          if (deadline !== undefined && Date.now() >= deadline) {
+            throw new Error('App evaluation timed out');
           }
         }
         if (!cdpSession.isConnected) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -786,6 +786,7 @@ export async function createMetroRuntime(
         const { stdout } = await execFileAsync(command, args, {
           encoding: 'buffer',
           maxBuffer: options?.maxBuffer,
+          timeout: options?.timeout,
         });
         return Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout);
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -150,6 +150,8 @@ export interface ReconnectController {
 
 interface ReconnectControllerOptions {
   connect: () => Promise<boolean>;
+  /** Verify that a successful attempt is still connected when it settles. */
+  isConnected?: () => boolean;
   isClosed: () => boolean;
   timers?: Pick<ReconnectWaitTimers, 'setTimeout' | 'clearTimeout'>;
   delays?: readonly number[];
@@ -221,11 +223,17 @@ export function createReconnectController(
     let ownedAttempt!: Promise<boolean>;
     ownedAttempt = rawAttempt.then(
       (connected) => {
+        // A CDP connection can open and emit `reconnected`, then close again
+        // before the owning connect operation settles. Treat that attempt as
+        // failed so its disconnected event cannot be lost behind
+        // activeAttempt ownership.
+        const settledConnected = connected &&
+          (options.isConnected?.() ?? true);
         // Clear active ownership before scheduling the next background retry;
         // schedule() must be able to claim the newly available slot.
         if (activeAttempt === ownedAttempt) activeAttempt = null;
-        if (!connected) schedule();
-        return connected;
+        if (!settledConnected) schedule();
+        return settledConnected;
       },
       (error) => {
         if (activeAttempt === ownedAttempt) activeAttempt = null;
@@ -1034,6 +1042,7 @@ export async function createMetroRuntime(
 
   reconnectController = createReconnectController({
     connect: performConnectToMetro,
+    isConnected: () => cdpSession.isConnected,
     isClosed: () => runtimeClosed,
     onSchedule: (delay, attempt) => {
       logger.info(`Reconnecting to Metro in ${delay}ms (attempt ${attempt})`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,6 +129,61 @@ const BUILT_IN_PLUGINS: PluginDefinition[] = [
   environmentPlugin,
 ];
 
+export interface ReconnectWaitTimers {
+  setInterval(callback: () => void, delay: number): ReturnType<typeof setInterval>;
+  clearInterval(handle: ReturnType<typeof setInterval>): void;
+  setTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout>;
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void;
+}
+
+const reconnectWaitTimers: ReconnectWaitTimers = {
+  setInterval,
+  clearInterval,
+  setTimeout,
+  clearTimeout,
+};
+
+export function waitForReconnect(
+  isReconnecting: () => boolean,
+  deadline?: number,
+  timers: ReconnectWaitTimers = reconnectWaitTimers,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (!isReconnecting()) {
+      resolve();
+      return;
+    }
+    let check: ReturnType<typeof setInterval> | null = null;
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    const finish = (error?: Error): void => {
+      if (check) {
+        timers.clearInterval(check);
+        check = null;
+      }
+      if (deadlineTimer) {
+        timers.clearTimeout(deadlineTimer);
+        deadlineTimer = null;
+      }
+      if (error) reject(error);
+      else resolve();
+    };
+    check = timers.setInterval(() => {
+      if (!isReconnecting()) finish();
+    }, 100);
+    if (deadline !== undefined) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        finish(new Error('App evaluation timed out'));
+        return;
+      }
+      deadlineTimer = timers.setTimeout(
+        () => finish(new Error('App evaluation timed out')),
+        remaining,
+      );
+    }
+  });
+}
+
 type RuntimeRegistration = (server: McpServer) => { remove: () => void };
 
 interface McpSession {
@@ -254,21 +309,6 @@ export async function createMetroRuntime(
     }
   }
 
-  function waitForReconnect(): Promise<void> {
-    return new Promise<void>((resolve) => {
-      if (!isReconnecting) {
-        resolve();
-        return;
-      }
-      const check = setInterval(() => {
-        if (!isReconnecting) {
-          clearInterval(check);
-          resolve();
-        }
-      }, 100);
-    });
-  }
-
   // Enable required CDP domains. Called on every CDP connection and after Metro
   // bundle rebuilds (fast refresh / hot reload resets Hermes domain registration).
   async function enableCDPDomains(): Promise<void> {
@@ -374,12 +414,12 @@ export async function createMetroRuntime(
   ): PluginContext {
     const pluginLogger = createLogger(plugin.name);
     const evalInApp = createAppEvaluator(cdpSession, {
-      ensureConnected: async () => {
+      ensureConnected: async (deadline?: number) => {
         if (!cdpSession.isConnected) {
           if (isReconnecting) {
             // A reconnect is already in flight — wait for it rather than
             // starting another one.
-            await waitForReconnect();
+            await waitForReconnect(() => isReconnecting, deadline);
           } else {
             // Reset the attempt counter so the background scheduler can resume
             // after this tool-triggered reconnect, rather than staying capped.
@@ -394,7 +434,8 @@ export async function createMetroRuntime(
           );
         }
       },
-      waitForReconnect,
+      waitForReconnect: (deadline?: number) =>
+        waitForReconnect(() => isReconnecting, deadline),
       isReconnecting: () => isReconnecting,
       getGeneration: () => runtimeGeneration,
       reconnect: async () => {
@@ -749,7 +790,7 @@ export async function createMetroRuntime(
   // Idempotent: concurrent callers wait for the in-flight attempt to finish.
   async function connectToMetro(): Promise<boolean> {
     if (isReconnecting) {
-      await waitForReconnect();
+      await waitForReconnect(() => isReconnecting);
       return cdpSession.isConnected;
     }
     isReconnecting = true;

--- a/src/server.ts
+++ b/src/server.ts
@@ -201,6 +201,7 @@ export async function createMetroRuntime(
   const sessions = new Set<McpSession>();
   const modernStdioServers = new Set<McpServer>();
   const runtimeRegistrations: RuntimeRegistration[] = [];
+  const runtimeCleanups = new Set<() => void | Promise<void>>();
   const resourceSubscriptions = new ResourceSubscriptionManager();
   let isInitializingPlugins = false;
   let runtimeClosed = false;
@@ -567,6 +568,15 @@ export async function createMetroRuntime(
         } catch (err) {
           pluginLogger.error(`Failed to register prompt ${name}:`, err);
         }
+      },
+      registerCleanup: (callback) => {
+        let called = false;
+        const once = () => {
+          if (called) return;
+          called = true;
+          return callback();
+        };
+        runtimeCleanups.add(once);
       },
       evalInApp,
       config: cfg as unknown as Record<string, unknown>,
@@ -1021,6 +1031,15 @@ export async function createMetroRuntime(
         sessionsToClose.map((session) => session.server.close().catch(() => {})),
       );
       await stdioToClose?.close().catch(() => {});
+      const cleanups = [...runtimeCleanups];
+      runtimeCleanups.clear();
+      await Promise.all(cleanups.map(async (cleanup) => {
+        try {
+          await cleanup();
+        } catch (err) {
+          logger.warn('Plugin cleanup failed:', err);
+        }
+      }));
       eventsClient.disconnect();
       cleanProxyLock();
       await cdpMultiplexer?.stop().catch(() => {});

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -257,7 +257,7 @@ describe('async app read results', () => {
     let mailboxWriteAttempts = 0;
     let reconnects = 0;
     const evaluateWithDisconnect: PluginContext['evalInApp'] = async (expression, options) => {
-      if (expression.includes('state.value =')) {
+      if (expression.includes('state.unserializableValue = void 0;')) {
         mailboxWriteAttempts += 1;
         if (mailboxWriteAttempts === 1) throw new Error('transport disconnected');
       }
@@ -267,7 +267,7 @@ describe('async app read results', () => {
       try {
         return await evaluateWithDisconnect(expression, options);
       } catch (error) {
-        if (!expression.includes('state.value =')) throw error;
+        if (!expression.includes('state.unserializableValue = void 0;')) throw error;
         reconnects += 1;
         return evaluateWithDisconnect(expression, options);
       }

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import vm from 'node:vm';
 import type { PluginContext } from '../plugin.js';
-import { awaitAppResult } from './await-app-result.js';
+import {
+  awaitAppResult,
+  type AppEvaluationCompletion,
+  type AwaitAppResultOptions,
+} from './await-app-result.js';
 
 function hermesHarness() {
   // A VM context gives eval its own global object, so global var/function
@@ -12,7 +16,55 @@ function hermesHarness() {
     // Simulate CDP returnByValue ignoring awaitPromise, not JS-level awaiting.
     return result === undefined ? undefined : JSON.parse(JSON.stringify(result));
   };
-  return { runtime, evaluate };
+  const remoteObjects = new Map<string, unknown>();
+  const releasedGroups: string[] = [];
+  let nextObjectId = 0;
+  const evaluateScript = async (expression: string): Promise<AppEvaluationCompletion> => {
+    const result = new vm.Script(expression).runInContext(runtime);
+    if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
+      const objectId = `remote-${++nextObjectId}`;
+      remoteObjects.set(objectId, result);
+      return { objectId };
+    }
+    return { value: result };
+  };
+  const settleRemote = async (objectId: string, mailboxName: string) => {
+    const state = (runtime as Record<string, unknown>)[mailboxName] as Record<string, unknown>;
+    const result = remoteObjects.get(objectId);
+    if (result && typeof (result as Promise<unknown>).then === 'function') {
+      void Promise.resolve(result).then(
+        (value) => {
+          if (state) { state.value = value; state.status = 'fulfilled'; }
+        },
+        (error) => {
+          if (state) {
+            state.error = String(error && (error as Error).message || error);
+            state.status = 'rejected';
+          }
+        },
+      );
+    } else if (state) {
+      state.value = result;
+      state.status = 'fulfilled';
+    }
+    return true;
+  };
+  const awaitResult = (
+    expression: string,
+    timeout?: number,
+    options?: AwaitAppResultOptions,
+  ) => awaitAppResult(
+    evaluate,
+    expression,
+    timeout,
+    {
+      ...options,
+      evaluateScript,
+      settleRemote,
+      releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
+    },
+  );
+  return { runtime, evaluate, awaitResult, releasedGroups };
 }
 
 function userRuntimeKeys(runtime: vm.Context): string[] {
@@ -23,64 +75,73 @@ function userRuntimeKeys(runtime: vm.Context): string[] {
 
 describe('async app read results', () => {
   test('awaits a promise when CDP serializes the promise object', async () => {
-    const { runtime, evaluate } = hermesHarness();
+    const { runtime, evaluate, awaitResult } = hermesHarness();
     expect(await evaluate('Promise.resolve(42)', { awaitPromise: true })).toEqual(
       {},
     );
-    expect(await awaitAppResult(
-      evaluate,
+    expect(await awaitResult(
       'new Promise(resolve => setTimeout(() => resolve({ found: true }), 10))',
     )).toEqual({ found: true });
     expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('propagates rejected and synchronously thrown errors and cleans up', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    await expect(awaitAppResult(
-      evaluate,
+    const { runtime, awaitResult } = hermesHarness();
+    await expect(awaitResult(
       'Promise.reject(new Error("measurement failed"))',
     )).rejects.toThrow('measurement failed');
-    await expect(awaitAppResult(
-      evaluate,
+    await expect(awaitResult(
       '(() => { throw new Error("sync failure"); })()',
     )).rejects.toThrow('sync failure');
     expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('bounds pending reads and leaves expiry to the app after host deadline', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    await expect(awaitAppResult(
-      evaluate,
+    const { runtime, awaitResult, releasedGroups } = hermesHarness();
+    await expect(awaitResult(
       'new Promise(() => {})',
       30,
     )).rejects.toThrow('timed out');
     expect(userRuntimeKeys(runtime)).toHaveLength(1);
     expect(userRuntimeKeys(runtime)[0]).toStartWith('__METRO_MCP_ASYNC_');
+    expect(releasedGroups).toHaveLength(0); // Runtime.releaseObject handled the Promise
   });
 
   test('isolates concurrent reads and preserves undefined and null', async () => {
-    const { runtime, evaluate } = hermesHarness();
+    const { runtime, awaitResult } = hermesHarness();
     expect(await Promise.all([
-      awaitAppResult(evaluate, 'Promise.resolve(undefined)'),
-      awaitAppResult(evaluate, 'Promise.resolve(null)'),
-      awaitAppResult(evaluate, 'Promise.resolve(42)'),
+      awaitResult('Promise.resolve(undefined)'),
+      awaitResult('Promise.resolve(null)'),
+      awaitResult('Promise.resolve(42)'),
     ])).toEqual([undefined, null, 42]);
     expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('preserves script completion values and executes the source once', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    expect(await awaitAppResult(
-      evaluate,
+    const { runtime, awaitResult, releasedGroups } = hermesHarness();
+    expect(await awaitResult(
       `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
        Promise.resolve({ count: globalThis.evaluationCount, value: 7 });`,
     )).toEqual({ count: 1, value: 7 });
     expect(runtime).toMatchObject({ evaluationCount: 1 });
     expect(userRuntimeKeys(runtime)).toEqual(['evaluationCount']);
+    expect(releasedGroups).toHaveLength(0);
+  });
+
+  test('assimilates nested thenables and ignores repeated resolution', async () => {
+    const { awaitResult } = hermesHarness();
+    await expect(awaitResult(`({
+      then: function(resolve) {
+        resolve({ then: function(resolveNested) {
+          resolveNested('nested value');
+        }});
+        resolve('second value');
+      }
+    })`)).resolves.toBe('nested value');
   });
 
   test('can reconnect mailbox reads without replaying the source', async () => {
-    const { runtime, evaluate } = hermesHarness();
+    const { runtime, awaitResult, evaluate } = hermesHarness();
     let pollReads = 0;
     let transportRecovered = false;
     const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
@@ -94,8 +155,7 @@ describe('async app read results', () => {
 
     // The helper leaves retry policy to its polling evaluator. This models a
     // server reconnect that retries only a mailbox read after a lost transport.
-    await expect(awaitAppResult(
-      evaluate,
+    await expect(awaitResult(
       `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
        new Promise(resolve => setTimeout(() => resolve(globalThis.evaluationCount), 10));`,
       1000,
@@ -107,15 +167,12 @@ describe('async app read results', () => {
   });
 
   test('keeps global script declarations across awaited evaluations', async () => {
-    const { runtime, evaluate } = hermesHarness();
-    await expect(awaitAppResult(
-      evaluate,
-      'var persistedValue = 41; Promise.resolve(persistedValue);',
+    const { runtime, awaitResult } = hermesHarness();
+    await expect(awaitResult(
+      'let persistedValue = 41; class PersistedClass {} Promise.resolve(persistedValue);',
     )).resolves.toBe(41);
-    await expect(awaitAppResult(
-      evaluate,
-      'Promise.resolve(persistedValue + 1);',
+    await expect(awaitResult(
+      'Promise.resolve(persistedValue + (typeof PersistedClass === "function" ? 1 : 0));',
     )).resolves.toBe(42);
-    expect(runtime).toHaveProperty('persistedValue', 41);
   });
 });

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -34,7 +34,19 @@ function hermesHarness() {
     if (result && typeof (result as Promise<unknown>).then === 'function') {
       void Promise.resolve(result).then(
         (value) => {
-          if (state) { state.value = value; state.status = 'fulfilled'; }
+          if (state) {
+            state.unserializableValue = undefined;
+            if (typeof value === 'number') {
+              if (Number.isNaN(value)) state.unserializableValue = 'NaN';
+              else if (value === Infinity) state.unserializableValue = 'Infinity';
+              else if (value === -Infinity) state.unserializableValue = '-Infinity';
+              else if (Object.is(value, -0)) state.unserializableValue = '-0';
+            } else if (typeof value === 'bigint') {
+              state.unserializableValue = String(value) + 'n';
+            }
+            state.value = state.unserializableValue === undefined ? value : undefined;
+            state.status = 'fulfilled';
+          }
         },
         (error) => {
           if (state) {
@@ -122,6 +134,48 @@ describe('async app read results', () => {
       awaitResult('Promise.resolve(42)'),
     ])).toEqual([undefined, null, 42]);
     expect(userRuntimeKeys(runtime)).toEqual([]);
+  });
+
+  test('preserves unserializable values from remote Promise settlement', async () => {
+    const { awaitResult } = hermesHarness();
+    const cases: Array<[string, unknown]> = [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['-0', -0],
+      ['123456789012345678901234567890n', 123456789012345678901234567890n],
+    ];
+    for (const [source, expected] of cases) {
+      const actual = await awaitResult(`Promise.resolve(${source})`);
+      if (typeof expected === 'number' && Object.is(expected, -0)) {
+        expect(Object.is(actual, -0)).toBe(true);
+      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+        expect(Number.isNaN(actual)).toBe(true);
+      } else {
+        expect(actual).toBe(expected);
+      }
+    }
+  });
+
+  test('preserves unserializable synchronous awaited completions', async () => {
+    const { awaitResult } = hermesHarness();
+    const cases: Array<[string, unknown]> = [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['-0', -0],
+      ['123456789012345678901234567890n', 123456789012345678901234567890n],
+    ];
+    for (const [source, expected] of cases) {
+      const actual = await awaitResult(source);
+      if (typeof expected === 'number' && Object.is(expected, -0)) {
+        expect(Object.is(actual, -0)).toBe(true);
+      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+        expect(Number.isNaN(actual)).toBe(true);
+      } else {
+        expect(actual).toBe(expected);
+      }
+    }
   });
 
   test('preserves script completion values and executes the source once', async () => {

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, test } from 'bun:test';
+import vm from 'node:vm';
 import type { PluginContext } from '../plugin.js';
 import { awaitAppResult } from './await-app-result.js';
 
 function hermesHarness() {
-  const runtime = {};
+  // A VM context gives eval its own global object, so global var/function
+  // declarations behave like Runtime.evaluate across separate calls.
+  const runtime = vm.createContext({ setTimeout, clearTimeout });
   const evaluate: PluginContext['evalInApp'] = async (expression) => {
-    const result = new Function('globalThis', `return ${expression};`)(runtime);
+    const result = new vm.Script(expression).runInContext(runtime);
     // Simulate CDP returnByValue ignoring awaitPromise, not JS-level awaiting.
     return result === undefined ? undefined : JSON.parse(JSON.stringify(result));
   };
   return { runtime, evaluate };
+}
+
+function userRuntimeKeys(runtime: vm.Context): string[] {
+  return Object.getOwnPropertyNames(runtime).filter(
+    (name) => name !== 'setTimeout' && name !== 'clearTimeout',
+  );
 }
 
 describe('async app read results', () => {
@@ -22,7 +31,7 @@ describe('async app read results', () => {
       evaluate,
       'new Promise(resolve => setTimeout(() => resolve({ found: true }), 10))',
     )).toEqual({ found: true });
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
   test('propagates rejected and synchronously thrown errors and cleans up', async () => {
@@ -35,17 +44,18 @@ describe('async app read results', () => {
       evaluate,
       '(() => { throw new Error("sync failure"); })()',
     )).rejects.toThrow('sync failure');
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toEqual([]);
   });
 
-  test('bounds pending reads and deletes their mailbox', async () => {
+  test('bounds pending reads and leaves expiry to the app after host deadline', async () => {
     const { runtime, evaluate } = hermesHarness();
     await expect(awaitAppResult(
       evaluate,
       'new Promise(() => {})',
       30,
     )).rejects.toThrow('timed out');
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toHaveLength(1);
+    expect(userRuntimeKeys(runtime)[0]).toStartWith('__METRO_MCP_ASYNC_');
   });
 
   test('isolates concurrent reads and preserves undefined and null', async () => {
@@ -55,6 +65,57 @@ describe('async app read results', () => {
       awaitAppResult(evaluate, 'Promise.resolve(null)'),
       awaitAppResult(evaluate, 'Promise.resolve(42)'),
     ])).toEqual([undefined, null, 42]);
-    expect(Object.getOwnPropertyNames(runtime)).toEqual([]);
+    expect(userRuntimeKeys(runtime)).toEqual([]);
+  });
+
+  test('preserves script completion values and executes the source once', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    expect(await awaitAppResult(
+      evaluate,
+      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
+       Promise.resolve({ count: globalThis.evaluationCount, value: 7 });`,
+    )).toEqual({ count: 1, value: 7 });
+    expect(runtime).toMatchObject({ evaluationCount: 1 });
+    expect(userRuntimeKeys(runtime)).toEqual(['evaluationCount']);
+  });
+
+  test('can reconnect mailbox reads without replaying the source', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    let pollReads = 0;
+    let transportRecovered = false;
+    const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
+      pollReads += 1;
+      if (pollReads === 1) {
+        // A server-side poll wrapper reconnects, then retries this read.
+        transportRecovered = true;
+      }
+      return evaluate(expression, options);
+    };
+
+    // The helper leaves retry policy to its polling evaluator. This models a
+    // server reconnect that retries only a mailbox read after a lost transport.
+    await expect(awaitAppResult(
+      evaluate,
+      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
+       new Promise(resolve => setTimeout(() => resolve(globalThis.evaluationCount), 10));`,
+      1000,
+      { pollEvaluate },
+    )).resolves.toBe(1);
+    expect(runtime).toMatchObject({ evaluationCount: 1 });
+    expect(pollReads).toBeGreaterThan(1);
+    expect(transportRecovered).toBe(true);
+  });
+
+  test('keeps global script declarations across awaited evaluations', async () => {
+    const { runtime, evaluate } = hermesHarness();
+    await expect(awaitAppResult(
+      evaluate,
+      'var persistedValue = 41; Promise.resolve(persistedValue);',
+    )).resolves.toBe(41);
+    await expect(awaitAppResult(
+      evaluate,
+      'Promise.resolve(persistedValue + 1);',
+    )).resolves.toBe(42);
+    expect(runtime).toHaveProperty('persistedValue', 41);
   });
 });

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -170,6 +170,34 @@ describe('async app read results', () => {
     }
   });
 
+  test('returns a by-value primitive without a mailbox write or poll', async () => {
+    const { evaluate, evaluateScript } = hermesHarness();
+    const evaluatedExpressions: string[] = [];
+    const trackingEvaluate: PluginContext['evalInApp'] = async (source, options) => {
+      evaluatedExpressions.push(source);
+      return evaluate(source, options);
+    };
+
+    await expect(awaitAppResult(
+      trackingEvaluate,
+      '42',
+      1000,
+      {
+        evaluateScript: async (source) => {
+          expect(source).toBe('42');
+          return evaluateScript(source);
+        },
+      },
+    )).resolves.toBe(42);
+
+    expect(evaluatedExpressions).toHaveLength(2);
+    expect(evaluatedExpressions[0]).toContain("status: 'pending'");
+    expect(evaluatedExpressions[1]).toContain('delete root[');
+    expect(
+      evaluatedExpressions.some((source) => source.includes('status: state.status')),
+    ).toBe(false);
+  });
+
   test('preserves script completion values and executes the source once', async () => {
     const { runtime, awaitResult, releasedGroups } = hermesHarness();
     expect(await awaitResult(
@@ -244,51 +272,6 @@ describe('async app read results', () => {
     expect(runtime).toMatchObject({ evaluationCount: 1 });
     expect(pollReads).toBeGreaterThan(1);
     expect(transportRecovered).toBe(true);
-  });
-
-  test('retries a mailbox completion write without replaying the source', async () => {
-    const {
-      runtime,
-      evaluate,
-      evaluateScript,
-      settleRemote,
-      releasedGroups,
-    } = hermesHarness();
-    let mailboxWriteAttempts = 0;
-    let reconnects = 0;
-    const evaluateWithDisconnect: PluginContext['evalInApp'] = async (expression, options) => {
-      if (expression.includes('state.unserializableValue = void 0;')) {
-        mailboxWriteAttempts += 1;
-        if (mailboxWriteAttempts === 1) throw new Error('transport disconnected');
-      }
-      return evaluate(expression, options);
-    };
-    const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
-      try {
-        return await evaluateWithDisconnect(expression, options);
-      } catch (error) {
-        if (!expression.includes('state.unserializableValue = void 0;')) throw error;
-        reconnects += 1;
-        return evaluateWithDisconnect(expression, options);
-      }
-    };
-
-    await expect(awaitAppResult(
-      evaluateWithDisconnect,
-      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
-       globalThis.evaluationCount;`,
-      1000,
-      {
-        pollEvaluate,
-        evaluateScript,
-        settleRemote,
-        releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
-      },
-    )).resolves.toBe(1);
-    expect(runtime).toMatchObject({ evaluationCount: 1 });
-    expect(mailboxWriteAttempts).toBe(2);
-    expect(reconnects).toBe(1);
-    expect(releasedGroups).toHaveLength(0);
   });
 
   test('keeps global script declarations across awaited evaluations', async () => {

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -92,6 +92,24 @@ function userRuntimeKeys(runtime: vm.Context): string[] {
   );
 }
 
+const UNSERIALIZABLE_CASES: Array<[string, unknown]> = [
+  ['NaN', Number.NaN],
+  ['Infinity', Number.POSITIVE_INFINITY],
+  ['-Infinity', Number.NEGATIVE_INFINITY],
+  ['-0', -0],
+  ['123456789012345678901234567890n', 123456789012345678901234567890n],
+];
+
+function expectUnserializableValue(actual: unknown, expected: unknown): void {
+  if (typeof expected === 'number' && Object.is(expected, -0)) {
+    expect(Object.is(actual, -0)).toBe(true);
+  } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+    expect(Number.isNaN(actual)).toBe(true);
+  } else {
+    expect(actual).toBe(expected);
+  }
+}
+
 describe('async app read results', () => {
   test('awaits a promise when CDP serializes the promise object', async () => {
     const { runtime, evaluate, awaitResult } = hermesHarness();
@@ -138,43 +156,17 @@ describe('async app read results', () => {
 
   test('preserves unserializable values from remote Promise settlement', async () => {
     const { awaitResult } = hermesHarness();
-    const cases: Array<[string, unknown]> = [
-      ['NaN', Number.NaN],
-      ['Infinity', Number.POSITIVE_INFINITY],
-      ['-Infinity', Number.NEGATIVE_INFINITY],
-      ['-0', -0],
-      ['123456789012345678901234567890n', 123456789012345678901234567890n],
-    ];
-    for (const [source, expected] of cases) {
+    for (const [source, expected] of UNSERIALIZABLE_CASES) {
       const actual = await awaitResult(`Promise.resolve(${source})`);
-      if (typeof expected === 'number' && Object.is(expected, -0)) {
-        expect(Object.is(actual, -0)).toBe(true);
-      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
-        expect(Number.isNaN(actual)).toBe(true);
-      } else {
-        expect(actual).toBe(expected);
-      }
+      expectUnserializableValue(actual, expected);
     }
   });
 
   test('preserves unserializable synchronous awaited completions', async () => {
     const { awaitResult } = hermesHarness();
-    const cases: Array<[string, unknown]> = [
-      ['NaN', Number.NaN],
-      ['Infinity', Number.POSITIVE_INFINITY],
-      ['-Infinity', Number.NEGATIVE_INFINITY],
-      ['-0', -0],
-      ['123456789012345678901234567890n', 123456789012345678901234567890n],
-    ];
-    for (const [source, expected] of cases) {
+    for (const [source, expected] of UNSERIALIZABLE_CASES) {
       const actual = await awaitResult(source);
-      if (typeof expected === 'number' && Object.is(expected, -0)) {
-        expect(Object.is(actual, -0)).toBe(true);
-      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
-        expect(Number.isNaN(actual)).toBe(true);
-      } else {
-        expect(actual).toBe(expected);
-      }
+      expectUnserializableValue(actual, expected);
     }
   });
 

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -181,6 +181,33 @@ describe('async app read results', () => {
     expect(releasedGroups).toHaveLength(0);
   });
 
+  test('does not delay a settled result for stalled mailbox cleanup', async () => {
+    const { runtime, evaluate, awaitResult } = hermesHarness();
+    let cleanupStarted = false;
+    let finishCleanup: (() => void) | undefined;
+    const cleanupEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
+      cleanupStarted = true;
+      await new Promise<void>((resolve) => { finishCleanup = resolve; });
+      return evaluate(expression, options);
+    };
+    let resultSettled = false;
+    const result = awaitResult('Promise.resolve(42)', 1000, { cleanupEvaluate })
+      .then((value) => {
+        resultSettled = true;
+        return value;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    try {
+      expect(cleanupStarted).toBe(true);
+      expect(resultSettled).toBe(true);
+      await expect(result).resolves.toBe(42);
+    } finally {
+      finishCleanup?.();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(userRuntimeKeys(runtime)).toEqual([]);
+  });
+
   test('assimilates nested thenables and ignores repeated resolution', async () => {
     const { awaitResult } = hermesHarness();
     await expect(awaitResult(`({

--- a/src/utils/await-app-result.test.ts
+++ b/src/utils/await-app-result.test.ts
@@ -64,7 +64,14 @@ function hermesHarness() {
       releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
     },
   );
-  return { runtime, evaluate, awaitResult, releasedGroups };
+  return {
+    runtime,
+    evaluate,
+    evaluateScript,
+    settleRemote,
+    awaitResult,
+    releasedGroups,
+  };
 }
 
 function userRuntimeKeys(runtime: vm.Context): string[] {
@@ -164,6 +171,51 @@ describe('async app read results', () => {
     expect(runtime).toMatchObject({ evaluationCount: 1 });
     expect(pollReads).toBeGreaterThan(1);
     expect(transportRecovered).toBe(true);
+  });
+
+  test('retries a mailbox completion write without replaying the source', async () => {
+    const {
+      runtime,
+      evaluate,
+      evaluateScript,
+      settleRemote,
+      releasedGroups,
+    } = hermesHarness();
+    let mailboxWriteAttempts = 0;
+    let reconnects = 0;
+    const evaluateWithDisconnect: PluginContext['evalInApp'] = async (expression, options) => {
+      if (expression.includes('state.value =')) {
+        mailboxWriteAttempts += 1;
+        if (mailboxWriteAttempts === 1) throw new Error('transport disconnected');
+      }
+      return evaluate(expression, options);
+    };
+    const pollEvaluate: PluginContext['evalInApp'] = async (expression, options) => {
+      try {
+        return await evaluateWithDisconnect(expression, options);
+      } catch (error) {
+        if (!expression.includes('state.value =')) throw error;
+        reconnects += 1;
+        return evaluateWithDisconnect(expression, options);
+      }
+    };
+
+    await expect(awaitAppResult(
+      evaluateWithDisconnect,
+      `globalThis.evaluationCount = (globalThis.evaluationCount || 0) + 1;
+       globalThis.evaluationCount;`,
+      1000,
+      {
+        pollEvaluate,
+        evaluateScript,
+        settleRemote,
+        releaseObjectGroup: async (objectGroup) => { releasedGroups.push(objectGroup); },
+      },
+    )).resolves.toBe(1);
+    expect(runtime).toMatchObject({ evaluationCount: 1 });
+    expect(mailboxWriteAttempts).toBe(2);
+    expect(reconnects).toBe(1);
+    expect(releasedGroups).toHaveLength(0);
   });
 
   test('keeps global script declarations across awaited evaluations', async () => {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -102,6 +102,8 @@ export async function awaitPromiseBeforeDeadline<T>(
 }
 
 export interface AwaitAppResultOptions {
+  /** Absolute caller deadline shared by every awaited stage. */
+  deadline?: number;
   /**
    * Evaluation used for mailbox reads. This may reconnect before a read, but
    * must never replay the expression that created the mailbox.
@@ -186,7 +188,10 @@ export async function awaitAppResult(
   const mailboxName = `__METRO_MCP_ASYNC_${randomUUID()}`;
   const objectGroup = `__METRO_MCP_ASYNC_GROUP_${randomUUID()}`;
   const key = JSON.stringify(mailboxName);
-  const deadline = Date.now() + timeout;
+  const timeoutDeadline = Date.now() + timeout;
+  const deadline = options?.deadline === undefined
+    ? timeoutDeadline
+    : Math.min(timeoutDeadline, options.deadline);
   let sourceCompletedByValue = false;
   let remoteHandleReleased = false;
   let sourceEvaluation: Promise<AppEvaluationCompletion> | undefined;
@@ -194,15 +199,22 @@ export async function awaitAppResult(
 
   const releaseGroup = async (): Promise<void> => {
     if (!options?.releaseObjectGroup) return;
-    const releaseDeadline = Date.now() + 100;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return;
+    const releaseTimeout = Math.min(100, remaining);
+    const releaseDeadline = Date.now() + releaseTimeout;
     await awaitPromiseBeforeDeadline(
-      options.releaseObjectGroup(objectGroup, { timeout: 100 }),
+      options.releaseObjectGroup(objectGroup, { timeout: releaseTimeout }),
       releaseDeadline,
-      100,
+      releaseTimeout,
     ).catch(() => {});
   };
 
   try {
+    const mailboxLifetime = Math.max(
+      0,
+      Math.min(timeout, deadline - Date.now()),
+    ) + 1000;
     const mailboxSetup = `(function() {
       var state = { status: 'pending' };
       Object.defineProperty(globalThis, ${key}, {
@@ -210,7 +222,7 @@ export async function awaitAppResult(
       });
       state.timer = setTimeout(function() {
         if (globalThis[${key}] === state) delete globalThis[${key}];
-      }, ${timeout + 1000});
+      }, ${mailboxLifetime});
       return true;
     })()`;
     const mailboxGeneration = options?.setupMailbox

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -227,12 +227,41 @@ export async function awaitAppResult(
     ) + 1000;
     const mailboxSetup = `(function() {
       var root = this;
-      var PromiseCtor = root.Promise;
-      var state = {
-        status: 'pending',
-        promiseConstructor: PromiseCtor,
-        promiseResolve: PromiseCtor && PromiseCtor.resolve,
-        promiseThen: PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then
+      var state = { status: 'pending', observing: false };
+      function rejectionMessage(error) {
+        var message;
+        try {
+          if (error !== null && error !== undefined) message = error.message;
+        } catch (_) {}
+        if (message !== undefined && message !== null) {
+          try { return String(message); } catch (_) {}
+        }
+        try { return String(error); } catch (_) {}
+        return 'Promise rejected with an unstringifiable reason';
+      }
+      function fulfill(value) {
+        if (root[${key}] !== state) return;
+        state.unserializableValue = undefined;
+        if (typeof value === 'number') {
+          if (value !== value) state.unserializableValue = 'NaN';
+          else if (value === Infinity) state.unserializableValue = 'Infinity';
+          else if (value === -Infinity) state.unserializableValue = '-Infinity';
+          else if (value === 0 && 1 / value === -Infinity) state.unserializableValue = '-0';
+        } else if (typeof value === 'bigint') {
+          state.unserializableValue = String(value) + 'n';
+        }
+        state.value = state.unserializableValue === undefined ? value : undefined;
+        state.status = 'fulfilled';
+      }
+      function reject(error) {
+        if (root[${key}] !== state) return;
+        state.error = rejectionMessage(error);
+        state.status = 'rejected';
+      }
+      state.observe = async function(value) {
+        if (state.observing) return;
+        state.observing = true;
+        try { fulfill(await value); } catch (error) { reject(error); }
       };
       root.Object.defineProperty(root, ${key}, {
         value: state, configurable: true

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -213,9 +213,18 @@ export async function awaitAppResult(
         state.observing = true;
         try { fulfill(await value); } catch (error) { reject(error); }
       };
-      root.Object.defineProperty(root, ${key}, {
-        value: state, configurable: true
-      });
+      // Keep setup viable after the app replaces Object or defineProperty.
+      // With normal intrinsics, hide and protect the temporary mailbox as before.
+      var descriptor = {
+        value: state, configurable: true, enumerable: false, writable: false
+      };
+      try {
+        root.Reflect.defineProperty(root, ${key}, descriptor);
+      } catch (_) {}
+      if (root[${key}] !== state) {
+        try { root.Object.defineProperty(root, ${key}, descriptor); } catch (_) {}
+      }
+      if (root[${key}] !== state) root[${key}] = state;
       state.timer = root.setTimeout(function() {
         if (root[${key}] === state) delete root[${key}];
       }, ${mailboxLifetime});

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -18,8 +18,18 @@ export type AppEvaluationCompletion =
 
 type EvaluateScript = (
   expression: string,
-  options?: { timeout?: number; deadline?: number; objectGroup?: string },
+  options?: {
+    timeout?: number;
+    deadline?: number;
+    objectGroup?: string;
+    generation?: number;
+  },
 ) => Promise<AppEvaluationCompletion>;
+
+type SetupMailbox = (
+  expression: string,
+  options: { timeout?: number; deadline: number },
+) => Promise<number | undefined>;
 
 type SettleRemote = (
   objectId: string,
@@ -98,6 +108,45 @@ export interface AwaitAppResultOptions {
   settleRemote?: SettleRemote;
   /** Release handles if source evaluation completes after the host deadline. */
   releaseObjectGroup?: ReleaseObjectGroup;
+  /** Runtime generation captured after mailbox creation. */
+  getRuntimeGeneration?: () => number;
+  /** Create the mailbox while bracketing the dispatch with generation checks. */
+  setupMailbox?: SetupMailbox;
+}
+
+function decodeUnserializableValue(value: unknown): unknown {
+  if (value === 'NaN') return Number.NaN;
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
+  if (value === '-0') return -0;
+  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
+    return BigInt(value.slice(0, -1));
+  }
+  throw new Error('Unsupported CDP unserializable value');
+}
+
+function serializeCompletionValue(value: unknown): {
+  expression: string;
+  unserializableValue?: string;
+} {
+  if (value === undefined) return { expression: 'void 0' };
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) return { expression: 'void 0', unserializableValue: 'NaN' };
+    if (value === Number.POSITIVE_INFINITY) return { expression: 'void 0', unserializableValue: 'Infinity' };
+    if (value === Number.NEGATIVE_INFINITY) return { expression: 'void 0', unserializableValue: '-Infinity' };
+    if (Object.is(value, -0)) return { expression: 'void 0', unserializableValue: '-0' };
+  }
+  if (typeof value === 'bigint') {
+    return {
+      expression: 'void 0',
+      unserializableValue: `${value.toString()}n`,
+    };
+  }
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error('App evaluation result could not be serialized');
+  }
+  return { expression: serialized };
 }
 
 async function completeByValue(
@@ -106,16 +155,17 @@ async function completeByValue(
   value: unknown,
   options: { deadline: number; timeout: number },
 ): Promise<void> {
-  const serialized = value === undefined ? 'void 0' : JSON.stringify(value);
-  if (serialized === undefined) {
-    throw new Error('App evaluation result could not be serialized');
-  }
+  const serialized = serializeCompletionValue(value);
+  const unserializableValue = serialized.unserializableValue === undefined
+    ? 'void 0'
+    : JSON.stringify(serialized.unserializableValue);
   await evaluateBeforeDeadline(
     evaluate,
     `(function() {
       var state = globalThis[${key}];
       if (state) {
-        state.value = ${serialized};
+        state.unserializableValue = ${unserializableValue};
+        state.value = ${serialized.expression};
         state.status = 'fulfilled';
       }
     })()`,
@@ -157,7 +207,7 @@ export async function awaitAppResult(
   };
 
   try {
-    await evaluateBeforeDeadline(evaluate, `(function() {
+    const mailboxSetup = `(function() {
       var state = { status: 'pending' };
       Object.defineProperty(globalThis, ${key}, {
         value: state, configurable: true
@@ -166,7 +216,20 @@ export async function awaitAppResult(
         if (globalThis[${key}] === state) delete globalThis[${key}];
       }, ${timeout + 1000});
       return true;
-    })()`, { timeout, deadline }, timeout);
+    })()`;
+    const mailboxGeneration = options?.setupMailbox
+      ? await evaluateBeforeDeadline(
+        options.setupMailbox,
+        mailboxSetup,
+        { timeout, deadline },
+        timeout,
+      )
+      : await evaluateBeforeDeadline(
+        evaluate,
+        mailboxSetup,
+        { timeout, deadline },
+        timeout,
+      ).then(() => options?.getRuntimeGeneration?.());
 
     // Runtime.evaluate must receive the user's source itself. Indirect eval
     // runs in a separate variable environment and silently loses top-level
@@ -176,7 +239,12 @@ export async function awaitAppResult(
     let completion: AppEvaluationCompletion;
     if (options?.evaluateScript) {
       if (Date.now() >= deadline) throw timeoutError(timeout);
-      sourceEvaluation = options.evaluateScript(expression, { timeout, deadline, objectGroup });
+      sourceEvaluation = options.evaluateScript(expression, {
+        timeout,
+        deadline,
+        objectGroup,
+        generation: mailboxGeneration,
+      });
       sourceEvaluation.then(
         () => { sourceEvaluationSettled = true; },
         () => { sourceEvaluationSettled = true; },
@@ -213,14 +281,22 @@ export async function awaitAppResult(
         var state = globalThis[${key}];
         if (!state) return { status: 'missing' };
         return {
-          status: state.status, value: state.value, error: state.error
+          status: state.status,
+          value: state.value,
+          unserializableValue: state.unserializableValue,
+          error: state.error
         };
       })()`, { timeout: Math.max(1, deadline - Date.now()), deadline }, timeout) as {
         status: string;
         value?: unknown;
+        unserializableValue?: unknown;
         error?: string;
       };
-      if (result?.status === 'fulfilled') return result.value;
+      if (result?.status === 'fulfilled') {
+        return result.unserializableValue === undefined
+          ? result.value
+          : decodeUnserializableValue(result.unserializableValue);
+      }
       if (result?.status === 'rejected') throw new Error(result.error);
       if (!result || result.status !== 'pending') {
         throw new Error('App evaluation context was lost before measurement completed');

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -2,6 +2,46 @@ import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { PluginContext } from '../plugin.js';
 
+type Evaluate = PluginContext['evalInApp'];
+
+function timeoutError(timeout: number): Error {
+  return new Error(`App evaluation timed out after ${timeout}ms`);
+}
+
+async function evaluateBeforeDeadline(
+  evaluate: Evaluate,
+  expression: string,
+  options: { timeout?: number; deadline: number },
+  timeout: number,
+): Promise<unknown> {
+  const remaining = options.deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(timeout);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const operation = evaluate(expression, {
+    timeout: Math.max(1, Math.min(options.timeout ?? remaining, remaining)),
+    deadline: options.deadline,
+  });
+  const deadlineReached = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
+  });
+  try {
+    return await Promise.race([operation, deadlineReached]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface AwaitAppResultOptions {
+  /**
+   * Evaluation used for mailbox reads. This may reconnect before a read, but
+   * must never replay the expression that created the mailbox.
+   */
+  pollEvaluate?: Evaluate;
+  /** Evaluation used to remove the mailbox during cleanup. */
+  cleanupEvaluate?: Evaluate;
+}
+
 /**
  * Await a read expression without relying on CDP's awaitPromise support.
  * Hermes can return a serialized JS Promise instead of its resolved value.
@@ -11,11 +51,14 @@ export async function awaitAppResult(
   evaluate: PluginContext['evalInApp'],
   expression: string,
   timeout = 10_000,
+  options?: AwaitAppResultOptions,
 ): Promise<unknown> {
+  const pollEvaluate = options?.pollEvaluate ?? evaluate;
+  const cleanupEvaluate = options?.cleanupEvaluate ?? evaluate;
   const key = JSON.stringify(`__METRO_MCP_ASYNC_${randomUUID()}`);
   const deadline = Date.now() + timeout;
   try {
-    await evaluate(`(function() {
+    await evaluateBeforeDeadline(evaluate, `(function() {
       var state = { status: 'pending' };
       Object.defineProperty(globalThis, ${key}, {
         value: state, configurable: true
@@ -28,22 +71,26 @@ export async function awaitAppResult(
         state.error = String(error && error.message || error);
       }
       try {
-        Promise.resolve(${expression}).then(function(value) {
+        // Evaluate the caller's source as a script so awaitPromise works for
+        // the same completion values as Runtime.evaluate (including multiple
+        // statements and declarations), rather than interpolating it into an
+        // expression. The source is evaluated exactly once before polling.
+        Promise.resolve((0, eval)(${JSON.stringify(expression)})).then(function(value) {
           state.value = value;
           state.status = 'fulfilled';
         }, reject);
       } catch (error) { reject(error); }
       return true;
-    })()`, { timeout });
+    })()`, { timeout, deadline }, timeout);
 
     while (Date.now() < deadline) {
-      const result = await evaluate(`(function() {
+      const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {
         var state = globalThis[${key}];
         if (!state) return { status: 'missing' };
         return {
           status: state.status, value: state.value, error: state.error
         };
-      })()`, { timeout: Math.max(1, deadline - Date.now()) }) as {
+      })()`, { timeout: Math.max(1, deadline - Date.now()), deadline }, timeout) as {
         status: string;
         value?: unknown;
         error?: string;
@@ -55,13 +102,16 @@ export async function awaitAppResult(
       }
       await delay(Math.min(25, Math.max(0, deadline - Date.now())));
     }
-    throw new Error(`App evaluation timed out after ${timeout}ms`);
+    throw timeoutError(timeout);
   } finally {
     // Also expires inside the app if the MCP process or CDP connection is lost.
-    await evaluate(`(function() {
-      var state = globalThis[${key}];
-      if (state) clearTimeout(state.timer);
-      delete globalThis[${key}];
-    })()`, { timeout: 1000 }).catch(() => {});
+    const remaining = deadline - Date.now();
+    if (remaining > 0) {
+      await evaluateBeforeDeadline(cleanupEvaluate, `(function() {
+        var state = globalThis[${key}];
+        if (state) clearTimeout(state.timer);
+        delete globalThis[${key}];
+      })()`, { timeout: Math.min(1000, remaining), deadline }, timeout).catch(() => {});
+    }
   }
 }

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -127,56 +127,6 @@ export interface AwaitAppResultOptions {
   setupMailbox?: SetupMailbox;
 }
 
-function serializeCompletionValue(value: unknown): {
-  expression: string;
-  unserializableValue?: string;
-} {
-  if (value === undefined) return { expression: 'void 0' };
-  if (typeof value === 'number') {
-    if (Number.isNaN(value)) return { expression: 'void 0', unserializableValue: 'NaN' };
-    if (value === Number.POSITIVE_INFINITY) return { expression: 'void 0', unserializableValue: 'Infinity' };
-    if (value === Number.NEGATIVE_INFINITY) return { expression: 'void 0', unserializableValue: '-Infinity' };
-    if (Object.is(value, -0)) return { expression: 'void 0', unserializableValue: '-0' };
-  }
-  if (typeof value === 'bigint') {
-    return {
-      expression: 'void 0',
-      unserializableValue: `${value.toString()}n`,
-    };
-  }
-  const serialized = JSON.stringify(value);
-  if (serialized === undefined) {
-    throw new Error('App evaluation result could not be serialized');
-  }
-  return { expression: serialized };
-}
-
-async function completeByValue(
-  evaluate: Evaluate,
-  key: string,
-  value: unknown,
-  options: { deadline: number; timeout: number },
-): Promise<void> {
-  const serialized = serializeCompletionValue(value);
-  const unserializableValue = serialized.unserializableValue === undefined
-    ? 'void 0'
-    : JSON.stringify(serialized.unserializableValue);
-  await evaluateBeforeDeadline(
-    evaluate,
-    `(function() {
-      var root = this;
-      var state = root[${key}];
-      if (state) {
-        state.unserializableValue = ${unserializableValue};
-        state.value = ${serialized.expression};
-        state.status = 'fulfilled';
-      }
-    })()`,
-    options,
-    options.timeout,
-  );
-}
-
 /**
  * Await a read expression without relying on CDP's awaitPromise support.
  * Hermes can return a serialized JS Promise instead of its resolved value.
@@ -328,11 +278,12 @@ export async function awaitAppResult(
         timeout,
       );
     } else {
+      // Runtime.evaluate returns primitives by value when the source has no
+      // remote object completion. They are already complete, so writing them
+      // back through the mailbox would add an unnecessary request and poll.
+      // The finally block still performs best-effort mailbox cleanup.
       sourceCompletedByValue = true;
-      // The source has already executed. A transport failure while writing its
-      // completion is safe to retry through the mailbox evaluator, which owns
-      // reconnect policy and never replays the caller's source.
-      await completeByValue(pollEvaluate, key, completion.value, { deadline, timeout });
+      return completion.value;
     }
 
     while (Date.now() < deadline) {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -4,24 +4,76 @@ import type { PluginContext } from '../plugin.js';
 
 type Evaluate = PluginContext['evalInApp'];
 
+export type AppEvaluationCompletion =
+  | {
+      /** Remote object handle for object and Promise completions. */
+      objectId: string;
+      value?: unknown;
+    }
+  | {
+      /** By-value completion, including an explicit undefined value. */
+      objectId?: undefined;
+      value: unknown;
+    };
+
+type EvaluateScript = (
+  expression: string,
+  options?: { timeout?: number; deadline?: number; objectGroup?: string },
+) => Promise<AppEvaluationCompletion>;
+
+type SettleRemote = (
+  objectId: string,
+  mailboxKey: string,
+  options: { timeout?: number; deadline: number },
+) => Promise<boolean>;
+
+type ReleaseObjectGroup = (
+  objectGroup: string,
+  options: { timeout?: number },
+) => Promise<void>;
+
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
 
-async function evaluateBeforeDeadline(
-  evaluate: Evaluate,
+type DeadlineEvaluate<T> = (
   expression: string,
-  options: { timeout?: number; deadline: number },
+  options: { timeout?: number; deadline: number; objectGroup?: string },
+) => Promise<T>;
+
+async function evaluateBeforeDeadline<T>(
+  evaluate: DeadlineEvaluate<T>,
+  expression: string,
+  options: { timeout?: number; deadline: number; objectGroup?: string },
   timeout: number,
-): Promise<unknown> {
+): Promise<T> {
   const remaining = options.deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(timeout);
+  return awaitPromiseBeforeDeadline(
+    evaluate(expression, {
+      timeout: Math.max(
+        1,
+        Math.min(
+          options.timeout ?? remaining,
+          remaining,
+        ),
+      ),
+      deadline: options.deadline,
+    }),
+    options.deadline,
+    timeout,
+  );
+}
+
+async function awaitPromiseBeforeDeadline<T>(
+  operation: Promise<T>,
+  deadline: number,
+  timeout: number,
+): Promise<T> {
+  const remaining = deadline - Date.now();
   if (remaining <= 0) throw timeoutError(timeout);
 
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const operation = evaluate(expression, {
-    timeout: Math.max(1, Math.min(options.timeout ?? remaining, remaining)),
-    deadline: options.deadline,
-  });
   const deadlineReached = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
   });
@@ -40,6 +92,36 @@ export interface AwaitAppResultOptions {
   pollEvaluate?: Evaluate;
   /** Evaluation used to remove the mailbox during cleanup. */
   cleanupEvaluate?: Evaluate;
+  /** Execute the caller's source as a Runtime.evaluate script exactly once. */
+  evaluateScript?: EvaluateScript;
+  /** Attach mailbox settlement to a remote Promise/object completion. */
+  settleRemote?: SettleRemote;
+  /** Release handles if source evaluation completes after the host deadline. */
+  releaseObjectGroup?: ReleaseObjectGroup;
+}
+
+async function completeByValue(
+  evaluate: Evaluate,
+  key: string,
+  value: unknown,
+  options: { deadline: number; timeout: number },
+): Promise<void> {
+  const serialized = value === undefined ? 'void 0' : JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error('App evaluation result could not be serialized');
+  }
+  await evaluateBeforeDeadline(
+    evaluate,
+    `(function() {
+      var state = globalThis[${key}];
+      if (state) {
+        state.value = ${serialized};
+        state.status = 'fulfilled';
+      }
+    })()`,
+    options,
+    options.timeout,
+  );
 }
 
 /**
@@ -55,8 +137,25 @@ export async function awaitAppResult(
 ): Promise<unknown> {
   const pollEvaluate = options?.pollEvaluate ?? evaluate;
   const cleanupEvaluate = options?.cleanupEvaluate ?? evaluate;
-  const key = JSON.stringify(`__METRO_MCP_ASYNC_${randomUUID()}`);
+  const mailboxName = `__METRO_MCP_ASYNC_${randomUUID()}`;
+  const objectGroup = `__METRO_MCP_ASYNC_GROUP_${randomUUID()}`;
+  const key = JSON.stringify(mailboxName);
   const deadline = Date.now() + timeout;
+  let sourceCompletedByValue = false;
+  let remoteHandleReleased = false;
+  let sourceEvaluation: Promise<AppEvaluationCompletion> | undefined;
+  let sourceEvaluationSettled = false;
+
+  const releaseGroup = async (): Promise<void> => {
+    if (!options?.releaseObjectGroup) return;
+    const releaseDeadline = Date.now() + 100;
+    await awaitPromiseBeforeDeadline(
+      options.releaseObjectGroup(objectGroup, { timeout: 100 }),
+      releaseDeadline,
+      100,
+    ).catch(() => {});
+  };
+
   try {
     await evaluateBeforeDeadline(evaluate, `(function() {
       var state = { status: 'pending' };
@@ -66,22 +165,45 @@ export async function awaitAppResult(
       state.timer = setTimeout(function() {
         if (globalThis[${key}] === state) delete globalThis[${key}];
       }, ${timeout + 1000});
-      function reject(error) {
-        state.status = 'rejected';
-        state.error = String(error && error.message || error);
-      }
-      try {
-        // Evaluate the caller's source as a script so awaitPromise works for
-        // the same completion values as Runtime.evaluate (including multiple
-        // statements and declarations), rather than interpolating it into an
-        // expression. The source is evaluated exactly once before polling.
-        Promise.resolve((0, eval)(${JSON.stringify(expression)})).then(function(value) {
-          state.value = value;
-          state.status = 'fulfilled';
-        }, reject);
-      } catch (error) { reject(error); }
       return true;
     })()`, { timeout, deadline }, timeout);
+
+    // Runtime.evaluate must receive the user's source itself. Indirect eval
+    // runs in a separate variable environment and silently loses top-level
+    // let/const/class declarations. The evaluator supplied by the server
+    // requests a remote completion object so Hermes' Promise can settle the
+    // mailbox without replaying the source during a reconnect.
+    let completion: AppEvaluationCompletion;
+    if (options?.evaluateScript) {
+      if (Date.now() >= deadline) throw timeoutError(timeout);
+      sourceEvaluation = options.evaluateScript(expression, { timeout, deadline, objectGroup });
+      sourceEvaluation.then(
+        () => { sourceEvaluationSettled = true; },
+        () => { sourceEvaluationSettled = true; },
+      );
+      completion = await awaitPromiseBeforeDeadline(sourceEvaluation, deadline, timeout);
+    } else {
+      completion = { value: await evaluateBeforeDeadline(evaluate, expression, { timeout, deadline }, timeout) };
+      sourceCompletedByValue = true;
+    }
+
+    if (completion.objectId) {
+      if (!options?.settleRemote) {
+        throw new Error('App evaluation returned a remote object without settlement support');
+      }
+      if (Date.now() >= deadline) throw timeoutError(timeout);
+      remoteHandleReleased = await awaitPromiseBeforeDeadline(
+        options.settleRemote(completion.objectId, mailboxName, {
+          timeout,
+          deadline,
+        }),
+        deadline,
+        timeout,
+      );
+    } else {
+      sourceCompletedByValue = true;
+      await completeByValue(evaluate, key, completion.value, { deadline, timeout });
+    }
 
     while (Date.now() < deadline) {
       const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {
@@ -104,6 +226,18 @@ export async function awaitAppResult(
     }
     throw timeoutError(timeout);
   } finally {
+    // Runtime.evaluate may still complete after the host-side deadline and
+    // return an object handle that never reaches settleRemote. Release the
+    // whole group best effort so late completions cannot accumulate handles.
+    if (!sourceCompletedByValue && !remoteHandleReleased) {
+      await releaseGroup();
+      if (sourceEvaluation && !sourceEvaluationSettled) {
+        // A transport timeout can race the engine's eventual response. Keep
+        // this continuation bounded and release the same unique group after
+        // that response arrives, without leaving a polling timer alive.
+        void sourceEvaluation.then(() => releaseGroup(), () => releaseGroup());
+      }
+    }
     // Also expires inside the app if the MCP process or CDP connection is lost.
     const remaining = deadline - Date.now();
     if (remaining > 0) {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -5,6 +5,15 @@ import { decodeCDPUnserializableValue } from './cdp.js';
 
 type Evaluate = PluginContext['evalInApp'];
 
+type SetupMailbox = (
+  expression: string,
+  options: { timeout?: number; deadline: number },
+) => Promise<number | undefined>;
+
+type RetryMailboxSetup = (
+  options: { timeout?: number; deadline: number },
+) => Promise<number | undefined>;
+
 export type AppEvaluationCompletion =
   | {
       /** Remote object handle for object and Promise completions. */
@@ -24,13 +33,10 @@ type EvaluateScript = (
     deadline?: number;
     objectGroup?: string;
     generation?: number;
+    /** Recreate the mailbox after a safe pre-dispatch source retry. */
+    retryMailboxSetup?: RetryMailboxSetup;
   },
 ) => Promise<AppEvaluationCompletion>;
-
-type SetupMailbox = (
-  expression: string,
-  options: { timeout?: number; deadline: number },
-) => Promise<number | undefined>;
 
 type SettleRemote = (
   objectId: string,
@@ -234,6 +240,9 @@ export async function awaitAppResult(
         deadline,
         objectGroup,
         generation: mailboxGeneration,
+        retryMailboxSetup: options.setupMailbox
+          ? (retryOptions) => options.setupMailbox!(mailboxSetup, retryOptions)
+          : undefined,
       });
       sourceEvaluation.then(
         () => { sourceEvaluationSettled = true; },

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -58,6 +58,9 @@ type DeadlineEvaluate<T> = (
   options: { timeout?: number; deadline: number; objectGroup?: string },
 ) => Promise<T>;
 
+const RELEASE_GROUP_TIMEOUT_MS = 100;
+const RELEASE_GROUP_AFTER_DEADLINE_MS = 250;
+
 async function evaluateBeforeDeadline<T>(
   evaluate: DeadlineEvaluate<T>,
   expression: string,
@@ -194,14 +197,19 @@ export async function awaitAppResult(
     : Math.min(timeoutDeadline, options.deadline);
   let sourceCompletedByValue = false;
   let remoteHandleReleased = false;
+  let sourceEvaluationStarted = false;
   let sourceEvaluation: Promise<AppEvaluationCompletion> | undefined;
   let sourceEvaluationSettled = false;
 
   const releaseGroup = async (): Promise<void> => {
     if (!options?.releaseObjectGroup) return;
     const remaining = deadline - Date.now();
-    if (remaining <= 0) return;
-    const releaseTimeout = Math.min(100, remaining);
+    // Cleanup is detached from the caller, so it may use a small independent
+    // budget after the caller deadline to release a handle whose evaluate
+    // response arrived late. Before the deadline, retain the caller bound.
+    const releaseTimeout = remaining > 0
+      ? Math.min(RELEASE_GROUP_TIMEOUT_MS, remaining)
+      : RELEASE_GROUP_AFTER_DEADLINE_MS;
     const releaseDeadline = Date.now() + releaseTimeout;
     await awaitPromiseBeforeDeadline(
       options.releaseObjectGroup(objectGroup, { timeout: releaseTimeout }),
@@ -247,6 +255,7 @@ export async function awaitAppResult(
     let completion: AppEvaluationCompletion;
     if (options?.evaluateScript) {
       if (Date.now() >= deadline) throw timeoutError(timeout);
+      sourceEvaluationStarted = true;
       sourceEvaluation = options.evaluateScript(expression, {
         timeout,
         deadline,
@@ -319,7 +328,7 @@ export async function awaitAppResult(
     // Runtime.evaluate may still complete after the host-side deadline and
     // return an object handle that never reaches settleRemote. Release the
     // whole group best effort so late completions cannot accumulate handles.
-    if (!sourceCompletedByValue && !remoteHandleReleased) {
+    if (sourceEvaluationStarted && !sourceCompletedByValue && !remoteHandleReleased) {
       // Cleanup has its own transport and host deadline. Keep it detached so
       // a result found within the caller's deadline is never delayed past it.
       void releaseGroup();

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -230,7 +230,9 @@ export async function awaitAppResult(
     // return an object handle that never reaches settleRemote. Release the
     // whole group best effort so late completions cannot accumulate handles.
     if (!sourceCompletedByValue && !remoteHandleReleased) {
-      await releaseGroup();
+      // Cleanup has its own transport and host deadline. Keep it detached so
+      // a result found within the caller's deadline is never delayed past it.
+      void releaseGroup();
       if (sourceEvaluation && !sourceEvaluationSettled) {
         // A transport timeout can race the engine's eventual response. Keep
         // this continuation bounded and release the same unique group after

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -65,7 +65,7 @@ async function evaluateBeforeDeadline<T>(
   );
 }
 
-async function awaitPromiseBeforeDeadline<T>(
+export async function awaitPromiseBeforeDeadline<T>(
   operation: Promise<T>,
   deadline: number,
   timeout: number,

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -202,7 +202,10 @@ export async function awaitAppResult(
       );
     } else {
       sourceCompletedByValue = true;
-      await completeByValue(evaluate, key, completion.value, { deadline, timeout });
+      // The source has already executed. A transport failure while writing its
+      // completion is safe to retry through the mailbox evaluator, which owns
+      // reconnect policy and never replays the caller's source.
+      await completeByValue(pollEvaluate, key, completion.value, { deadline, timeout });
     }
 
     while (Date.now() < deadline) {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -226,8 +226,14 @@ export async function awaitAppResult(
       Math.min(timeout, deadline - Date.now()),
     ) + 1000;
     const mailboxSetup = `(function() {
-      var state = { status: 'pending' };
       var root = this;
+      var PromiseCtor = root.Promise;
+      var state = {
+        status: 'pending',
+        promiseConstructor: PromiseCtor,
+        promiseResolve: PromiseCtor && PromiseCtor.resolve,
+        promiseThen: PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then
+      };
       root.Object.defineProperty(root, ${key}, {
         value: state, configurable: true
       });

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -264,7 +264,10 @@ export async function awaitAppResult(
       sourceCompletedByValue = true;
     }
 
-    if (completion.objectId) {
+    const runtimeGenerationChanged = mailboxGeneration !== undefined &&
+      options?.getRuntimeGeneration !== undefined &&
+      options.getRuntimeGeneration() !== mailboxGeneration;
+    if (completion.objectId && !runtimeGenerationChanged) {
       if (!options?.settleRemote) {
         throw new Error('App evaluation returned a remote object without settlement support');
       }
@@ -277,7 +280,7 @@ export async function awaitAppResult(
         deadline,
         timeout,
       );
-    } else {
+    } else if (!completion.objectId) {
       // Runtime.evaluate returns primitives by value when the source has no
       // remote object completion. They are already complete, so writing them
       // back through the mailbox would add an unnecessary request and poll.
@@ -285,6 +288,10 @@ export async function awaitAppResult(
       sourceCompletedByValue = true;
       return completion.value;
     }
+
+    // The source may have completed just before a reconnect changed the
+    // runtime generation. Its completion handle is now stale, but the
+    // source's mailbox observation is still the safe one-shot result.
 
     while (Date.now() < deadline) {
       const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { PluginContext } from '../plugin.js';
+import { decodeCDPUnserializableValue } from './cdp.js';
 
 type Evaluate = PluginContext['evalInApp'];
 
@@ -112,17 +113,6 @@ export interface AwaitAppResultOptions {
   getRuntimeGeneration?: () => number;
   /** Create the mailbox while bracketing the dispatch with generation checks. */
   setupMailbox?: SetupMailbox;
-}
-
-function decodeUnserializableValue(value: unknown): unknown {
-  if (value === 'NaN') return Number.NaN;
-  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
-  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
-  if (value === '-0') return -0;
-  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
-    return BigInt(value.slice(0, -1));
-  }
-  throw new Error('Unsupported CDP unserializable value');
 }
 
 function serializeCompletionValue(value: unknown): {
@@ -295,7 +285,7 @@ export async function awaitAppResult(
       if (result?.status === 'fulfilled') {
         return result.unserializableValue === undefined
           ? result.value
-          : decodeUnserializableValue(result.unserializableValue);
+          : decodeCDPUnserializableValue(result.unserializableValue);
       }
       if (result?.status === 'rejected') throw new Error(result.error);
       if (!result || result.status !== 'pending') {

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -312,7 +312,10 @@ export async function awaitAppResult(
     // Also expires inside the app if the MCP process or CDP connection is lost.
     const remaining = deadline - Date.now();
     if (remaining > 0) {
-      await evaluateBeforeDeadline(cleanupEvaluate, `(function() {
+      // Cleanup is best effort and must not delay delivery of a value that has
+      // already settled. The mailbox also has an in-app expiry for a lost
+      // host, so leave this bounded operation detached from the caller.
+      void evaluateBeforeDeadline(cleanupEvaluate, `(function() {
         var state = globalThis[${key}];
         if (state) clearTimeout(state.timer);
         delete globalThis[${key}];

--- a/src/utils/await-app-result.ts
+++ b/src/utils/await-app-result.ts
@@ -32,6 +32,7 @@ type EvaluateScript = (
     timeout?: number;
     deadline?: number;
     objectGroup?: string;
+    completionKey?: string;
     generation?: number;
     /** Recreate the mailbox after a safe pre-dispatch source retry. */
     retryMailboxSetup?: RetryMailboxSetup;
@@ -163,7 +164,8 @@ async function completeByValue(
   await evaluateBeforeDeadline(
     evaluate,
     `(function() {
-      var state = globalThis[${key}];
+      var root = this;
+      var state = root[${key}];
       if (state) {
         state.unserializableValue = ${unserializableValue};
         state.value = ${serialized.expression};
@@ -225,11 +227,12 @@ export async function awaitAppResult(
     ) + 1000;
     const mailboxSetup = `(function() {
       var state = { status: 'pending' };
-      Object.defineProperty(globalThis, ${key}, {
+      var root = this;
+      root.Object.defineProperty(root, ${key}, {
         value: state, configurable: true
       });
-      state.timer = setTimeout(function() {
-        if (globalThis[${key}] === state) delete globalThis[${key}];
+      state.timer = root.setTimeout(function() {
+        if (root[${key}] === state) delete root[${key}];
       }, ${mailboxLifetime});
       return true;
     })()`;
@@ -260,6 +263,7 @@ export async function awaitAppResult(
         timeout,
         deadline,
         objectGroup,
+        completionKey: mailboxName,
         generation: mailboxGeneration,
         retryMailboxSetup: options.setupMailbox
           ? (retryOptions) => options.setupMailbox!(mailboxSetup, retryOptions)
@@ -298,7 +302,8 @@ export async function awaitAppResult(
 
     while (Date.now() < deadline) {
       const result = await evaluateBeforeDeadline(pollEvaluate, `(function() {
-        var state = globalThis[${key}];
+        var root = this;
+        var state = root[${key}];
         if (!state) return { status: 'missing' };
         return {
           status: state.status,
@@ -346,9 +351,10 @@ export async function awaitAppResult(
       // already settled. The mailbox also has an in-app expiry for a lost
       // host, so leave this bounded operation detached from the caller.
       void evaluateBeforeDeadline(cleanupEvaluate, `(function() {
-        var state = globalThis[${key}];
-        if (state) clearTimeout(state.timer);
-        delete globalThis[${key}];
+        var root = this;
+        var state = root[${key}];
+        if (state) root.clearTimeout(state.timer);
+        delete root[${key}];
       })()`, { timeout: Math.min(1000, remaining), deadline }, timeout).catch(() => {});
     }
   }

--- a/src/utils/cdp.ts
+++ b/src/utils/cdp.ts
@@ -14,3 +14,15 @@ export function extractCDPExceptionMessage(
     fallback
   );
 }
+
+/** Decode the primitive formats CDP cannot carry in JSON's value field. */
+export function decodeCDPUnserializableValue(value: unknown): unknown {
+  if (value === 'NaN') return Number.NaN;
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
+  if (value === '-0') return -0;
+  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
+    return BigInt(value.slice(0, -1));
+  }
+  throw new Error('Unsupported CDP unserializable value');
+}

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -20,6 +20,7 @@ function runnerFor(options: {
   iosFailure?: boolean;
   iosUnavailable?: boolean;
   androidFailure?: boolean;
+  androidUnavailable?: boolean;
 }): DeviceDiscoveryRunner & { calls: string[][] } {
   const ios = [...(options.ios ?? [iosInventory([
     { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
@@ -36,6 +37,9 @@ function runnerFor(options: {
         if (options.iosFailure) throw new Error('simctl unavailable');
         const output = ios.shift() ?? ios.at(-1) ?? iosInventory([]);
         return Buffer.from(output);
+      }
+      if (options.androidUnavailable) {
+        throw Object.assign(new Error('spawn adb ENOENT'), { code: 'ENOENT' });
       }
       if (options.androidFailure) throw new Error('adb unavailable');
       return Buffer.from(options.android ?? 'List of devices attached\n');
@@ -95,6 +99,29 @@ describe('device discovery', () => {
     await expect(resolveDevice(runner, 'auto', {
       reactNative: { logicalDeviceId: 'opaque-inspector-id' },
     })).resolves.toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('uses a unique iOS name when adb is unavailable for a connected target', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+        { name: 'iPhone 17', udid: 'IOS-17', state: 'Booted' },
+      ])],
+      androidUnavailable: true,
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'iPhone 17',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).resolves.toMatchObject({ platform: 'ios', id: 'IOS-17' });
+  });
+
+  test('uses the sole iOS simulator when adb is unavailable and Metro ID is opaque', async () => {
+    const runner = runnerFor({
+      androidUnavailable: true,
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).resolves.toMatchObject({ platform: 'ios', id: 'IOS-16' });
   });
 
   test('does not treat a generic iOS inventory error as a missing executable', async () => {

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  adbPrefix,
   discoverBootedSimulators,
+  isSafeDeviceId,
   parseAndroidDevices,
   parseBootedSimulators,
   resolveDevice,
@@ -48,6 +50,15 @@ function runnerFor(options: {
 }
 
 describe('device discovery', () => {
+  test('accepts a valid bracketed IPv6 ADB serial and keeps it quoted', () => {
+    const serial = '[2001:db8::1]:5555';
+    expect(parseAndroidDevices(`List of devices attached\n${serial}\tdevice model:Pixel_8\n`))
+      .toEqual([{ id: serial, status: 'device', model: 'Pixel_8' }]);
+    expect(adbPrefix(serial)).toBe('adb -s "[2001:db8::1]:5555"');
+    expect(isSafeDeviceId('[not-an-ipv6]:5555')).toBe(false);
+    expect(isSafeDeviceId('[2001:db8::1]:70000')).toBe(false);
+  });
+
   test('uses literal simctl JSON arguments and resolves a connected target by UDID', async () => {
     const runner = runnerFor({});
     const device = await resolveDevice(runner, 'ios', {

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -182,7 +182,7 @@ describe('device discovery', () => {
     })).rejects.toThrow('iOS simulator discovery failed');
   });
 
-  test('uses a unique iOS name when adb is unavailable for a connected target', async () => {
+  test('uses a verified iOS target when adb is unavailable for a connected target', async () => {
     const runner = runnerFor({
       ios: [iosInventory([
         { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
@@ -192,8 +192,21 @@ describe('device discovery', () => {
     });
     await expect(resolveDevice(runner, 'auto', {
       deviceName: 'iPhone 17',
-      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+      reactNative: { logicalDeviceId: 'IOS-17' },
     })).resolves.toMatchObject({ platform: 'ios', id: 'IOS-17' });
+  });
+
+  test('does not use a same-name iOS simulator when adb is unavailable', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Pixel 8', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      androidUnavailable: true,
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).rejects.toThrow('Android device discovery failed');
   });
 
   test('uses the sole iOS simulator when adb is unavailable and Metro ID is opaque', async () => {

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   adbPrefix,
   discoverBootedSimulators,
+  getConnectedDeviceTarget,
   isSafeDeviceId,
   parseAndroidDevices,
   parseBootedSimulators,
@@ -50,6 +51,20 @@ function runnerFor(options: {
 }
 
 describe('device discovery', () => {
+  test('ignores stale target metadata after CDP disconnects', () => {
+    const target = {
+      deviceName: 'Old simulator',
+      reactNative: { logicalDeviceId: 'OLD-UDID' },
+    };
+    const cdp = {
+      getTarget: () => target,
+      isConnected: false,
+    };
+
+    expect(getConnectedDeviceTarget({ cdp })).toBeUndefined();
+    expect(getConnectedDeviceTarget({ cdp: { ...cdp, isConnected: true } })).toBe(target);
+  });
+
   test('accepts a valid bracketed IPv6 ADB serial and keeps it quoted', () => {
     const serial = '[2001:db8::1]:5555';
     expect(parseAndroidDevices(`List of devices attached\n${serial}\tdevice model:Pixel_8\n`))

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -389,6 +389,33 @@ describe('device discovery', () => {
     });
   });
 
+  test('does not use Android target metadata for an ambiguous explicit iOS selection', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Pixel 8', udid: 'IOS-16', state: 'Booted' },
+        { name: 'iPhone 17', udid: 'IOS-17', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nandroid-1\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'ios', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'android-1' },
+    })).rejects.toThrow('Ambiguous booted iOS simulators');
+  });
+
+  test('does not use iOS target metadata for an ambiguous explicit Android selection', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nandroid-1\tdevice model:Pixel_8\nandroid-2\tdevice model:Pixel_9\n',
+    });
+    await expect(resolveDevice(runner, 'android', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'IOS-16' },
+    })).rejects.toThrow('Ambiguous Android devices');
+  });
+
   test('does not choose the first Android device when target identity is absent', async () => {
     const runner = runnerFor({
       ios: [iosInventory([])],
@@ -408,10 +435,13 @@ describe('device discovery', () => {
         ios: [iosInventory([])],
         android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_8\n',
       });
-      await expect(resolveDevice(duplicates, platform, { deviceName: 'Pixel_8' }))
-        .rejects.toThrow('Ambiguous Android devices named');
+      await expect(resolveDevice(duplicates, platform, {
+        deviceName: 'Pixel_8',
+      }))
+        .rejects.toThrow(platform === 'auto' ? 'Ambiguous Android devices named' : 'Ambiguous Android devices:');
       expect(await resolveDevice(duplicates, platform, {
-        deviceName: 'Pixel_8', reactNative: { logicalDeviceId: 'two' },
+        deviceName: 'Pixel_8',
+        reactNative: { logicalDeviceId: 'two' },
       })).toMatchObject({ platform: 'android', id: 'two' });
     }
   });
@@ -428,7 +458,7 @@ describe('device discovery', () => {
     );
   });
 
-  test('matches a unique inventory name when Metro supplies an opaque logical ID', async () => {
+  test('matches concrete inventory IDs during explicit platform selection', async () => {
     const runner = runnerFor({
       ios: [iosInventory([
         { name: 'First simulator', udid: 'IOS-1', state: 'Booted' },
@@ -436,15 +466,15 @@ describe('device discovery', () => {
       ])],
       android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_9\n',
     });
-    // Metro's logical ID is an inspector identity, not necessarily a simctl
-    // UDID or adb serial. A unique inventory name remains usable evidence.
+    // Explicit platform selection only trusts a concrete inventory ID. Names
+    // alone are not platform-qualified and cannot identify a target safely.
     expect(await resolveDevice(runner, 'ios', {
       deviceName: 'Connected simulator',
-      reactNative: { logicalDeviceId: 'opaque-metro-inspector-id' },
+      reactNative: { logicalDeviceId: 'IOS-2' },
     })).toMatchObject({ id: 'IOS-2' });
     expect(await resolveDevice(runner, 'android', {
       deviceName: 'Pixel_9',
-      reactNative: { logicalDeviceId: 'another-opaque-inspector-id' },
+      reactNative: { logicalDeviceId: 'two' },
     })).toMatchObject({ id: 'two' });
   });
 
@@ -465,13 +495,16 @@ describe('device discovery', () => {
         android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_9_Pro\n',
       });
       expect(await resolveDevice(runner, platform, {
-        deviceName: 'Pixel 9 Pro', reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+        deviceName: 'Pixel 9 Pro',
+        reactNative: { logicalDeviceId: platform === 'android' ? 'two' : 'opaque-inspector-id' },
       })).toMatchObject({ platform: 'android', id: 'two' });
       const duplicates = runnerFor({
         android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_8\n',
       });
-      await expect(resolveDevice(duplicates, platform, { deviceName: 'Pixel 8' }))
-        .rejects.toThrow('Ambiguous Android devices named');
+      await expect(resolveDevice(duplicates, platform, {
+        deviceName: 'Pixel 8',
+      }))
+        .rejects.toThrow(platform === 'auto' ? 'Ambiguous Android devices named' : 'Ambiguous Android devices:');
     }
   });
 
@@ -482,7 +515,8 @@ describe('device discovery', () => {
           android: `List of devices attached\none\tdevice model:Other\ntwo\tdevice model:${model}\n`,
         });
         expect(await resolveDevice(runner, platform, {
-          deviceName: name, reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+          deviceName: name,
+          reactNative: { logicalDeviceId: platform === 'android' ? 'two' : 'opaque-inspector-id' },
         })).toMatchObject({ platform: 'android', id: 'two' });
       }
     }
@@ -490,7 +524,7 @@ describe('device discovery', () => {
       android: 'List of devices attached\none\tdevice model:SM_G991B\ntwo\tdevice model:SM_G991B\n',
     });
     await expect(resolveDevice(collision, 'android', { deviceName: 'SM-G991B' }))
-      .rejects.toThrow('Ambiguous Android devices named');
+      .rejects.toThrow('Ambiguous Android devices:');
   });
 
   test('excludes an unavailable booted entry and supports explicit platform selection', async () => {

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -18,6 +18,7 @@ function runnerFor(options: {
   ios?: string[];
   android?: string;
   iosFailure?: boolean;
+  iosUnavailable?: boolean;
   androidFailure?: boolean;
 }): DeviceDiscoveryRunner & { calls: string[][] } {
   const ios = [...(options.ios ?? [iosInventory([
@@ -29,6 +30,9 @@ function runnerFor(options: {
     async execFile(command, args) {
       calls.push([command, ...args]);
       if (command === 'xcrun') {
+        if (options.iosUnavailable) {
+          throw Object.assign(new Error('spawn xcrun ENOENT'), { code: 'ENOENT' });
+        }
         if (options.iosFailure) throw new Error('simctl unavailable');
         const output = ios.shift() ?? ios.at(-1) ?? iosInventory([]);
         return Buffer.from(output);
@@ -72,7 +76,28 @@ describe('device discovery', () => {
     expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
   });
 
-  test('does not use an Android name or sole fallback when iOS discovery fails for a connected target', async () => {
+  test('uses a unique Android name when xcrun is unavailable for a connected target', async () => {
+    const runner = runnerFor({
+      iosUnavailable: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).resolves.toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('uses the sole Android device when xcrun is unavailable and Metro ID is opaque', async () => {
+    const runner = runnerFor({
+      iosUnavailable: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).resolves.toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('does not treat a generic iOS inventory error as a missing executable', async () => {
     const runner = runnerFor({
       iosFailure: true,
       android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -82,6 +82,20 @@ describe('device discovery', () => {
     expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
   });
 
+  test('checks exact target IDs before a colliding iOS device name', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Pixel_8', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    const device = await resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel_8',
+      reactNative: { logicalDeviceId: 'emulator-42' },
+    });
+    expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
   test('does not choose the first Android device when target identity is absent', async () => {
     const runner = runnerFor({
       ios: [iosInventory([])],

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -96,6 +96,52 @@ describe('device discovery', () => {
     expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
   });
 
+  test('reports ambiguity when an opaque target name matches both platforms', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Pixel 8', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-metro-inspector-id' },
+    })).rejects.toThrow('Ambiguous connected device name "Pixel 8" across iOS and Android');
+  });
+
+  test('does not hide an ambiguous iOS name behind a unique Android name', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Pixel 8', udid: 'IOS-16', state: 'Booted' },
+        { name: 'Pixel 8', udid: 'IOS-17', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-metro-inspector-id' },
+    })).rejects.toThrow('Ambiguous connected device name "Pixel 8" across iOS and Android');
+  });
+
+  test('keeps explicit platform selection independent of cross-platform names', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Pixel 8', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    const target = {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-metro-inspector-id' },
+    };
+    expect(await resolveDevice(runner, 'ios', target)).toMatchObject({
+      platform: 'ios', id: 'IOS-16',
+    });
+    expect(await resolveDevice(runner, 'android', target)).toMatchObject({
+      platform: 'android', id: 'emulator-42',
+    });
+  });
+
   test('does not choose the first Android device when target identity is absent', async () => {
     const runner = runnerFor({
       ios: [iosInventory([])],

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -250,6 +250,28 @@ describe('device discovery', () => {
     expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
   });
 
+  test('uses a sole iOS simulator when Android discovery is successfully empty and the Metro ID is opaque', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).resolves.toMatchObject({ platform: 'ios', id: 'IOS-16' });
+  });
+
+  test('uses a sole Android device when iOS discovery is successfully empty and the Metro ID is opaque', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).resolves.toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
   test('does not use a sole iOS fallback for a contradictory connected Android target', async () => {
     const runner = runnerFor({
       ios: [iosInventory([

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -104,6 +104,32 @@ describe('device discovery', () => {
     ]);
   });
 
+  test('bounds both auto-discovery subprocesses before using a ready inventory', async () => {
+    const timeouts: Array<{ command: string; timeout: number | undefined }> = [];
+    const runner: DeviceDiscoveryRunner = {
+      execFile(command, _args, options) {
+        timeouts.push({ command, timeout: options?.timeout });
+        if (command === 'xcrun') {
+          return Promise.resolve(Buffer.from(iosInventory([
+            { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+          ])));
+        }
+        return new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('adb inventory timed out')), options?.timeout ?? 1000);
+        });
+      },
+    };
+
+    await expect(resolveDevice(runner, 'auto', undefined, 10)).resolves.toMatchObject({
+      platform: 'ios',
+      id: 'IOS-16',
+    });
+    expect(timeouts).toEqual([
+      { command: 'xcrun', timeout: 10 },
+      { command: 'adb', timeout: 10 },
+    ]);
+  });
+
   test('auto selection uses the sole authorized Android device when iOS is unavailable', async () => {
     const runner = runnerFor({
       ios: [],

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -250,6 +250,30 @@ describe('device discovery', () => {
     expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
   });
 
+  test('does not use a sole iOS fallback for a contradictory connected Android target', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'emulator-42' },
+    })).rejects.toThrow('does not match the sole available iOS simulator');
+  });
+
+  test('does not use a sole Android fallback for a contradictory connected iOS target', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'iPhone 16',
+      reactNative: { logicalDeviceId: 'IOS-16' },
+    })).rejects.toThrow('does not match the sole available Android device');
+  });
+
   test('checks exact target IDs before a colliding iOS device name', async () => {
     const runner = runnerFor({
       ios: [iosInventory([

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -152,6 +152,22 @@ describe('device discovery', () => {
     expect(runner.calls).toHaveLength(2);
   });
 
+  test('matches ADB model underscores to Metro names containing spaces', async () => {
+    for (const platform of ['auto', 'android'] as const) {
+      const runner = runnerFor({
+        android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_9_Pro\n',
+      });
+      expect(await resolveDevice(runner, platform, {
+        deviceName: 'Pixel 9 Pro', reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+      })).toMatchObject({ platform: 'android', id: 'two' });
+      const duplicates = runnerFor({
+        android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_8\n',
+      });
+      await expect(resolveDevice(duplicates, platform, { deviceName: 'Pixel 8' }))
+        .rejects.toThrow('Ambiguous Android devices named');
+    }
+  });
+
   test('excludes an unavailable booted entry and supports explicit platform selection', async () => {
     const runner = runnerFor({
       ios: [iosInventory([

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -283,6 +283,40 @@ describe('device discovery', () => {
     expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
   });
 
+  test('does not fall back to an iOS simulator when the connected Android ID is unavailable', async () => {
+    for (const status of ['offline', 'unauthorized'] as const) {
+      const runner = runnerFor({
+        ios: [iosInventory([
+          { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+        ])],
+        android: `List of devices attached\nconnected-android\t${status} model:Pixel_8\n`,
+      });
+
+      await expect(resolveDevice(runner, 'auto', {
+        deviceName: 'Pixel 8',
+        reactNative: { logicalDeviceId: 'connected-android' },
+      })).rejects.toThrow(
+        `Connected Android device "connected-android" is ${status}; refusing to select another device.`,
+      );
+    }
+  });
+
+  test('does not fall back to another authorized Android device when the connected ID is unavailable', async () => {
+    for (const status of ['offline', 'unauthorized'] as const) {
+      const runner = runnerFor({
+        ios: [iosInventory([])],
+        android: `List of devices attached\nconnected-android\t${status} model:Pixel_8\nother-android\tdevice model:Pixel_8\n`,
+      });
+
+      await expect(resolveDevice(runner, 'auto', {
+        deviceName: 'Pixel 8',
+        reactNative: { logicalDeviceId: 'connected-android' },
+      })).rejects.toThrow(
+        `Connected Android device "connected-android" is ${status}; refusing to select another device.`,
+      );
+    }
+  });
+
   test('uses a sole iOS simulator when Android discovery is successfully empty and the Metro ID is opaque', async () => {
     const runner = runnerFor({
       ios: [iosInventory([

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -17,6 +17,8 @@ const iosInventory = (devices: Array<Record<string, string>>) =>
 function runnerFor(options: {
   ios?: string[];
   android?: string;
+  iosFailure?: boolean;
+  androidFailure?: boolean;
 }): DeviceDiscoveryRunner & { calls: string[][] } {
   const ios = [...(options.ios ?? [iosInventory([
     { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
@@ -27,9 +29,11 @@ function runnerFor(options: {
     async execFile(command, args) {
       calls.push([command, ...args]);
       if (command === 'xcrun') {
+        if (options.iosFailure) throw new Error('simctl unavailable');
         const output = ios.shift() ?? ios.at(-1) ?? iosInventory([]);
         return Buffer.from(output);
       }
+      if (options.androidFailure) throw new Error('adb unavailable');
       return Buffer.from(options.android ?? 'List of devices attached\n');
     },
   };
@@ -66,6 +70,86 @@ describe('device discovery', () => {
     });
     const device = await resolveDevice(runner, 'auto');
     expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('does not use an Android name or sole fallback when iOS discovery fails for a connected target', async () => {
+    const runner = runnerFor({
+      iosFailure: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).rejects.toThrow('iOS simulator discovery failed');
+  });
+
+  test('does not use a sole fallback for a connected target with no identity metadata', async () => {
+    const runner = runnerFor({
+      iosFailure: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {})).rejects.toThrow(
+      'iOS simulator discovery failed',
+    );
+  });
+
+  test('does not use an iOS name or sole fallback when Android discovery fails for a connected target', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Pixel 8', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      androidFailure: true,
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).rejects.toThrow('Android device discovery failed');
+  });
+
+  test('keeps exact connected IDs usable when the other inventory is unavailable', async () => {
+    const runner = runnerFor({
+      iosFailure: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    expect(await resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'emulator-42' },
+    })).toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('keeps sole fallback usable without a connected target after an inventory failure', async () => {
+    const runner = runnerFor({
+      iosFailure: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    expect(await resolveDevice(runner, 'auto')).toMatchObject({
+      platform: 'android', id: 'emulator-42',
+    });
+  });
+
+  test('reports ambiguity when an unmatched connected target has devices on both platforms', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Unknown device',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).rejects.toThrow('Ambiguous available devices across iOS and Android');
+  });
+
+  test('reports ambiguity when no target is connected and both platforms have candidates', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto')).rejects.toThrow(
+      'Ambiguous available devices across iOS and Android',
+    );
   });
 
   test('auto selection follows the connected Android target over booted iOS', async () => {

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -512,6 +512,20 @@ describe('device discovery', () => {
     })).toMatchObject({ id: 'two' });
   });
 
+  test('rejects an unavailable explicit Android target before fallback selection', async () => {
+    for (const status of ['offline', 'unauthorized'] as const) {
+      const runner = runnerFor({
+        android: `List of devices attached\nconnected-android\t${status} model:Pixel_8\nother-android\tdevice model:Pixel_9\n`,
+      });
+      await expect(resolveDevice(runner, 'android', {
+        deviceName: 'Pixel 9',
+        reactNative: { logicalDeviceId: 'connected-android' },
+      })).rejects.toThrow(
+        `Connected Android device "connected-android" is ${status}; refusing to select another device.`,
+      );
+    }
+  });
+
   test('retries discovery on every call after a missed boot', async () => {
     const runner = runnerFor({
       ios: [iosInventory([]), iosInventory([

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  discoverBootedSimulators,
+  parseAndroidDevices,
+  parseBootedSimulators,
+  resolveDevice,
+  type DeviceDiscoveryRunner,
+} from './device-discovery.js';
+
+const iosInventory = (devices: Array<Record<string, string>>) =>
+  JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-18-0': devices,
+    },
+  });
+
+function runnerFor(options: {
+  ios?: string[];
+  android?: string;
+}): DeviceDiscoveryRunner & { calls: string[][] } {
+  const ios = [...(options.ios ?? [iosInventory([
+    { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+  ])])];
+  const calls: string[][] = [];
+  return {
+    calls,
+    async execFile(command, args) {
+      calls.push([command, ...args]);
+      if (command === 'xcrun') {
+        const output = ios.shift() ?? ios.at(-1) ?? iosInventory([]);
+        return Buffer.from(output);
+      }
+      return Buffer.from(options.android ?? 'List of devices attached\n');
+    },
+  };
+}
+
+describe('device discovery', () => {
+  test('uses literal simctl JSON arguments and resolves a connected target by UDID', async () => {
+    const runner = runnerFor({});
+    const device = await resolveDevice(runner, 'ios', {
+      deviceName: 'iPhone 16',
+      reactNative: { logicalDeviceId: 'IOS-16' },
+    });
+
+    expect(device).toEqual({
+      platform: 'ios',
+      id: 'IOS-16',
+      name: 'iPhone 16',
+      runtime: 'iOS-18-0',
+    });
+    expect(runner.calls[0]).toEqual([
+      'xcrun',
+      'simctl',
+      'list',
+      'devices',
+      'booted',
+      '--json',
+    ]);
+  });
+
+  test('auto selection uses the sole authorized Android device when iOS is unavailable', async () => {
+    const runner = runnerFor({
+      ios: [],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    const device = await resolveDevice(runner, 'auto');
+    expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('auto selection follows the connected Android target over booted iOS', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    const device = await resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel_8',
+      reactNative: { logicalDeviceId: 'emulator-42' },
+    });
+    expect(device).toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('does not choose the first Android device when target identity is absent', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([])],
+      android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_9\n',
+    });
+    await expect(resolveDevice(runner, 'auto')).rejects.toThrow('Ambiguous Android devices');
+  });
+
+  test('missing models and duplicate model names never select an arbitrary Android device', async () => {
+    const withoutModels = runnerFor({
+      ios: [iosInventory([])],
+      android: 'List of devices attached\none\tdevice\ntwo\tdevice\n',
+    });
+    await expect(resolveDevice(withoutModels, 'auto')).rejects.toThrow('Ambiguous Android devices');
+    for (const platform of ['auto', 'android'] as const) {
+      const duplicates = runnerFor({
+        ios: [iosInventory([])],
+        android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_8\n',
+      });
+      await expect(resolveDevice(duplicates, platform, { deviceName: 'Pixel_8' }))
+        .rejects.toThrow('Ambiguous Android devices named');
+      expect(await resolveDevice(duplicates, platform, {
+        deviceName: 'Pixel_8', reactNative: { logicalDeviceId: 'two' },
+      })).toMatchObject({ platform: 'android', id: 'two' });
+    }
+  });
+
+  test('reports ambiguity instead of choosing an arbitrary booted simulator', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+        { name: 'iPhone 17', udid: 'IOS-17', state: 'Booted' },
+      ])],
+    });
+    await expect(resolveDevice(runner, 'ios')).rejects.toThrow(
+      'Ambiguous booted iOS simulators',
+    );
+  });
+
+  test('matches a unique inventory name when Metro supplies an opaque logical ID', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'First simulator', udid: 'IOS-1', state: 'Booted' },
+        { name: 'Connected simulator', udid: 'IOS-2', state: 'Booted' },
+      ])],
+      android: 'List of devices attached\none\tdevice model:Pixel_8\ntwo\tdevice model:Pixel_9\n',
+    });
+    // Metro's logical ID is an inspector identity, not necessarily a simctl
+    // UDID or adb serial. A unique inventory name remains usable evidence.
+    expect(await resolveDevice(runner, 'ios', {
+      deviceName: 'Connected simulator',
+      reactNative: { logicalDeviceId: 'opaque-metro-inspector-id' },
+    })).toMatchObject({ id: 'IOS-2' });
+    expect(await resolveDevice(runner, 'android', {
+      deviceName: 'Pixel_9',
+      reactNative: { logicalDeviceId: 'another-opaque-inspector-id' },
+    })).toMatchObject({ id: 'two' });
+  });
+
+  test('retries discovery on every call after a missed boot', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([]), iosInventory([
+        { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+      ])],
+    });
+    expect(await resolveDevice(runner, 'ios')).toBeNull();
+    expect(await resolveDevice(runner, 'ios')).toMatchObject({ id: 'IOS-16' });
+    expect(runner.calls).toHaveLength(2);
+  });
+
+  test('excludes an unavailable booted entry and supports explicit platform selection', async () => {
+    const runner = runnerFor({
+      ios: [iosInventory([
+        { name: 'Unavailable', udid: 'IOS-OLD', state: 'Booted', isAvailable: 'NO' },
+        { name: 'Available', udid: 'IOS-NEW', state: 'Booted', isAvailable: 'YES' },
+      ])],
+      android: 'List of devices attached\nemulator-42\tdevice\n',
+    });
+    expect(await resolveDevice(runner, 'ios')).toMatchObject({ id: 'IOS-NEW' });
+    // Explicit Android reads only adb and does not get shadowed by iOS state.
+    expect(await resolveDevice(runner, 'android')).toMatchObject({ id: 'emulator-42' });
+  });
+
+  test('ignores booted watchOS runtimes when selecting an iOS app simulator', async () => {
+    const runner = runnerFor({
+      ios: [JSON.stringify({
+        devices: {
+          'com.apple.CoreSimulator.SimRuntime.watchOS-11-0': [
+            { name: 'Apple Watch', udid: 'WATCH-1', state: 'Booted' },
+          ],
+          'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+            { name: 'iPhone 16', udid: 'IOS-16', state: 'Booted' },
+          ],
+        },
+      })],
+    });
+    expect(await resolveDevice(runner, 'ios')).toMatchObject({ id: 'IOS-16' });
+    const watchOnly = runnerFor({
+      ios: [JSON.stringify({
+        devices: {
+          'com.apple.CoreSimulator.SimRuntime.watchOS-11-0': [
+            { name: 'Apple Watch', udid: 'WATCH-1', state: 'Booted' },
+          ],
+        },
+      })],
+    });
+    expect(await resolveDevice(watchOnly, 'ios')).toBeNull();
+  });
+
+  test('rejects malformed inventories and ignores unauthorized Android devices', async () => {
+    expect(() => parseBootedSimulators('{"devices": []}')).toThrow(
+      'missing devices map',
+    );
+    expect(parseAndroidDevices(
+      'List of devices attached\noffline-1\toffline\nunauth-1\tunauthorized\n',
+    )).toEqual([
+      { id: 'offline-1', status: 'offline' },
+      { id: 'unauth-1', status: 'unauthorized' },
+    ]);
+    const runner = runnerFor({
+      android: 'List of devices attached\noffline-1\toffline\n',
+    });
+    expect(await resolveDevice(runner, 'android')).toBeNull();
+    await expect(discoverBootedSimulators({
+      execFile: async () => Buffer.from('not-json'),
+    })).rejects.toThrow('Malformed iOS simulator inventory');
+    expect(() => parseAndroidDevices(
+      'List of devices attached\nserial;touch\tdevice\n',
+    )).toThrow('invalid device serial');
+  });
+});

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -168,6 +168,24 @@ describe('device discovery', () => {
     }
   });
 
+  test('matches the full ADB model sanitization while keeping collisions ambiguous', async () => {
+    for (const [name, model] of [['SM-G991B', 'SM_G991B'], ['Pixel (Pro)', 'Pixel__Pro_'], ['Téléphone', 'T__l__phone']]) {
+      for (const platform of ['auto', 'android'] as const) {
+        const runner = runnerFor({
+          android: `List of devices attached\none\tdevice model:Other\ntwo\tdevice model:${model}\n`,
+        });
+        expect(await resolveDevice(runner, platform, {
+          deviceName: name, reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+        })).toMatchObject({ platform: 'android', id: 'two' });
+      }
+    }
+    const collision = runnerFor({
+      android: 'List of devices attached\none\tdevice model:SM_G991B\ntwo\tdevice model:SM_G991B\n',
+    });
+    await expect(resolveDevice(collision, 'android', { deviceName: 'SM-G991B' }))
+      .rejects.toThrow('Ambiguous Android devices named');
+  });
+
   test('excludes an unavailable booted entry and supports explicit platform selection', async () => {
     const runner = runnerFor({
       ios: [iosInventory([

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -112,6 +112,17 @@ describe('device discovery', () => {
     })).resolves.toMatchObject({ platform: 'android', id: 'emulator-42' });
   });
 
+  test('rejects a contradictory Android name when xcrun is unavailable', async () => {
+    const runner = runnerFor({
+      iosUnavailable: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Other device',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).rejects.toThrow('iOS simulator discovery failed');
+  });
+
   test('uses a unique iOS name when adb is unavailable for a connected target', async () => {
     const runner = runnerFor({
       ios: [iosInventory([
@@ -133,6 +144,16 @@ describe('device discovery', () => {
     await expect(resolveDevice(runner, 'auto', {
       reactNative: { logicalDeviceId: 'opaque-inspector-id' },
     })).resolves.toMatchObject({ platform: 'ios', id: 'IOS-16' });
+  });
+
+  test('rejects a contradictory iOS name when adb is unavailable', async () => {
+    const runner = runnerFor({
+      androidUnavailable: true,
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Other simulator',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).rejects.toThrow('Android device discovery failed');
   });
 
   test('does not treat a generic iOS inventory error as a missing executable', async () => {

--- a/src/utils/device-discovery.test.ts
+++ b/src/utils/device-discovery.test.ts
@@ -21,6 +21,7 @@ function runnerFor(options: {
   ios?: string[];
   android?: string;
   iosFailure?: boolean;
+  iosMissingSimctl?: boolean;
   iosUnavailable?: boolean;
   androidFailure?: boolean;
   androidUnavailable?: boolean;
@@ -36,6 +37,12 @@ function runnerFor(options: {
       if (command === 'xcrun') {
         if (options.iosUnavailable) {
           throw Object.assign(new Error('spawn xcrun ENOENT'), { code: 'ENOENT' });
+        }
+        if (options.iosMissingSimctl) {
+          throw Object.assign(
+            new Error('Command failed: xcrun: error: unable to find utility "simctl", not a developer tool or in PATH'),
+            { code: 69, stderr: 'xcrun: error: unable to find utility "simctl", not a developer tool or in PATH' },
+          );
         }
         if (options.iosFailure) throw new Error('simctl unavailable');
         const output = ios.shift() ?? ios.at(-1) ?? iosInventory([]);
@@ -109,6 +116,17 @@ describe('device discovery', () => {
   test('uses a unique Android name when xcrun is unavailable for a connected target', async () => {
     const runner = runnerFor({
       iosUnavailable: true,
+      android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
+    });
+    await expect(resolveDevice(runner, 'auto', {
+      deviceName: 'Pixel 8',
+      reactNative: { logicalDeviceId: 'opaque-inspector-id' },
+    })).resolves.toMatchObject({ platform: 'android', id: 'emulator-42' });
+  });
+
+  test('uses a verified Android target when xcrun cannot find simctl', async () => {
+    const runner = runnerFor({
+      iosMissingSimctl: true,
       android: 'List of devices attached\nemulator-42\tdevice model:Pixel_8\n',
     });
     await expect(resolveDevice(runner, 'auto', {

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -1,0 +1,282 @@
+import type { PluginContext } from '../plugin.js';
+
+/** A booted simulator as reported by CoreSimulatorService. */
+export interface BootedSimulator {
+  name: string;
+  udid: string;
+  state: string;
+  runtime: string;
+}
+
+// UDIDs/serials are later passed as one shell argument by legacy plugin
+// commands. Keep only identifier characters so inventory data cannot turn into
+// shell syntax before those commands are migrated to execFile.
+export function isSafeDeviceId(value: string): boolean {
+  return /^[A-Za-z0-9._:-]+$/.test(value);
+}
+
+/** Safely scope a legacy shell based adb command to one resolved serial. */
+export function adbPrefix(serial: string): string {
+  if (!isSafeDeviceId(serial)) throw new Error('Invalid Android device serial');
+  return `adb -s "${serial}"`;
+}
+
+export interface AndroidDevice {
+  id: string;
+  status: string;
+  model?: string;
+  [key: string]: string | undefined;
+}
+
+export interface ResolvedDevice {
+  platform: 'ios' | 'android';
+  /** A concrete simulator UDID. Android uses the adb serial in `id`. */
+  id: string;
+  name?: string;
+  runtime?: string;
+}
+
+export interface DeviceDiscoveryRunner {
+  execFile(
+    command: string,
+    args: string[],
+    options?: { maxBuffer?: number },
+  ): Promise<Buffer | string>;
+}
+
+export interface ConnectedDeviceTarget {
+  deviceName?: string;
+  reactNative?: { logicalDeviceId?: string };
+}
+
+function outputText(output: Buffer | string): string {
+  return typeof output === 'string' ? output : output.toString('utf8');
+}
+
+/** Parse simctl's JSON output without accepting a partially valid inventory. */
+export function parseBootedSimulators(output: string): BootedSimulator[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch (error) {
+    throw new Error(
+      `Malformed iOS simulator inventory: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Malformed iOS simulator inventory: expected an object');
+  }
+  const devices = (parsed as { devices?: unknown }).devices;
+  if (!devices || typeof devices !== 'object' || Array.isArray(devices)) {
+    throw new Error('Malformed iOS simulator inventory: missing devices map');
+  }
+
+  const result: BootedSimulator[] = [];
+  for (const [runtime, entries] of Object.entries(devices)) {
+    const normalizedRuntime = runtime.replace(/^com\.apple\.CoreSimulator\.SimRuntime\./, '');
+    if (!/^iOS(?:-|$)/i.test(normalizedRuntime)) continue;
+    if (!Array.isArray(entries)) {
+      throw new Error(`Malformed iOS simulator inventory: ${runtime} is not an array`);
+    }
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') {
+        throw new Error('Malformed iOS simulator inventory: invalid device entry');
+      }
+      const device = entry as Record<string, unknown>;
+      if (
+        device.state !== 'Booted' ||
+        device.isAvailable === false ||
+        device.isAvailable === 'NO'
+      ) continue;
+      if (typeof device.udid !== 'string' || !device.udid.trim()) {
+        throw new Error('Malformed iOS simulator inventory: booted device has no UDID');
+      }
+      if (!isSafeDeviceId(device.udid)) {
+        throw new Error('Malformed iOS simulator inventory: booted device has an invalid UDID');
+      }
+      if (typeof device.name !== 'string' || !device.name.trim()) {
+        throw new Error('Malformed iOS simulator inventory: booted device has no name');
+      }
+      result.push({
+        name: device.name,
+        udid: device.udid,
+        state: 'Booted',
+        runtime: normalizedRuntime,
+      });
+    }
+  }
+  return result;
+}
+
+export async function discoverBootedSimulators(
+  runner: DeviceDiscoveryRunner,
+): Promise<BootedSimulator[]> {
+  const output = await runner.execFile('xcrun', [
+    'simctl',
+    'list',
+    'devices',
+    'booted',
+    '--json',
+  ]);
+  return parseBootedSimulators(outputText(output));
+}
+
+export function parseAndroidDevices(output: string): AndroidDevice[] {
+  const lines = output.split(/\r?\n/).slice(1);
+  return lines.flatMap((line) => {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 2 || !parts[0] || parts[0].startsWith('*')) return [];
+    if (!isSafeDeviceId(parts[0])) {
+      throw new Error('Malformed Android device inventory: invalid device serial');
+    }
+    const info: AndroidDevice = { id: parts[0], status: parts[1] };
+    for (const part of parts.slice(2)) {
+      const separator = part.indexOf(':');
+      if (separator > 0) info[part.slice(0, separator)] = part.slice(separator + 1);
+    }
+    return [info];
+  });
+}
+
+export async function discoverAndroidDevices(
+  runner: DeviceDiscoveryRunner,
+): Promise<AndroidDevice[]> {
+  const output = await runner.execFile('adb', ['devices', '-l']);
+  return parseAndroidDevices(outputText(output));
+}
+
+function targetId(target?: ConnectedDeviceTarget | null): string | undefined {
+  const id = target?.reactNative?.logicalDeviceId?.trim();
+  return id || undefined;
+}
+
+/**
+ * Resolve one concrete device for a tool invocation. Discovery is intentionally
+ * uncached: a simulator booted after a failed call must be visible immediately.
+ */
+export async function resolveDevice(
+  runner: DeviceDiscoveryRunner,
+  platform: 'ios' | 'android' | 'auto',
+  target?: ConnectedDeviceTarget | null,
+): Promise<ResolvedDevice | null> {
+  if (platform === 'android') {
+    const devices = await discoverAndroidDevices(runner);
+    const authorized = devices.filter((device) => device.status === 'device');
+    if (authorized.length === 0) return null;
+    const selected = findAndroidTarget(authorized, targetId(target), target?.deviceName?.trim())
+      ?? (authorized.length === 1 ? authorized[0] : undefined);
+    if (!selected) {
+      throw new Error(
+        `Ambiguous Android devices: ${authorized.map((device) => device.id).join(', ')}.`,
+      );
+    }
+    return { platform: 'android', id: selected.id, name: selected.model };
+  }
+
+  if (platform === 'ios') {
+    const devices = await discoverBootedSimulators(runner);
+    return resolveIosDevice(devices, target);
+  }
+
+  const [iosResult, androidResult] = await Promise.allSettled([
+    discoverBootedSimulators(runner),
+    discoverAndroidDevices(runner),
+  ]);
+  // A connected target is stronger evidence than runtime ordering. This
+  // matters when an Android app is connected while an unrelated iOS
+  // simulator happens to be booted.
+  const connectedId = targetId(target);
+  const connectedName = target?.deviceName?.trim();
+  if (iosResult.status === 'fulfilled') {
+    const iosMatch = findIosTarget(iosResult.value, connectedId, connectedName);
+    if (iosMatch) return toResolvedIos(iosMatch);
+  }
+  if (androidResult.status === 'fulfilled') {
+    const android = androidResult.value.filter((device) => device.status === 'device');
+    const match = findAndroidTarget(android, connectedId, connectedName);
+    if (match) return { platform: 'android', id: match.id, name: match.model };
+  }
+  // A valid iOS inventory wins when both runtimes are present, matching the
+  // historical auto-selection order while making ambiguity explicit.
+  if (iosResult.status === 'fulfilled' && iosResult.value.length > 0) {
+    return resolveIosDevice(iosResult.value, target);
+  }
+  if (androidResult.status === 'fulfilled') {
+    const authorized = androidResult.value.filter((device) => device.status === 'device');
+    if (authorized.length === 1) {
+      return { platform: 'android', id: authorized[0].id, name: authorized[0].model };
+    }
+    if (authorized.length > 1) {
+      throw new Error(
+        `Ambiguous Android devices: ${authorized.map((device) => device.id).join(', ')}.`,
+      );
+    }
+  }
+  if (iosResult.status === 'rejected' && androidResult.status === 'rejected') {
+    throw iosResult.reason instanceof Error ? iosResult.reason : new Error(String(iosResult.reason));
+  }
+  return null;
+}
+
+function findAndroidTarget(
+  devices: AndroidDevice[],
+  connectedId?: string,
+  connectedName?: string,
+): AndroidDevice | undefined {
+  const byId = connectedId ? devices.find((device) => device.id === connectedId) : undefined;
+  if (byId) return byId;
+  if (!connectedName) return undefined;
+  const matches = devices.filter((device) => device.model === connectedName);
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous Android devices named "${connectedName}": ${matches.map((device) => device.id).join(', ')}.`,
+    );
+  }
+  return matches[0];
+}
+
+function resolveIosDevice(
+  devices: BootedSimulator[],
+  target?: ConnectedDeviceTarget | null,
+): ResolvedDevice | null {
+  if (devices.length === 0) return null;
+
+  const match = findIosTarget(devices, targetId(target), target?.deviceName?.trim());
+  if (match) return toResolvedIos(match);
+
+  if (devices.length === 1) {
+    const device = devices[0];
+    return toResolvedIos(device);
+  }
+  throw new Error(
+    `Ambiguous booted iOS simulators: ${devices.map((device) => `${device.name} (${device.udid})`).join(', ')}.`,
+  );
+}
+
+function toResolvedIos(device: BootedSimulator): ResolvedDevice {
+  return { platform: 'ios', id: device.udid, name: device.name, runtime: device.runtime };
+}
+
+function findIosTarget(
+  devices: BootedSimulator[],
+  connectedId?: string,
+  connectedName?: string,
+): BootedSimulator | undefined {
+  const byId = connectedId
+    ? devices.find((device) => device.udid.toLowerCase() === connectedId.toLowerCase())
+    : undefined;
+  if (byId) return byId;
+  const byName = connectedName
+    ? devices.filter((device) => device.name === connectedName)
+    : [];
+  return byName.length === 1 ? byName[0] : undefined;
+}
+
+/** Convenience wrapper used by plugins that only need the selected platform. */
+export async function detectPlatform(
+  ctx: PluginContext,
+): Promise<'ios' | 'android' | null> {
+  const device = await resolveDevice(ctx, 'auto', ctx.cdp.getTarget());
+  return device?.platform ?? null;
+}

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -179,13 +179,24 @@ export async function resolveDevice(
 ): Promise<ResolvedDevice | null> {
   if (platform === 'android') {
     const devices = await discoverAndroidDevices(runner);
+    const connectedId = targetId(target);
+    // Inspect the complete ADB inventory before dropping unavailable entries.
+    // An offline or unauthorized exact match proves which Android target Metro
+    // is connected to and must never turn into a fallback to another handset.
+    const connectedDevice = connectedId
+      ? devices.find((device) => device.id === connectedId)
+      : undefined;
+    if (connectedDevice && connectedDevice.status !== 'device') {
+      throw new Error(
+        `Connected Android device "${connectedDevice.id}" is ${connectedDevice.status}; ` +
+        'refusing to select another device.',
+      );
+    }
     const authorized = devices.filter((device) => device.status === 'device');
     if (authorized.length === 0) return null;
     // A target's name is not platform-qualified. A concrete serial match is
     // the only inventory evidence that proves its metadata belongs to Android.
-    const platformTarget = targetId(target) && authorized.some(
-      (device) => device.id === targetId(target),
-    ) ? target : undefined;
+    const platformTarget = connectedDevice?.status === 'device' ? target : undefined;
     const selected = findAndroidTarget(
       authorized,
       targetId(platformTarget),

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -364,8 +364,18 @@ export async function resolveDevice(
 }
 
 function isUnavailableToolError(reason: unknown): boolean {
-  return typeof reason === 'object' && reason !== null &&
-    'code' in reason && reason.code === 'ENOENT';
+  if (typeof reason !== 'object' || reason === null) return false;
+  if ('code' in reason && reason.code === 'ENOENT') return true;
+
+  // xcrun can start successfully and still fail because the requested
+  // developer utility is absent. Treat only that precise simctl diagnostic as
+  // unavailable; malformed inventories and other non-zero exits remain
+  // strict so they cannot silently select a different runtime.
+  const error = reason as { message?: unknown; stderr?: unknown };
+  const text = [error.message, error.stderr]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n');
+  return /xcrun:\s*error:\s*unable to find utility ["']simctl["']/i.test(text);
 }
 
 function findAndroidTarget(

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -237,7 +237,7 @@ export async function resolveDevice(
       // An opaque Metro logical ID is still evidence that a target is
       // connected. With only one authorized Android device remaining, there
       // is no competing local candidate to choose accidentally.
-      if (targetId(target) && authorized.length === 1 &&
+      if (connectedId && authorized.length === 1 &&
         (!connectedName || nameMatches.length === 1)) {
         const device = authorized[0];
         return { platform: 'android', id: device.id, name: device.model };
@@ -253,7 +253,7 @@ export async function resolveDevice(
       // A connected opaque inspector ID plus one booted simulator is the
       // symmetric iOS case: the missing Android executable cannot hide a
       // competing local Android device.
-      if (targetId(target) && iosResult.value.length === 1 &&
+      if (connectedId && iosResult.value.length === 1 &&
         (!connectedName || nameMatches.length === 1)) {
         return toResolvedIos(iosResult.value[0]);
       }

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -205,14 +205,44 @@ export async function resolveDevice(
   if (ios) return toResolvedIos(ios);
   if (android) return { platform: 'android', id: android.id, name: android.model };
 
-  if (iosResult.status === 'fulfilled') {
-    const iosMatch = findIosName(iosResult.value, connectedName);
-    if (iosMatch) return toResolvedIos(iosMatch);
+  // Resolve name evidence for both platforms before selecting either one.
+  // A Metro target's name is not platform-qualified, so selecting the first
+  // inventory to report a match can silently target an unrelated app when
+  // both runtimes use the same model name.
+  const iosNameMatches = iosResult.status === 'fulfilled'
+    ? findIosNames(iosResult.value, connectedName)
+    : [];
+  const authorizedAndroid = androidResult.status === 'fulfilled'
+    ? androidResult.value.filter((device) => device.status === 'device')
+    : [];
+  const androidNameMatches = connectedName
+    ? findAndroidNameMatches(authorizedAndroid, connectedName)
+    : [];
+  if (iosNameMatches.length > 0 && androidNameMatches.length > 0) {
+    throw new Error(
+      `Ambiguous connected device name "${connectedName}" across iOS and Android: ` +
+      `${iosNameMatches.map((device) => device.udid).join(', ')}, ` +
+      `${androidNameMatches.map((device) => device.id).join(', ')}.`,
+    );
   }
-  if (androidResult.status === 'fulfilled') {
-    const android = androidResult.value.filter((device) => device.status === 'device');
-    const match = findAndroidTarget(android, undefined, connectedName);
-    if (match) return { platform: 'android', id: match.id, name: match.model };
+  if (iosNameMatches.length > 1 || androidNameMatches.length > 1) {
+    // Do not let a unique name on the other platform hide an ambiguous
+    // same-name inventory. The name evidence cannot establish the platform.
+    if (iosNameMatches.length > 1) {
+      throw new Error(
+        `Ambiguous booted iOS simulators named "${connectedName}": ` +
+        `${iosNameMatches.map((device) => device.udid).join(', ')}.`,
+      );
+    }
+    throw new Error(
+      `Ambiguous Android devices named "${connectedName}": ` +
+      `${androidNameMatches.map((device) => device.id).join(', ')}.`,
+    );
+  }
+  if (iosNameMatches.length === 1) return toResolvedIos(iosNameMatches[0]);
+  if (androidNameMatches.length === 1) {
+    const match = androidNameMatches[0];
+    return { platform: 'android', id: match.id, name: match.model };
   }
   // A valid iOS inventory wins when both runtimes are present, matching the
   // historical auto-selection order while making ambiguity explicit.
@@ -244,15 +274,22 @@ function findAndroidTarget(
   const byId = connectedId ? devices.find((device) => device.id === connectedId) : undefined;
   if (byId) return byId;
   if (!connectedName) return undefined;
-  // ADB sanitizes every non-alphanumeric UTF-8 byte in its model field.
-  const modelName = Buffer.from(connectedName, 'utf8').toString('latin1').replace(/[^a-zA-Z0-9]/g, '_');
-  const matches = devices.filter((device) => device.model === modelName);
+  const matches = findAndroidNameMatches(devices, connectedName);
   if (matches.length > 1) {
     throw new Error(
       `Ambiguous Android devices named "${connectedName}": ${matches.map((device) => device.id).join(', ')}.`,
     );
   }
   return matches[0];
+}
+
+function findAndroidNameMatches(
+  devices: AndroidDevice[],
+  connectedName: string,
+): AndroidDevice[] {
+  // ADB sanitizes every non-alphanumeric UTF-8 byte in its model field.
+  const modelName = Buffer.from(connectedName, 'utf8').toString('latin1').replace(/[^a-zA-Z0-9]/g, '_');
+  return devices.filter((device) => device.model === modelName);
 }
 
 function resolveIosDevice(
@@ -290,10 +327,15 @@ function findIosName(
   devices: BootedSimulator[],
   connectedName?: string,
 ): BootedSimulator | undefined {
-  const byName = connectedName
-    ? devices.filter((device) => device.name === connectedName)
-    : [];
+  const byName = findIosNames(devices, connectedName);
   return byName.length === 1 ? byName[0] : undefined;
+}
+
+function findIosNames(
+  devices: BootedSimulator[],
+  connectedName?: string,
+): BootedSimulator[] {
+  return connectedName ? devices.filter((device) => device.name === connectedName) : [];
 }
 
 /** Convenience wrapper used by plugins that only need the selected platform. */

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -213,6 +213,30 @@ export async function resolveDevice(
     (iosResult.status === 'rejected' || androidResult.status === 'rejected') &&
     target != null
   ) {
+    // Some hosts (for example Linux) cannot run xcrun at all. When that
+    // impossible platform is the only failed inventory, a connected Android
+    // target can still be resolved from a unique surviving inventory match.
+    // Keep the stricter retry path for ordinary discovery failures, where the
+    // missing inventory may simply be temporarily unavailable.
+    if (
+      iosResult.status === 'rejected' &&
+      androidResult.status === 'fulfilled' &&
+      isUnavailableToolError(iosResult.reason)
+    ) {
+      const authorized = androidResult.value.filter((device) => device.status === 'device');
+      const nameMatches = connectedName ? findAndroidNameMatches(authorized, connectedName) : [];
+      if (nameMatches.length === 1) {
+        const match = nameMatches[0];
+        return { platform: 'android', id: match.id, name: match.model };
+      }
+      // An opaque Metro logical ID is still evidence that a target is
+      // connected. With only one authorized Android device remaining, there
+      // is no competing local candidate to choose accidentally.
+      if (targetId(target) && authorized.length === 1) {
+        const device = authorized[0];
+        return { platform: 'android', id: device.id, name: device.model };
+      }
+    }
     const failed = [
       iosResult.status === 'rejected' ? 'iOS simulator' : null,
       androidResult.status === 'rejected' ? 'Android device' : null,
@@ -290,6 +314,11 @@ export async function resolveDevice(
     throw iosResult.reason instanceof Error ? iosResult.reason : new Error(String(iosResult.reason));
   }
   return null;
+}
+
+function isUnavailableToolError(reason: unknown): boolean {
+  return typeof reason === 'object' && reason !== null &&
+    'code' in reason && reason.code === 'ENOENT';
 }
 
 function findAndroidTarget(

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -52,6 +52,8 @@ export interface DeviceDiscoveryRunner {
 const DEVICE_DISCOVERY_TIMEOUT_MS = 5_000;
 
 export interface ConnectedDeviceTarget {
+  id?: string;
+  title?: string;
   appId?: string;
   deviceName?: string;
   reactNative?: { logicalDeviceId?: string };
@@ -66,6 +68,17 @@ export function getConnectedDeviceTarget(
   ctx: { cdp: { isConnected: boolean; getTarget(): ConnectedDeviceTarget | null } },
 ): ConnectedDeviceTarget | undefined {
   return ctx.cdp.isConnected ? ctx.cdp.getTarget() ?? undefined : undefined;
+}
+
+/** Retain the target identity while asynchronous native discovery runs. */
+export function snapshotConnectedDeviceTarget(
+  target: ConnectedDeviceTarget | undefined,
+): ConnectedDeviceTarget | undefined {
+  if (!target) return undefined;
+  return {
+    ...target,
+    ...(target.reactNative ? { reactNative: { ...target.reactNative } } : {}),
+  };
 }
 
 function outputText(output: Buffer | string): string {

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -50,6 +50,7 @@ export interface DeviceDiscoveryRunner {
 }
 
 export interface ConnectedDeviceTarget {
+  appId?: string;
   deviceName?: string;
   reactNative?: { logicalDeviceId?: string };
 }

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -237,7 +237,8 @@ export async function resolveDevice(
       // An opaque Metro logical ID is still evidence that a target is
       // connected. With only one authorized Android device remaining, there
       // is no competing local candidate to choose accidentally.
-      if (targetId(target) && authorized.length === 1) {
+      if (targetId(target) && authorized.length === 1 &&
+        (!connectedName || nameMatches.length === 1)) {
         const device = authorized[0];
         return { platform: 'android', id: device.id, name: device.model };
       }
@@ -252,7 +253,8 @@ export async function resolveDevice(
       // A connected opaque inspector ID plus one booted simulator is the
       // symmetric iOS case: the missing Android executable cannot hide a
       // competing local Android device.
-      if (targetId(target) && iosResult.value.length === 1) {
+      if (targetId(target) && iosResult.value.length === 1 &&
+        (!connectedName || nameMatches.length === 1)) {
         return toResolvedIos(iosResult.value[0]);
       }
     }

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -45,9 +45,11 @@ export interface DeviceDiscoveryRunner {
   execFile(
     command: string,
     args: string[],
-    options?: { maxBuffer?: number },
+    options?: { maxBuffer?: number; timeout?: number },
   ): Promise<Buffer | string>;
 }
+
+const DEVICE_DISCOVERY_TIMEOUT_MS = 5_000;
 
 export interface ConnectedDeviceTarget {
   appId?: string;
@@ -128,6 +130,7 @@ export function parseBootedSimulators(output: string): BootedSimulator[] {
 
 export async function discoverBootedSimulators(
   runner: DeviceDiscoveryRunner,
+  timeout = DEVICE_DISCOVERY_TIMEOUT_MS,
 ): Promise<BootedSimulator[]> {
   const output = await runner.execFile('xcrun', [
     'simctl',
@@ -135,7 +138,7 @@ export async function discoverBootedSimulators(
     'devices',
     'booted',
     '--json',
-  ]);
+  ], { timeout });
   return parseBootedSimulators(outputText(output));
 }
 
@@ -158,8 +161,9 @@ export function parseAndroidDevices(output: string): AndroidDevice[] {
 
 export async function discoverAndroidDevices(
   runner: DeviceDiscoveryRunner,
+  timeout = DEVICE_DISCOVERY_TIMEOUT_MS,
 ): Promise<AndroidDevice[]> {
-  const output = await runner.execFile('adb', ['devices', '-l']);
+  const output = await runner.execFile('adb', ['devices', '-l'], { timeout });
   return parseAndroidDevices(outputText(output));
 }
 
@@ -176,9 +180,10 @@ export async function resolveDevice(
   runner: DeviceDiscoveryRunner,
   platform: 'ios' | 'android' | 'auto',
   target?: ConnectedDeviceTarget | null,
+  discoveryTimeout = DEVICE_DISCOVERY_TIMEOUT_MS,
 ): Promise<ResolvedDevice | null> {
   if (platform === 'android') {
-    const devices = await discoverAndroidDevices(runner);
+    const devices = await discoverAndroidDevices(runner, discoveryTimeout);
     const connectedId = targetId(target);
     // Inspect the complete ADB inventory before dropping unavailable entries.
     // An offline or unauthorized exact match proves which Android target Metro
@@ -212,7 +217,7 @@ export async function resolveDevice(
   }
 
   if (platform === 'ios') {
-    const devices = await discoverBootedSimulators(runner);
+    const devices = await discoverBootedSimulators(runner, discoveryTimeout);
     // A target's name is not platform-qualified. A concrete simulator UDID
     // match is positive evidence that the connected target is iOS.
     const platformTarget = findIosId(devices, targetId(target)) ? target : undefined;
@@ -220,8 +225,8 @@ export async function resolveDevice(
   }
 
   const [iosResult, androidResult] = await Promise.allSettled([
-    discoverBootedSimulators(runner),
-    discoverAndroidDevices(runner),
+    discoverBootedSimulators(runner, discoveryTimeout),
+    discoverAndroidDevices(runner, discoveryTimeout),
   ]);
   // A connected target is stronger evidence than runtime ordering. This
   // matters when an Android app is connected while an unrelated iOS

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -237,6 +237,20 @@ export async function resolveDevice(
         return { platform: 'android', id: device.id, name: device.model };
       }
     }
+    if (
+      androidResult.status === 'rejected' &&
+      iosResult.status === 'fulfilled' &&
+      isUnavailableToolError(androidResult.reason)
+    ) {
+      const nameMatches = findIosNames(iosResult.value, connectedName);
+      if (nameMatches.length === 1) return toResolvedIos(nameMatches[0]);
+      // A connected opaque inspector ID plus one booted simulator is the
+      // symmetric iOS case: the missing Android executable cannot hide a
+      // competing local Android device.
+      if (targetId(target) && iosResult.value.length === 1) {
+        return toResolvedIos(iosResult.value[0]);
+      }
+    }
     const failed = [
       iosResult.status === 'rejected' ? 'iOS simulator' : null,
       androidResult.status === 'rejected' ? 'Android device' : null,

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -188,13 +188,30 @@ export async function resolveDevice(
   // simulator happens to be booted.
   const connectedId = targetId(target);
   const connectedName = target?.deviceName?.trim();
+  // Check concrete IDs across both inventories before considering names. A
+  // Metro logical ID is the only evidence that can unambiguously identify the
+  // connected runtime when another platform has a colliding device name.
+  const ios = iosResult.status === 'fulfilled'
+    ? findIosId(iosResult.value, connectedId)
+    : undefined;
+  const android = androidResult.status === 'fulfilled'
+    ? androidResult.value
+        .filter((device) => device.status === 'device')
+        .find((device) => device.id === connectedId)
+    : undefined;
+  if (ios && android) {
+    throw new Error(`Ambiguous connected device ID "${connectedId}" across iOS and Android.`);
+  }
+  if (ios) return toResolvedIos(ios);
+  if (android) return { platform: 'android', id: android.id, name: android.model };
+
   if (iosResult.status === 'fulfilled') {
-    const iosMatch = findIosTarget(iosResult.value, connectedId, connectedName);
+    const iosMatch = findIosName(iosResult.value, connectedName);
     if (iosMatch) return toResolvedIos(iosMatch);
   }
   if (androidResult.status === 'fulfilled') {
     const android = androidResult.value.filter((device) => device.status === 'device');
-    const match = findAndroidTarget(android, connectedId, connectedName);
+    const match = findAndroidTarget(android, undefined, connectedName);
     if (match) return { platform: 'android', id: match.id, name: match.model };
   }
   // A valid iOS inventory wins when both runtimes are present, matching the
@@ -244,7 +261,7 @@ function resolveIosDevice(
 ): ResolvedDevice | null {
   if (devices.length === 0) return null;
 
-  const match = findIosTarget(devices, targetId(target), target?.deviceName?.trim());
+  const match = findIosId(devices, targetId(target)) ?? findIosName(devices, target?.deviceName?.trim());
   if (match) return toResolvedIos(match);
 
   if (devices.length === 1) {
@@ -260,15 +277,19 @@ function toResolvedIos(device: BootedSimulator): ResolvedDevice {
   return { platform: 'ios', id: device.udid, name: device.name, runtime: device.runtime };
 }
 
-function findIosTarget(
+function findIosId(
   devices: BootedSimulator[],
   connectedId?: string,
-  connectedName?: string,
 ): BootedSimulator | undefined {
-  const byId = connectedId
+  return connectedId
     ? devices.find((device) => device.udid.toLowerCase() === connectedId.toLowerCase())
     : undefined;
-  if (byId) return byId;
+}
+
+function findIosName(
+  devices: BootedSimulator[],
+  connectedName?: string,
+): BootedSimulator | undefined {
   const byName = connectedName
     ? devices.filter((device) => device.name === connectedName)
     : [];

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -54,6 +54,17 @@ export interface ConnectedDeviceTarget {
   reactNative?: { logicalDeviceId?: string };
 }
 
+/**
+ * Return target metadata only while its CDP connection is current.
+ * metro-bridge retains the last target after disconnecting, so using that
+ * metadata during native discovery can reject or select a replacement device.
+ */
+export function getConnectedDeviceTarget(
+  ctx: { cdp: { isConnected: boolean; getTarget(): ConnectedDeviceTarget | null } },
+): ConnectedDeviceTarget | undefined {
+  return ctx.cdp.isConnected ? ctx.cdp.getTarget() ?? undefined : undefined;
+}
+
 function outputText(output: Buffer | string): string {
   return typeof output === 'string' ? output : output.toString('utf8');
 }
@@ -432,6 +443,6 @@ function findIosNames(
 export async function detectPlatform(
   ctx: PluginContext,
 ): Promise<'ios' | 'android' | null> {
-  const device = await resolveDevice(ctx, 'auto', ctx.cdp.getTarget());
+  const device = await resolveDevice(ctx, 'auto', getConnectedDeviceTarget(ctx));
   return device?.platform ?? null;
 }

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -181,7 +181,16 @@ export async function resolveDevice(
     const devices = await discoverAndroidDevices(runner);
     const authorized = devices.filter((device) => device.status === 'device');
     if (authorized.length === 0) return null;
-    const selected = findAndroidTarget(authorized, targetId(target), target?.deviceName?.trim())
+    // A target's name is not platform-qualified. A concrete serial match is
+    // the only inventory evidence that proves its metadata belongs to Android.
+    const platformTarget = targetId(target) && authorized.some(
+      (device) => device.id === targetId(target),
+    ) ? target : undefined;
+    const selected = findAndroidTarget(
+      authorized,
+      targetId(platformTarget),
+      platformTarget?.deviceName?.trim(),
+    )
       ?? (authorized.length === 1 ? authorized[0] : undefined);
     if (!selected) {
       throw new Error(
@@ -193,7 +202,10 @@ export async function resolveDevice(
 
   if (platform === 'ios') {
     const devices = await discoverBootedSimulators(runner);
-    return resolveIosDevice(devices, target);
+    // A target's name is not platform-qualified. A concrete simulator UDID
+    // match is positive evidence that the connected target is iOS.
+    const platformTarget = findIosId(devices, targetId(target)) ? target : undefined;
+    return resolveIosDevice(devices, platformTarget);
   }
 
   const [iosResult, androidResult] = await Promise.allSettled([

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -227,9 +227,9 @@ function findAndroidTarget(
   const byId = connectedId ? devices.find((device) => device.id === connectedId) : undefined;
   if (byId) return byId;
   if (!connectedName) return undefined;
-  // `adb devices -l` replaces spaces in model names with underscores.
-  const modelName = connectedName.replace(/_/g, ' ');
-  const matches = devices.filter((device) => device.model?.replace(/_/g, ' ') === modelName);
+  // ADB sanitizes every non-alphanumeric UTF-8 byte in its model field.
+  const modelName = Buffer.from(connectedName, 'utf8').toString('latin1').replace(/[^a-zA-Z0-9]/g, '_');
+  const matches = devices.filter((device) => device.model === modelName);
   if (matches.length > 1) {
     throw new Error(
       `Ambiguous Android devices named "${connectedName}": ${matches.map((device) => device.id).join(', ')}.`,

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -282,7 +282,6 @@ export async function resolveDevice(
   const androidNameMatches = connectedName
     ? findAndroidNameMatches(authorizedAndroid, connectedName)
     : [];
-  const hasConnectedIdentity = Boolean(connectedId || connectedName);
   if (iosNameMatches.length > 0 && androidNameMatches.length > 0) {
     throw new Error(
       `Ambiguous connected device name "${connectedName}" across iOS and Android: ` +
@@ -319,11 +318,12 @@ export async function resolveDevice(
       `${authorizedAndroid.map((device) => `${device.model ?? device.id} (${device.id})`).join(', ')}.`,
     );
   }
-  // A sole inventory is safe to use only when the connected target has no
-  // identity metadata. Any unmatched ID or name means this may be a sole
-  // device on the other platform; exact matches returned above already win.
+  // A sole inventory is safe to use when the connected target only exposes an
+  // opaque logical ID. A device name is useful contradiction evidence, while
+  // an unmatched logical ID may simply be an inspector-generated identifier;
+  // exact matches returned above already win.
   if (bootedIos.length > 0) {
-    if (bootedIos.length === 1 && hasConnectedIdentity) {
+    if (bootedIos.length === 1 && connectedName) {
       throw new Error(
         'Connected Metro target does not match the sole available iOS simulator.',
       );
@@ -332,7 +332,7 @@ export async function resolveDevice(
   }
   if (authorizedAndroid.length > 0) {
     if (authorizedAndroid.length === 1) {
-      if (hasConnectedIdentity) {
+      if (connectedName) {
         throw new Error(
           'Connected Metro target does not match the sole available Android device.',
         );

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -223,16 +223,27 @@ export async function resolveDevice(
   const ios = iosResult.status === 'fulfilled'
     ? findIosId(iosResult.value, connectedId)
     : undefined;
+  // Keep an exact Android ID match even when adb reports it as offline or
+  // unauthorized. The entry is still proof that the connected Metro target
+  // belongs to Android, so it must prevent a fallback to another device or a
+  // booted iOS simulator. Dispatch callers continue to use authorizedAndroid
+  // below and therefore never send commands to this unavailable entry.
   const android = androidResult.status === 'fulfilled'
-    ? androidResult.value
-        .filter((device) => device.status === 'device')
-        .find((device) => device.id === connectedId)
+    ? androidResult.value.find((device) => device.id === connectedId)
     : undefined;
   if (ios && android) {
     throw new Error(`Ambiguous connected device ID "${connectedId}" across iOS and Android.`);
   }
   if (ios) return toResolvedIos(ios);
-  if (android) return { platform: 'android', id: android.id, name: android.model };
+  if (android) {
+    if (android.status !== 'device') {
+      throw new Error(
+        `Connected Android device "${android.id}" is ${android.status}; ` +
+        'refusing to select another device.',
+      );
+    }
+    return { platform: 'android', id: android.id, name: android.model };
+  }
 
   // If one inventory failed, names and sole-device fallbacks are unsafe while
   // a Metro target is connected: the surviving inventory may describe an

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -299,13 +299,13 @@ export async function resolveDevice(
       iosResult.status === 'fulfilled' &&
       isUnavailableToolError(androidResult.reason)
     ) {
-      const nameMatches = findIosNames(iosResult.value, connectedName);
-      if (nameMatches.length === 1) return toResolvedIos(nameMatches[0]);
       // A connected opaque inspector ID plus one booted simulator is the
       // symmetric iOS case: the missing Android executable cannot hide a
-      // competing local Android device.
+      // competing local Android device. A matching name alone cannot prove
+      // that the connected target is iOS, so require the target to omit a
+      // name before using this sole-device fallback.
       if (connectedId && iosResult.value.length === 1 &&
-        (!connectedName || nameMatches.length === 1)) {
+        !connectedName) {
         return toResolvedIos(iosResult.value[0]);
       }
     }

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -205,15 +205,34 @@ export async function resolveDevice(
   if (ios) return toResolvedIos(ios);
   if (android) return { platform: 'android', id: android.id, name: android.model };
 
+  // If one inventory failed, names and sole-device fallbacks are unsafe while
+  // a Metro target is connected: the surviving inventory may describe an
+  // unrelated device. Require concrete identity evidence in that case and
+  // let callers retry after the failed discovery has recovered.
+  if (
+    (iosResult.status === 'rejected' || androidResult.status === 'rejected') &&
+    target != null
+  ) {
+    const failed = [
+      iosResult.status === 'rejected' ? 'iOS simulator' : null,
+      androidResult.status === 'rejected' ? 'Android device' : null,
+    ].filter(Boolean).join(' and ');
+    throw new Error(
+      `Unable to verify the connected device because ${failed} discovery failed. ` +
+      'Retry after device discovery is available.',
+    );
+  }
+
   // Resolve name evidence for both platforms before selecting either one.
   // A Metro target's name is not platform-qualified, so selecting the first
   // inventory to report a match can silently target an unrelated app when
   // both runtimes use the same model name.
-  const iosNameMatches = iosResult.status === 'fulfilled'
-    ? findIosNames(iosResult.value, connectedName)
-    : [];
+  const bootedIos = iosResult.status === 'fulfilled' ? iosResult.value : [];
   const authorizedAndroid = androidResult.status === 'fulfilled'
     ? androidResult.value.filter((device) => device.status === 'device')
+    : [];
+  const iosNameMatches = iosResult.status === 'fulfilled'
+    ? findIosNames(iosResult.value, connectedName)
     : [];
   const androidNameMatches = connectedName
     ? findAndroidNameMatches(authorizedAndroid, connectedName)
@@ -244,19 +263,26 @@ export async function resolveDevice(
     const match = androidNameMatches[0];
     return { platform: 'android', id: match.id, name: match.model };
   }
-  // A valid iOS inventory wins when both runtimes are present, matching the
-  // historical auto-selection order while making ambiguity explicit.
-  if (iosResult.status === 'fulfilled' && iosResult.value.length > 0) {
-    return resolveIosDevice(iosResult.value, target);
+  // Once the connected target's concrete identity and name evidence have
+  // been exhausted, runtime ordering cannot identify which platform it is on.
+  // Refuse to choose iOS merely because it happens to be listed first.
+  if (bootedIos.length > 0 && authorizedAndroid.length > 0) {
+    throw new Error(
+      'Ambiguous available devices across iOS and Android: ' +
+      `${bootedIos.map((device) => `${device.name} (${device.udid})`).join(', ')}; ` +
+      `${authorizedAndroid.map((device) => `${device.model ?? device.id} (${device.id})`).join(', ')}.`,
+    );
   }
-  if (androidResult.status === 'fulfilled') {
-    const authorized = androidResult.value.filter((device) => device.status === 'device');
-    if (authorized.length === 1) {
-      return { platform: 'android', id: authorized[0].id, name: authorized[0].model };
+  if (bootedIos.length > 0) {
+    return resolveIosDevice(bootedIos, target);
+  }
+  if (authorizedAndroid.length > 0) {
+    if (authorizedAndroid.length === 1) {
+      return { platform: 'android', id: authorizedAndroid[0].id, name: authorizedAndroid[0].model };
     }
-    if (authorized.length > 1) {
+    if (authorizedAndroid.length > 1) {
       throw new Error(
-        `Ambiguous Android devices: ${authorized.map((device) => device.id).join(', ')}.`,
+        `Ambiguous Android devices: ${authorizedAndroid.map((device) => device.id).join(', ')}.`,
       );
     }
   }

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -282,6 +282,7 @@ export async function resolveDevice(
   const androidNameMatches = connectedName
     ? findAndroidNameMatches(authorizedAndroid, connectedName)
     : [];
+  const hasConnectedIdentity = Boolean(connectedId || connectedName);
   if (iosNameMatches.length > 0 && androidNameMatches.length > 0) {
     throw new Error(
       `Ambiguous connected device name "${connectedName}" across iOS and Android: ` +
@@ -318,11 +319,24 @@ export async function resolveDevice(
       `${authorizedAndroid.map((device) => `${device.model ?? device.id} (${device.id})`).join(', ')}.`,
     );
   }
+  // A sole inventory is safe to use only when the connected target has no
+  // identity metadata. Any unmatched ID or name means this may be a sole
+  // device on the other platform; exact matches returned above already win.
   if (bootedIos.length > 0) {
+    if (bootedIos.length === 1 && hasConnectedIdentity) {
+      throw new Error(
+        'Connected Metro target does not match the sole available iOS simulator.',
+      );
+    }
     return resolveIosDevice(bootedIos, target);
   }
   if (authorizedAndroid.length > 0) {
     if (authorizedAndroid.length === 1) {
+      if (hasConnectedIdentity) {
+        throw new Error(
+          'Connected Metro target does not match the sole available Android device.',
+        );
+      }
       return { platform: 'android', id: authorizedAndroid[0].id, name: authorizedAndroid[0].model };
     }
     if (authorizedAndroid.length > 1) {

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -227,7 +227,9 @@ function findAndroidTarget(
   const byId = connectedId ? devices.find((device) => device.id === connectedId) : undefined;
   if (byId) return byId;
   if (!connectedName) return undefined;
-  const matches = devices.filter((device) => device.model === connectedName);
+  // `adb devices -l` replaces spaces in model names with underscores.
+  const modelName = connectedName.replace(/_/g, ' ');
+  const matches = devices.filter((device) => device.model?.replace(/_/g, ' ') === modelName);
   if (matches.length > 1) {
     throw new Error(
       `Ambiguous Android devices named "${connectedName}": ${matches.map((device) => device.id).join(', ')}.`,

--- a/src/utils/device-discovery.ts
+++ b/src/utils/device-discovery.ts
@@ -1,3 +1,4 @@
+import { isIP } from 'node:net';
 import type { PluginContext } from '../plugin.js';
 
 /** A booted simulator as reported by CoreSimulatorService. */
@@ -12,7 +13,11 @@ export interface BootedSimulator {
 // commands. Keep only identifier characters so inventory data cannot turn into
 // shell syntax before those commands are migrated to execFile.
 export function isSafeDeviceId(value: string): boolean {
-  return /^[A-Za-z0-9._:-]+$/.test(value);
+  if (/^[A-Za-z0-9._:-]+$/.test(value)) return true;
+  const networkSerial = value.match(/^\[([^\]]+)\]:(\d{1,5})$/);
+  if (!networkSerial || isIP(networkSerial[1]) !== 6) return false;
+  const port = Number(networkSerial[2]);
+  return port >= 1 && port <= 65_535;
 }
 
 /** Safely scope a legacy shell based adb command to one resolved serial. */

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -77,6 +77,29 @@ describe('raw app evaluation', () => {
     await expect(evaluateAppScript(cdp, 'increment();')).rejects.toThrow('WebSocket closed');
     expect(calls).toHaveLength(1);
   });
+
+  test('preserves CDP unserializable primitive completions', async () => {
+    const values: Array<[string, unknown]> = [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['-0', -0],
+      ['123456789012345678901234567890n', 123456789012345678901234567890n],
+    ];
+    for (const [unserializableValue, expected] of values) {
+      const { cdp } = cdpHarness({
+        result: { type: 'number', unserializableValue },
+      });
+      const actual = await evaluateAppScript(cdp, 'completion');
+      if (typeof expected === 'number' && Object.is(expected, -0)) {
+        expect(Object.is(actual, -0)).toBe(true);
+      } else if (typeof expected === 'number' && Number.isNaN(expected)) {
+        expect(Number.isNaN(actual)).toBe(true);
+      } else {
+        expect(actual).toBe(expected);
+      }
+    }
+  });
 });
 
 function vmTransport() {
@@ -126,6 +149,9 @@ function vmTransport() {
     },
     replaceContext() {
       appGlobal = vm.createContext({ setTimeout, clearTimeout });
+      remoteObjects = new Map();
+    },
+    invalidateHandles() {
       remoteObjects = new Map();
     },
     get context() {
@@ -223,7 +249,7 @@ describe('shared app evaluation policy', () => {
     expect(calls.length).toBeGreaterThan(2);
   });
 
-  test('reconnects a remote settlement attachment lost before dispatch', async () => {
+  test('leaves a pre-dispatch settlement loss pending without replay', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let settlementAttempts = 0;
@@ -239,35 +265,91 @@ describe('shared app evaluation policy', () => {
 
     await expect(evalInApp(
       'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
-      { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe(1);
+      { awaitPromise: true, timeout: 40 },
+    )).rejects.toThrow('timed out');
     expect(transport.context).toHaveProperty('executionCount', 1);
     expect(state.state().reconnectCount).toBe(1);
-    expect(settlementAttempts).toBe(2);
+    expect(settlementAttempts).toBe(1);
   });
 
-  test('reconnects a remote settlement attachment after a lost response', async () => {
+  test('recovers a lost settlement response without replaying a side-effecting thenable', async () => {
     const { transport } = vmTransport();
     const originalSend = transport.send;
     let settlementAttempts = 0;
     transport.send = async (method, params) => {
-      const result = await originalSend(method, params);
       if (method === 'Runtime.callFunctionOn') {
         settlementAttempts += 1;
+        const result = await originalSend(method, params);
         if (settlementAttempts === 1) throw new Error('WebSocket closed');
+        return result;
       }
-      return result;
+      return originalSend(method, params);
     };
-    const state = lifecycle();
+    let reconnects = 0;
+    const state = lifecycle({ reconnect: async () => {
+      reconnects += 1;
+      transport.invalidateHandles();
+    } });
     const evalInApp = createAppEvaluator(transport, state);
 
     await expect(evalInApp(
-      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      `globalThis.thenCalls = 0;
+       ({ then: function(resolve) { globalThis.thenCalls += 1; resolve(7); } });`,
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe(1);
-    expect(transport.context).toHaveProperty('executionCount', 1);
-    expect(state.state().reconnectCount).toBe(1);
-    expect(settlementAttempts).toBe(2);
+    )).resolves.toBe(7);
+    expect(transport.context).toHaveProperty('thenCalls', 1);
+    expect(reconnects).toBe(1);
+    expect(settlementAttempts).toBe(1);
+  });
+
+  test('does not dispatch source when runtime generation changes after mailbox setup', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 0;
+    const base = lifecycle();
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+      ensureConnected: async () => {
+        if (calls.filter((call) => call.method === 'Runtime.evaluate').length === 1) {
+          generation += 1;
+        }
+      },
+    });
+
+    await expect(evalInApp(
+      'globalThis.sourceMutation = true; Promise.resolve(1);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('context changed before source dispatch');
+    expect(transport.context).not.toHaveProperty('sourceMutation');
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
+  });
+
+  test('rejects a generation change immediately after mailbox setup response', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 0;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        generation += 1;
+      }
+      return result;
+    };
+    const base = lifecycle();
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+    });
+
+    await expect(evalInApp(
+      'globalThis.sourceMutation = true; Promise.resolve(1);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('context changed during mailbox setup');
+    expect(transport.context).not.toHaveProperty('sourceMutation');
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
   });
 
   test('does not retry remote settlement after a deadline-bounded reconnect', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -770,6 +770,18 @@ describe('shared app evaluation policy', () => {
       'globalThis.flag = false; let i = 0; L: while (i < 1) { i += 1; Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { continue L; } }',
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('before');
+
+    const retainsFinalizerCompletionWhenCaught = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(retainsFinalizerCompletionWhenCaught(
+      'globalThis.flag = false; L: { Promise.resolve("before"); try { try {} finally { Promise.resolve("leak"); if (flag) break L; throw 0; } } catch {} }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('leak');
+
+    const inheritsGuardedCompletionThroughReplacedExit = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(inheritsGuardedCompletionThroughReplacedExit(
+      'if (true) { A: { B: try { Promise.resolve("guarded"); break A; } finally { break B; } } } else Promise.resolve("other")',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
   });
 
   test('observes a completion expression before trailing declarations', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -279,6 +279,57 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('serverLevelRetryCount'))).toHaveLength(1);
   });
 
+  test('does not retry a dispatched mutation that reports the server guidance string', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    const cdp = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>): Promise<unknown> => {
+        const result = await originalSend(method, params, options);
+        if (method === 'Runtime.evaluate' && String(params?.expression).includes('__dispatchedServerError')) {
+          return {
+            exceptionDetails: {
+              text: 'Not connected to Metro. Use list_devices to check connection status.',
+            },
+          };
+        }
+        return result;
+      },
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(cdp, state);
+
+    await expect(evalInApp(
+      'globalThis.__dispatchedServerError = (globalThis.__dispatchedServerError || 0) + 1; __dispatchedServerError;',
+      { awaitPromise: false, timeout: 1000 },
+    )).rejects.toThrow('Not connected to Metro. Use list_devices to check connection status.');
+    expect(transport.context).toHaveProperty('__dispatchedServerError', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('__dispatchedServerError'))).toHaveLength(1);
+  });
+
+  test('does not dispatch after server-level recovery reaches the deadline', async () => {
+    const { transport, calls } = vmTransport();
+    let ensureAttempts = 0;
+    const evalInApp = createAppEvaluator(transport, lifecycle({
+      ensureConnected: async () => {
+        ensureAttempts += 1;
+        throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+      },
+      reconnect: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40));
+      },
+    }));
+
+    await expect(evalInApp('globalThis.mustNotDispatch = true;', {
+      awaitPromise: false,
+      timeout: 10,
+      deadline: Date.now() + 10,
+    })).rejects.toThrow('timed out');
+    expect(ensureAttempts).toBe(1);
+    expect(calls).toHaveLength(0);
+  });
+
   test('does not retry a duration-bearing evaluation timeout after dispatch', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -257,6 +257,28 @@ describe('shared app evaluation policy', () => {
     expect(state.state().reconnectCount).toBe(1);
   });
 
+  test('retries the server-level disconnected error before raw source dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    let ensureAttempts = 0;
+    const state = lifecycle({
+      ensureConnected: async () => {
+        ensureAttempts += 1;
+        if (ensureAttempts === 1) {
+          throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+        }
+      },
+    });
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.serverLevelRetryCount = (globalThis.serverLevelRetryCount || 0) + 1; serverLevelRetryCount;',
+      { awaitPromise: false, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(ensureAttempts).toBe(2);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('serverLevelRetryCount'))).toHaveLength(1);
+  });
+
   test('does not retry a duration-bearing evaluation timeout after dispatch', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -1212,6 +1212,57 @@ describe('shared app evaluation policy', () => {
     expect(settlementAttempts).toBe(1);
   });
 
+  test('polls the mailbox when the runtime generation changes after source dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 1;
+    const originalSend = transport.send;
+    transport.send = async (method, params, options) => {
+      const result = await originalSend(method, params, options);
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('generationAfterSource')) {
+        generation += 1;
+      }
+      return result;
+    };
+    const base = lifecycle();
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+    });
+
+    await expect(evalInApp(
+      'globalThis.generationAfterSourceExecutions = (globalThis.generationAfterSourceExecutions || 0) + 1; globalThis.generationAfterSource = new Promise(resolve => setTimeout(() => resolve(7), 10)); generationAfterSource;',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(7);
+    expect(transport.context).toHaveProperty('generationAfterSourceExecutions', 1);
+    expect(calls.filter((call) => call.method === 'Runtime.callFunctionOn')).toHaveLength(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('generationAfterSource'))).toHaveLength(1);
+  });
+
+  test('polls the mailbox after a stale completion handle error', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params, options) => {
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        await originalSend(method, params, options);
+        throw new Error('Could not find object with given id');
+      }
+      return originalSend(method, params, options);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'globalThis.staleSettlementExecutions = (globalThis.staleSettlementExecutions || 0) + 1; new Promise(resolve => setTimeout(() => resolve(8), 10));',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(8);
+    expect(transport.context).toHaveProperty('staleSettlementExecutions', 1);
+    expect(settlementAttempts).toBe(1);
+    expect(calls.filter((call) => call.method === 'Runtime.callFunctionOn')).toHaveLength(1);
+  });
+
   test('recreates the mailbox when generation changes after mailbox setup', async () => {
     const { transport, calls } = vmTransport();
     let generation = 0;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -335,4 +335,27 @@ describe('shared app evaluation policy', () => {
       .resolves.toBe(1);
     expect(Date.now() - started).toBeLessThan(500);
   });
+
+  test('does not delay a settled remote result for bounded group cleanup', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let groupReleaseStarted = false;
+    transport.send = async (method, params, options) => {
+      if (method === 'Runtime.releaseObjectGroup') {
+        groupReleaseStarted = true;
+        return new Promise(() => {});
+      }
+      return originalSend(method, params, options);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const started = Date.now();
+
+    await expect(evalInApp(
+      'new Promise(resolve => setTimeout(() => resolve(42), 10));',
+      { awaitPromise: true, timeout: 40 },
+    )).resolves.toBe(42);
+    expect(Date.now() - started).toBeLessThan(100);
+    expect(groupReleaseStarted).toBe(true);
+    expect(calls.some((call) => call.method === 'Runtime.releaseObject')).toBe(false);
+  });
 });

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from 'bun:test';
+import vm from 'node:vm';
+import { createAppEvaluator, evaluateAppScript } from './evaluate-app.js';
+
+function cdpHarness(response: unknown) {
+  const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const cdp = {
+    send: async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (response instanceof Error) throw response;
+      return response;
+    },
+  };
+  return { cdp, calls };
+}
+
+describe('raw app evaluation', () => {
+  test('uses synchronous CDP completion semantics and forwards timeout', async () => {
+    const { cdp, calls } = cdpHarness({ result: { value: 42 } });
+    await expect(evaluateAppScript(cdp, 'var answer = 42; answer;', { timeout: 1234 }))
+      .resolves.toBe(42);
+    expect(calls).toEqual([{
+      method: 'Runtime.evaluate',
+      params: {
+        expression: 'var answer = 42; answer;',
+        returnByValue: true,
+        awaitPromise: false,
+        timeout: 1234,
+      },
+    }]);
+  });
+
+  test('reports CDP exceptions without replaying the script', async () => {
+    const { cdp, calls } = cdpHarness({
+      exceptionDetails: { text: 'script failed' },
+    });
+    await expect(evaluateAppScript(cdp, 'mutateOnce();')).rejects.toThrow('script failed');
+    expect(calls).toHaveLength(1);
+  });
+
+  test('propagates an ambiguous transport failure after one dispatch', async () => {
+    const { cdp, calls } = cdpHarness(new Error('WebSocket closed'));
+    await expect(evaluateAppScript(cdp, 'increment();')).rejects.toThrow('WebSocket closed');
+    expect(calls).toHaveLength(1);
+  });
+});
+
+function vmTransport() {
+  let appGlobal = vm.createContext({ setTimeout, clearTimeout });
+  const calls: Array<Record<string, unknown>> = [];
+  const transport = {
+    send: async (_method: string, params?: Record<string, unknown>) => {
+      calls.push(params ?? {});
+      const result = new vm.Script(String(params?.expression)).runInContext(appGlobal);
+      return {
+        result: {
+          value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)),
+        },
+      };
+    },
+    replaceContext() {
+      appGlobal = vm.createContext({ setTimeout, clearTimeout });
+    },
+    get context() {
+      return appGlobal;
+    },
+  };
+  return { transport, calls };
+}
+
+function lifecycle(overrides: Partial<{
+  ensureConnected: () => Promise<void>;
+  waitForReconnect: () => Promise<void>;
+  reconnect: () => Promise<void>;
+  isReconnecting: () => boolean;
+}> = {}) {
+  let reconnecting = false;
+  let reconnectCount = 0;
+  return {
+    state: () => ({ reconnectCount }),
+    ensureConnected: overrides.ensureConnected ?? (async () => {}),
+    waitForReconnect: overrides.waitForReconnect ?? (async () => {}),
+    reconnect: overrides.reconnect ?? (async () => { reconnectCount += 1; }),
+    isReconnecting: overrides.isReconnecting ?? (() => reconnecting),
+  };
+}
+
+describe('shared app evaluation policy', () => {
+  test('does not replay a script after an ambiguous initial dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const initialContext = transport.context;
+    let first = true;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (first) {
+        first = false;
+        throw new Error('WebSocket closed');
+      }
+      return result;
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('WebSocket closed');
+    expect(initialContext).toHaveProperty('executionCount', 1);
+    expect(calls).toHaveLength(2); // initial dispatch plus mailbox cleanup
+  });
+
+  test('reconnects mailbox reads without replaying the original source', async () => {
+    const { transport, calls } = vmTransport();
+    let firstPoll = true;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (firstPoll && calls.length === 1) {
+        firstPoll = false;
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; new Promise(resolve => setTimeout(() => resolve(executionCount), 10));',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(calls.length).toBeGreaterThan(2);
+  });
+
+  test('keeps unawaited evaluation one-shot after an ambiguous dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const initialContext = transport.context;
+    let first = true;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (first) {
+        first = false;
+        await originalSend(method, params);
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; executionCount;',
+      { awaitPromise: false },
+    )).rejects.toThrow('WebSocket closed');
+    expect(initialContext).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.awaitPromise).toBe(false);
+  });
+
+  test('reports a lost mailbox when reconnect lands in a new app context', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 1) transport.replaceContext();
+      return originalSend(method, params);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'new Promise(resolve => setTimeout(() => resolve(1), 20));',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('context was lost');
+  });
+
+  test('bounds a stalled initial CDP request by the caller deadline', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const transport = {
+      send: async (_method: string, params?: Record<string, unknown>) => {
+        calls.push(params ?? {});
+        return new Promise(() => {});
+      },
+    };
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
+      .rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 1) return new Promise(() => {});
+      return originalSend(method, params);
+    };
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
+      .rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('bounds reconnect recovery after a dropped mailbox read', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 0) return originalSend(method, params);
+      throw new Error('WebSocket closed');
+    };
+    const state = lifecycle({ reconnect: async () => new Promise(() => {}) });
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
+      .rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test('keeps stalled cleanup best effort within the absolute deadline', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (calls.length === 2) return new Promise(() => {});
+      return originalSend(method, params);
+    };
+    const started = Date.now();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
+      .resolves.toBe(1);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+});

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -223,6 +223,83 @@ describe('shared app evaluation policy', () => {
     expect(calls.length).toBeGreaterThan(2);
   });
 
+  test('reconnects a remote settlement attachment lost before dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        if (settlementAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(settlementAttempts).toBe(2);
+  });
+
+  test('reconnects a remote settlement attachment after a lost response', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        if (settlementAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return result;
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(settlementAttempts).toBe(2);
+  });
+
+  test('does not retry remote settlement after a deadline-bounded reconnect', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    let settlementAttempts = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.callFunctionOn') {
+        settlementAttempts += 1;
+        if (settlementAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    let reconnects = 0;
+    const state = lifecycle({
+      reconnect: async () => {
+        reconnects += 1;
+        await new Promise((resolve) => setTimeout(resolve, 60));
+      },
+    });
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; new Promise(resolve => setTimeout(() => resolve(executionCount), 100));',
+      { awaitPromise: true, timeout: 30 },
+    )).rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(settlementAttempts).toBe(1);
+    expect(reconnects).toBe(1);
+  });
+
   test('keeps unawaited evaluation one-shot after an ambiguous dispatch', async () => {
     const { transport, calls } = vmTransport();
     const initialContext = transport.context;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -226,6 +226,20 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('executionCount'))).toHaveLength(1);
   });
 
+  test('settles hostile Promise rejection reasons instead of timing out', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'Promise.reject(Object.create(null))',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('unstringifiable reason');
+    await expect(evalInApp(
+      'Promise.reject({ get message() { throw new Error("message unavailable"); } })',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('[object Object]');
+  });
+
   test('reconnects mailbox reads without replaying the original source', async () => {
     const { transport, calls } = vmTransport();
     let firstPoll = true;
@@ -458,6 +472,30 @@ describe('shared app evaluation policy', () => {
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
     expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded cleanup
+  });
+
+  test('does not reconnect after a mailbox poll rejects after the deadline', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    let reconnects = 0;
+    transport.send = async (method, params, options) => {
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params, options);
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle({
+      reconnect: async () => { reconnects += 1; },
+    }));
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 30 },
+    )).rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(reconnects).toBe(0);
   });
 
   test('bounds reconnect recovery after a dropped mailbox read', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -226,6 +226,120 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('executionCount'))).toHaveLength(1);
   });
 
+  test('retries an exact pre-dispatch disconnect without replaying a raw script', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let first = true;
+    let sourceAttempts = 0;
+    transport.send = async (method, params) => {
+      if (first && method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
+        first = false;
+        sourceAttempts += 1;
+        throw new Error('Not connected to CDP target');
+      }
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) sourceAttempts += 1;
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; executionCount;',
+      { awaitPromise: false },
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(sourceAttempts).toBe(2);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+    expect(state.state().reconnectCount).toBe(1);
+  });
+
+  test('does not retry a duration-bearing evaluation timeout after dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      const result = await originalSend(method, params);
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
+        throw new Error('App evaluation timed out after 30ms');
+      }
+      return result;
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; executionCount;',
+      { awaitPromise: false },
+    )).rejects.toThrow('App evaluation timed out after 30ms');
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
+  test('retries an exact pre-dispatch disconnect before awaited source execution', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let sourceAttempts = 0;
+    let setupAttempts = 0;
+    let generation = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        setupAttempts += 1;
+      }
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
+        sourceAttempts += 1;
+        if (sourceAttempts === 1) throw new Error('Not connected to CDP target');
+      }
+      return originalSend(method, params);
+    };
+    const base = lifecycle({ reconnect: async () => { generation += 1; } });
+    const state = { ...base, getGeneration: () => generation };
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(sourceAttempts).toBe(2);
+    expect(setupAttempts).toBe(2);
+    expect(generation).toBe(1);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
+  test('retries mailbox setup after transport loss before source dispatch', async () => {
+    const { transport, calls } = vmTransport();
+    const originalSend = transport.send;
+    let setupAttempts = 0;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        setupAttempts += 1;
+        if (setupAttempts === 1) throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(transport, state);
+
+    await expect(evalInApp(
+      'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(setupAttempts).toBe(2);
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(1);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
   test('settles hostile Promise rejection reasons instead of timing out', async () => {
     const { transport } = vmTransport();
     const evalInApp = createAppEvaluator(transport, lifecycle());

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -966,6 +966,43 @@ describe('shared app evaluation policy', () => {
       String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
   });
 
+  test('recreates the mailbox after server-level recovery changes the runtime generation', async () => {
+    const { transport, calls } = vmTransport();
+    let generation = 1;
+    let ensureAttempts = 0;
+    let mailboxSetups = 0;
+    const originalSend = transport.send;
+    transport.send = async (method, params) => {
+      if (method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+        mailboxSetups += 1;
+      }
+      return originalSend(method, params);
+    };
+    const base = lifecycle({
+      ensureConnected: async () => {
+        ensureAttempts += 1;
+        if (ensureAttempts === 2) {
+          throw new Error('Not connected to Metro. Use list_devices to check connection status.');
+        }
+      },
+      reconnect: async () => { generation = 2; },
+    });
+    const evalInApp = createAppEvaluator(transport, {
+      ...base,
+      getGeneration: () => generation,
+    });
+
+    await expect(evalInApp(
+      'globalThis.generationRecoverySource = (globalThis.generationRecoverySource || 0) + 1; Promise.resolve(generationRecoverySource);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    expect(generation).toBe(2);
+    expect(mailboxSetups).toBe(2);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('generationRecoverySource'))).toHaveLength(1);
+  });
+
   test('does not retry remote settlement after a deadline-bounded reconnect', async () => {
     const { transport } = vmTransport();
     const originalSend = transport.send;

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -198,7 +198,7 @@ describe('shared app evaluation policy', () => {
     await expect(evaluate('mutate()', { awaitPromise: true, timeout: 10 })).rejects.toThrow('timed out');
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(calls.filter((call) => call.method === 'Runtime.evaluate')).toHaveLength(0);
-    expect(calls).toHaveLength(1); // bounded late-completion group cleanup
+    expect(calls).toHaveLength(0); // no cleanup request remains within the deadline
   });
 
   test('does not replay a script after an ambiguous initial dispatch', async () => {
@@ -278,6 +278,81 @@ describe('shared app evaluation policy', () => {
     expect(state.state().reconnectCount).toBe(0);
     expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('executionCount'))).toHaveLength(1);
+  });
+
+  test('does not retry an app exception that uses the Bridge disconnect message', async () => {
+    const { transport, calls } = vmTransport();
+    const cdp = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>): Promise<unknown> => {
+        const result = await transport.send(method, params, options);
+        if (method === 'Runtime.evaluate' &&
+            String(params?.expression).includes('__appExceptionMarker')) {
+          return { exceptionDetails: { text: 'Not connected to CDP target' } };
+        }
+        return result;
+      },
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(cdp, state);
+
+    await expect(evalInApp(
+      `globalThis.executionCount = (globalThis.executionCount || 0) + 1;
+       globalThis.__appExceptionMarker = true;
+       Promise.resolve(executionCount);`,
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('Not connected to CDP target');
+    expect(transport.context).toHaveProperty('executionCount', 1);
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('__appExceptionMarker'))).toHaveLength(1);
+  });
+
+  test('does not retry a remote settlement app exception that uses the Bridge disconnect message', async () => {
+    const { transport, calls } = vmTransport();
+    const cdp = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>): Promise<unknown> => {
+        const result = await transport.send(method, params, options);
+        if (method === 'Runtime.callFunctionOn') {
+          return { exceptionDetails: { text: 'Not connected to CDP target' } };
+        }
+        return result;
+      },
+    };
+    const state = lifecycle();
+    const evalInApp = createAppEvaluator(cdp, state);
+
+    await expect(evalInApp(
+      'Promise.resolve(42)',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('Not connected to CDP target');
+    expect(state.state().reconnectCount).toBe(0);
+    expect(calls.filter((call) => call.method === 'Runtime.callFunctionOn')).toHaveLength(1);
+  });
+
+  test('honors an explicit absolute deadline across awaited stages', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const deadline = Date.now() + 40;
+    const started = Date.now();
+
+    await expect(evalInApp(
+      'new Promise(() => {})',
+      { awaitPromise: true, timeout: 1000, deadline },
+    )).rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test('keeps the requested timeout when an explicit deadline is later', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const deadline = Date.now() + 200;
+    const started = Date.now();
+
+    await expect(evalInApp(
+      'new Promise(() => {})',
+      { awaitPromise: true, timeout: 40, deadline },
+    )).rejects.toThrow('timed out');
+    expect(Date.now() - started).toBeLessThan(150);
   });
 
   test('retries an exact pre-dispatch disconnect before awaited source execution', async () => {
@@ -567,7 +642,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(2); // stalled setup plus bounded group cleanup
+    expect(calls).toHaveLength(1); // stalled setup; cleanup has no remaining budget
   });
 
   test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
@@ -585,7 +660,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded cleanup
+    expect(calls).toHaveLength(3); // setup, source, and stalled poll
   });
 
   test('does not reconnect after a mailbox poll rejects after the deadline', async () => {
@@ -651,9 +726,13 @@ describe('shared app evaluation policy', () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let groupReleaseStarted = false;
+    const deadline = Date.now() + 100;
     transport.send = async (method, params, options) => {
       if (method === 'Runtime.releaseObjectGroup') {
         groupReleaseStarted = true;
+        const timeoutMs = Number(options?.timeoutMs);
+        expect(timeoutMs).toBeLessThan(100);
+        expect(timeoutMs).toBeLessThanOrEqual(deadline - Date.now() + 2);
         return new Promise(() => {});
       }
       return originalSend(method, params, options);
@@ -662,8 +741,8 @@ describe('shared app evaluation policy', () => {
     const started = Date.now();
 
     await expect(evalInApp(
-      'new Promise(resolve => setTimeout(() => resolve(42), 10));',
-      { awaitPromise: true, timeout: 40 },
+      'new Promise(resolve => setTimeout(() => resolve(42), 70));',
+      { awaitPromise: true, timeout: 1000, deadline },
     )).resolves.toBe(42);
     expect(Date.now() - started).toBeLessThan(100);
     expect(groupReleaseStarted).toBe(true);

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -463,6 +463,20 @@ describe('shared app evaluation policy', () => {
     )).resolves.toBe('final loop completion');
     expect(transport.context.observedPromises).toContain('final');
     expect(transport.context.observedPromises).not.toContain('discarded');
+    await expect(evalInApp(
+      `marked(Promise.resolve('discarded branch value'), 'discarded-branch');
+       if (false) Promise.resolve('untaken');`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      `while (true) {
+         marked(Promise.resolve('discarded break value'), 'discarded-break');
+         if (true) break;
+       }`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    expect(transport.context.observedPromises).not.toContain('discarded-branch');
+    expect(transport.context.observedPromises).not.toContain('discarded-break');
     await expect(evalInApp('Promise.prototype.then = globalThis.originalThen; void 0;', {
       awaitPromise: false,
     })).resolves.toBeUndefined();
@@ -498,7 +512,11 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('"use strict"; if (false) Promise.resolve(9)', {
       awaitPromise: true,
       timeout: 1000,
-    })).resolves.toBe('use strict');
+    })).resolves.toBeUndefined();
+    await expect(evalInApp('"use strict"; while (false) Promise.resolve(9)', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBeUndefined();
     await expect(evalInApp('Promise.resolve(9) // trailing line comment', {
       awaitPromise: true,
       timeout: 1000,
@@ -513,9 +531,6 @@ describe('shared app evaluation policy', () => {
       'try { Promise.reject(new Error("try completion rejection")); } finally {}',
       'try { Promise.reject(new Error("try/finally completion rejection")); } finally { Promise.resolve(1); }',
       'switch (1) { case 1: Promise.resolve(1); case 2: Promise.reject(new Error("switch completion rejection")); break; }',
-      'switch (1) { case 1: Promise.reject(new Error("conditional break completion rejection")); if (true) break; Promise.resolve(2); }',
-      'for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("conditional continue completion rejection")); if (true) continue; Promise.resolve(2); }',
-      'const flag = true; L: for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("labeled continue completion rejection")); if (flag) continue L; Promise.resolve(2); }',
     ];
     let unhandledRejections = 0;
     const onUnhandledRejection = () => { unhandledRejections += 1; };
@@ -549,7 +564,6 @@ describe('shared app evaluation policy', () => {
   test('retains labeled break paths through finalizers and nested switches', async () => {
     const sources = [
       'const flag = true; L: { try { throw 1; } finally { if (flag) break L; } } Promise.reject(new Error("outer labeled completion rejection"));',
-      'const flag = true; L: { switch (1) { case 1: Promise.reject(new Error("nested switch labeled break rejection")); if (flag) break L; Promise.resolve(2); } }',
     ];
     let unhandledRejections = 0;
     const onUnhandledRejection = () => { unhandledRejections += 1; };
@@ -569,24 +583,60 @@ describe('shared app evaluation policy', () => {
         timeout: 1000,
       })).rejects.toThrow('outer labeled completion rejection');
 
-      const second = vmTransport();
-      const secondSend = second.transport.send;
-      second.transport.send = async (method, params, options) => {
-        const result = await secondSend(method, params, options);
-        if (method === 'Runtime.evaluate' && String(params?.expression).includes('nested switch labeled break rejection')) {
-          await new Promise((resolve) => setTimeout(resolve, 30));
-        }
-        return result;
-      };
-      await expect(createAppEvaluator(second.transport, lifecycle())(sources[1]!, {
-        awaitPromise: true,
-        timeout: 1000,
-      })).rejects.toThrow('nested switch labeled break rejection');
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(unhandledRejections).toBe(0);
     } finally {
       process.off('unhandledRejection', onUnhandledRejection);
     }
+  });
+
+  test('matches native empty completions across untaken branches and exits', async () => {
+    const evaluate = (source: string) => createAppEvaluator(vmTransport().transport, lifecycle())(
+      source,
+      { awaitPromise: true, timeout: 1000 },
+    );
+
+    await expect(evaluate('Promise.resolve("discarded"); if (false) 2')).resolves.toBeUndefined();
+    await expect(evaluate('while (false) Promise.resolve("discarded")')).resolves.toBeUndefined();
+    await expect(evaluate('for (let i = 0; i < 0; i += 1) Promise.resolve("discarded")'))
+      .resolves.toBeUndefined();
+    await expect(evaluate('while (true) { Promise.resolve("direct"); break; }'))
+      .resolves.toBe('direct');
+    await expect(evaluate('while (true) { Promise.resolve("conditional"); if (true) break; }'))
+      .resolves.toBeUndefined();
+    await expect(evaluate(
+      'let i = 0; while (i < 2) { i += 1; if (i === 1) { Promise.resolve("discarded"); continue; } Promise.resolve("final"); }',
+    )).resolves.toBe('final');
+    await expect(evaluate('switch (1) { case 1: Promise.resolve("direct"); break; }'))
+      .resolves.toBe('direct');
+    await expect(evaluate('switch (1) { case 1: Promise.resolve("conditional"); if (true) break; }'))
+      .resolves.toBeUndefined();
+    await expect(evaluate(
+      'while (true) { if (true) break; Promise.resolve("unreachable after break"); }',
+    )).resolves.toBeUndefined();
+    await expect(evaluate(
+      'let i = 0; while (i < 1) { i += 1; if (true) continue; Promise.resolve("unreachable after continue"); }',
+    )).resolves.toBeUndefined();
+  });
+
+  test('keeps guarded values only when a finally exit is not taken', async () => {
+    const taken = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(taken(
+      'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+
+    const skipped = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(skipped(
+      'globalThis.flag = false; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const continued = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(continued(
+      'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { if (i === 1) continue outer; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
   });
 
   test('observes a completion expression before trailing declarations', async () => {
@@ -978,7 +1028,7 @@ describe('shared app evaluation policy', () => {
     expect(settlementAttempts).toBe(1);
   });
 
-  test('does not dispatch source when runtime generation changes after mailbox setup', async () => {
+  test('recreates the mailbox when generation changes after mailbox setup', async () => {
     const { transport, calls } = vmTransport();
     let generation = 0;
     const base = lifecycle();
@@ -995,10 +1045,10 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp(
       'globalThis.sourceMutation = true; Promise.resolve(1);',
       { awaitPromise: true, timeout: 1000 },
-    )).rejects.toThrow('context changed before source dispatch');
-    expect(transport.context).not.toHaveProperty('sourceMutation');
+    )).resolves.toBe(1);
+    expect(transport.context).toHaveProperty('sourceMutation', true);
     expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('sourceMutation'))).toHaveLength(0);
+      String(call.params.expression).includes('sourceMutation'))).toHaveLength(1);
   });
 
   test('rejects a generation change immediately after mailbox setup response', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -125,10 +125,11 @@ function vmTransport() {
             (typeof result === 'object' || typeof result === 'function')) {
           const objectId = `remote-${++nextObjectId}`;
           remoteObjects.set(objectId, result);
+          const isPromise = Object.prototype.toString.call(result) === '[object Promise]';
           return {
             result: {
               type: 'object',
-              subtype: result instanceof Promise ? 'promise' : undefined,
+              subtype: isPromise ? 'promise' : undefined,
               objectId,
             },
           };
@@ -305,6 +306,343 @@ describe('shared app evaluation policy', () => {
     expect(state.state().reconnectCount).toBe(0);
     expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('__appExceptionMarker'))).toHaveLength(1);
+  });
+
+  test('observes an immediately rejected Promise during source evaluation', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'Promise.reject(new Error("immediate rejection"));',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('immediate rejection');
+
+    const sourceCall = calls.find((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('immediate rejection'));
+    expect(sourceCall?.params.awaitPromise).toBe(false);
+    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+    expect(calls.filter((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('immediate rejection'))).toHaveLength(1);
+
+    await expect(evalInApp(
+      'Promise.reject(new Error("line comment rejection")); // trailing comment',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('line comment rejection');
+    await expect(evalInApp(
+      'Promise.reject(new Error("block comment rejection")); /* trailing comment */',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('block comment rejection');
+    await expect(evalInApp(
+      'Promise.reject(new Error("repeated terminator rejection"));; /* trailing comment */',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('repeated terminator rejection');
+    await expect(evalInApp(
+      'Promise.reject(new Error("mixed terminator rejection")); /* c */ ; // d',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('mixed terminator rejection');
+  });
+
+  test('observes a rejected Promise before a delayed Runtime.evaluate response', async () => {
+    const { transport } = vmTransport();
+    const originalSend = transport.send;
+    transport.send = async (method, params, options) => {
+      const result = await originalSend(method, params, options);
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('delayed rejection')) {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+      }
+      return result;
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    let unhandledRejections = 0;
+    const onUnhandledRejection = () => { unhandledRejections += 1; };
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      await expect(evalInApp(
+        'const delayedPromise = Promise.reject(new Error("delayed rejection")); delayedPromise;',
+        { awaitPromise: true, timeout: 1000 },
+      )).rejects.toThrow('delayed rejection');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toBe(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('observes completion Promises through control-flow statements before a delayed response', async () => {
+    const sources = [
+      '{ Promise.reject(new Error("block completion rejection")); }',
+      'if (true) Promise.reject(new Error("if completion rejection"));',
+      'if (false) {} else Promise.reject(new Error("else completion rejection"));',
+      'try { Promise.reject(new Error("try completion rejection")); } finally {}',
+      'try { Promise.reject(new Error("try/finally completion rejection")); } finally { Promise.resolve(1); }',
+      'switch (1) { case 1: Promise.resolve(1); case 2: Promise.reject(new Error("switch completion rejection")); break; }',
+      'switch (1) { case 1: Promise.reject(new Error("conditional break completion rejection")); if (true) break; Promise.resolve(2); }',
+      'for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("conditional continue completion rejection")); if (true) continue; Promise.resolve(2); }',
+      'const flag = true; L: for (let index = 0; index < 1; index += 1) { Promise.reject(new Error("labeled continue completion rejection")); if (flag) continue L; Promise.resolve(2); }',
+    ];
+    let unhandledRejections = 0;
+    const onUnhandledRejection = () => { unhandledRejections += 1; };
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      for (const source of sources) {
+        const { transport } = vmTransport();
+        const originalSend = transport.send;
+        transport.send = async (method, params, options) => {
+          const result = await originalSend(method, params, options);
+          if (method === 'Runtime.evaluate' && String(params?.expression).includes('completion rejection')) {
+            await new Promise((resolve) => setTimeout(resolve, 30));
+          }
+          return result;
+        };
+        const evalInApp = createAppEvaluator(transport, lifecycle());
+        try {
+          await expect(evalInApp(source, { awaitPromise: true, timeout: 1000 }))
+            .rejects.toThrow('completion rejection');
+        } catch (error) {
+          throw new Error(`${source}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toBe(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('retains labeled break paths through finalizers and nested switches', async () => {
+    const sources = [
+      'const flag = true; L: { try { throw 1; } finally { if (flag) break L; } } Promise.reject(new Error("outer labeled completion rejection"));',
+      'const flag = true; L: { switch (1) { case 1: Promise.reject(new Error("nested switch labeled break rejection")); if (flag) break L; Promise.resolve(2); } }',
+    ];
+    let unhandledRejections = 0;
+    const onUnhandledRejection = () => { unhandledRejections += 1; };
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      const first = vmTransport();
+      const firstSend = first.transport.send;
+      first.transport.send = async (method, params, options) => {
+        const result = await firstSend(method, params, options);
+        if (method === 'Runtime.evaluate' && String(params?.expression).includes('outer labeled completion rejection')) {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+        }
+        return result;
+      };
+      await expect(createAppEvaluator(first.transport, lifecycle())(sources[0]!, {
+        awaitPromise: true,
+        timeout: 1000,
+      })).rejects.toThrow('outer labeled completion rejection');
+
+      const second = vmTransport();
+      const secondSend = second.transport.send;
+      second.transport.send = async (method, params, options) => {
+        const result = await secondSend(method, params, options);
+        if (method === 'Runtime.evaluate' && String(params?.expression).includes('nested switch labeled break rejection')) {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+        }
+        return result;
+      };
+      await expect(createAppEvaluator(second.transport, lifecycle())(sources[1]!, {
+        awaitPromise: true,
+        timeout: 1000,
+      })).rejects.toThrow('nested switch labeled break rejection');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toBe(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('observes a completion expression before trailing declarations', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'const trailingPromise = Promise.reject(new Error("trailing declaration rejection")); trailingPromise; var afterCompletion = true;',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('trailing declaration rejection');
+    const sourceCall = calls.find((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('trailing declaration rejection'));
+    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+  });
+
+  test('does not invoke a native Promise subclass then override during observation', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      `(() => {
+        class TrackedPromise extends Promise {
+          then(...args) {
+            globalThis.thenOverrideCalls = (globalThis.thenOverrideCalls || 0) + 1;
+            return super.then(...args);
+          }
+        }
+        globalThis.thenOverrideCalls = 0;
+        return new TrackedPromise(resolve => resolve(7));
+      })()`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(7);
+    // The wrapper uses the intrinsic method; only SETTLE_REMOTE's single
+    // assimilation invokes the subclass override.
+    expect(transport.context).toHaveProperty('thenOverrideCalls', 1);
+  });
+
+  test('keeps declaration-form scripts in the direct evaluation scope', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('/* leading */ function /* interstitial */ persistedFunction() {}', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBeUndefined();
+    await expect(evalInApp('/* leading */ class /* interstitial */ PersistedClass {}', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBeUndefined();
+    await expect(evalInApp('typeof persistedFunction', {
+      awaitPromise: false,
+    })).resolves.toBe('function');
+    await expect(evalInApp('typeof PersistedClass', {
+      awaitPromise: false,
+    })).resolves.toBe('function');
+  });
+
+  test('observes sequence and parenthesized Promise expressions', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      '(Promise.resolve(1), Promise.resolve(2)); // sequence',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(2);
+    await expect(evalInApp(
+      '((Promise.resolve(3))); /* parenthesized */',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(3);
+    await expect(evalInApp(
+      'Promise.resolve("string // marker ;"); // trailing',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('string // marker ;');
+    await expect(evalInApp(
+      'Promise.resolve("no semicolon") // trailing without terminator',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('no semicolon');
+    await expect(evalInApp(
+      'Promise.resolve(`/template ; // marker`); /* trailing */',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('/template ; // marker');
+    await expect(evalInApp(
+      'Promise.resolve(/[//;]/.test("//;")); /* trailing */',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(true);
+    await expect(evalInApp(
+      'Promise.resolve(1); // first statement\n Promise.resolve(2)',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(2);
+  });
+
+  test('preserves direct eval bindings when observing a Promise expression', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'eval("var persistedByDirectEval = 41"), Promise.resolve(1);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(1);
+    await expect(evalInApp('persistedByDirectEval', {
+      awaitPromise: false,
+    })).resolves.toBe(41);
+  });
+
+  test('preserves top-level arguments errors while observing Promise expressions', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      'Promise.resolve(arguments.length);',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('arguments is not defined');
+  });
+
+  test('preserves brace-leading direct script completion semantics', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('{ foo: 1 }', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(1);
+  });
+
+  test('leaves Proxy thenables to the single later assimilation path', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp(
+      `(() => {
+        globalThis.proxyPrototypeChecks = 0;
+        globalThis.proxyThenCalls = 0;
+        return new Proxy({
+        then(resolve) {
+          globalThis.proxyThenCalls = (globalThis.proxyThenCalls || 0) + 1;
+          resolve(9);
+        }
+      }, {
+        getPrototypeOf() {
+          globalThis.proxyPrototypeChecks = (globalThis.proxyPrototypeChecks || 0) + 1;
+          throw new Error('proxy prototype trap');
+        }
+        });
+      })()`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(9);
+    expect(transport.context).toMatchObject({
+      proxyPrototypeChecks: 0,
+      proxyThenCalls: 1,
+    });
+  });
+
+  test('does not mistake a Unicode identifier prefix for a declaration', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp('globalThis.functioné = Promise.resolve(6)', {
+      awaitPromise: false,
+    })).resolves.toBeDefined();
+    await expect(evalInApp('functioné;', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(6);
+    expect(calls.some((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('observePromise'))).toBe(true);
+  });
+
+  test('keeps anonymous and async/generator declarations direct', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    const invalidDeclarations = [
+      'function() {}',
+      'class {}',
+      'async function() {}',
+      'function*() {}',
+      'async function*() {}',
+    ];
+
+    for (const source of invalidDeclarations) {
+      await expect(evalInApp(source, {
+        awaitPromise: true,
+        timeout: 1000,
+      })).rejects.toThrow();
+    }
+    const sourceExpressions = calls
+      .filter((call) => call.method === 'Runtime.evaluate')
+      .map((call) => String(call.params.expression));
+    for (const source of invalidDeclarations) {
+      expect(sourceExpressions).toContain(source);
+    }
   });
 
   test('does not retry a remote settlement app exception that uses the Bridge disconnect message', async () => {
@@ -645,6 +983,38 @@ describe('shared app evaluation policy', () => {
     expect(calls).toHaveLength(1); // stalled setup; cleanup has no remaining budget
   });
 
+  test('releases a late completion with a bounded post-deadline cleanup budget', async () => {
+    let resolveSource: ((result: unknown) => void) | undefined;
+    const calls: Array<{ method: string; options?: Record<string, unknown> }> = [];
+    const transport = {
+      send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>) => {
+        calls.push({ method, options });
+        if (method === 'Runtime.evaluate' &&
+            String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          return { result: { value: true } };
+        }
+        if (method === 'Runtime.evaluate') {
+          return new Promise((resolve) => { resolveSource = resolve; });
+        }
+        if (method === 'Runtime.releaseObjectGroup') return { result: { value: true } };
+        return { result: { value: true } };
+      },
+    };
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+
+    await expect(evalInApp('Promise.resolve(42)', { awaitPromise: true, timeout: 30 }))
+      .rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const release = calls.find((call) => call.method === 'Runtime.releaseObjectGroup');
+    expect(release?.options?.timeoutMs).toBe(250);
+
+    // A late source result gets the same best-effort cleanup path and never
+    // replays the source evaluation.
+    resolveSource?.({ result: { type: 'object', objectId: 'late-promise' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate')).toHaveLength(2);
+  });
+
   test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
@@ -660,7 +1030,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(3); // setup, source, and stalled poll
+    expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded group cleanup
   });
 
   test('does not reconnect after a mailbox poll rejects after the deadline', async () => {
@@ -726,12 +1096,12 @@ describe('shared app evaluation policy', () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let groupReleaseStarted = false;
-    const deadline = Date.now() + 100;
+    const deadline = Date.now() + 300;
     transport.send = async (method, params, options) => {
       if (method === 'Runtime.releaseObjectGroup') {
         groupReleaseStarted = true;
         const timeoutMs = Number(options?.timeoutMs);
-        expect(timeoutMs).toBeLessThan(100);
+        expect(timeoutMs).toBeLessThanOrEqual(100);
         expect(timeoutMs).toBeLessThanOrEqual(deadline - Date.now() + 2);
         return new Promise(() => {});
       }
@@ -744,7 +1114,9 @@ describe('shared app evaluation policy', () => {
       'new Promise(resolve => setTimeout(() => resolve(42), 70));',
       { awaitPromise: true, timeout: 1000, deadline },
     )).resolves.toBe(42);
-    expect(Date.now() - started).toBeLessThan(100);
+    // Keep this separate from the cleanup budget: a stalled release must not
+    // delay delivery of a result that already settled.
+    expect(Date.now() - started).toBeLessThan(250);
     expect(groupReleaseStarted).toBe(true);
     expect(calls.some((call) => call.method === 'Runtime.releaseObject')).toBe(false);
   });

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -443,6 +443,68 @@ describe('shared app evaluation policy', () => {
     }
   });
 
+  test('observes only the final loop completion without touching discarded values', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      `globalThis.observedPromises = [];
+       const originalThen = Promise.prototype.then;
+       globalThis.originalThen = originalThen;
+       Promise.prototype.then = function(...args) {
+         if (this.marker) globalThis.observedPromises.push(this.marker);
+         return originalThen.apply(this, args);
+       };
+       function marked(value, marker) { value.marker = marker; return value; }
+       for (let index = 0; index < 2; index += 1) {
+         if (index === 0) marked(Promise.resolve('discarded loop value'), 'discarded');
+         else marked(Promise.resolve('final loop completion'), 'final');
+       }`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('final loop completion');
+    expect(transport.context.observedPromises).toContain('final');
+    expect(transport.context.observedPromises).not.toContain('discarded');
+    await expect(evalInApp('Promise.prototype.then = globalThis.originalThen; void 0;', {
+      awaitPromise: false,
+    })).resolves.toBeUndefined();
+  });
+
+  test('uses the intrinsic global when the source shadows globalThis', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      'let globalThis = { shadowed: true }; Promise.resolve(7);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(7);
+
+    const byValue = vmTransport();
+    const evaluateByValue = createAppEvaluator(byValue.transport, lifecycle());
+    await expect(evaluateByValue('let globalThis = null; 42;', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(42);
+  });
+
+  test('preserves directive prologues while observing the final completion', async () => {
+    const { transport, calls } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp('"use strict"; Promise.resolve(8);', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(8);
+    const sourceCall = calls.find((call) =>
+      call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('"use strict"'));
+    expect(String(sourceCall?.params.expression).startsWith('"use strict";')).toBe(true);
+    await expect(evalInApp('"use strict"; if (false) Promise.resolve(9)', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe('use strict');
+    await expect(evalInApp('Promise.resolve(9) // trailing line comment', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(9);
+  });
+
   test('observes completion Promises through control-flow statements before a delayed response', async () => {
     const sources = [
       '{ Promise.reject(new Error("block completion rejection")); }',
@@ -690,7 +752,7 @@ describe('shared app evaluation policy', () => {
     })).resolves.toBe(6);
     expect(calls.some((call) =>
       call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('observePromise'))).toBe(true);
+      String(call.params.expression).includes('PromiseCtor.prototype.then.call'))).toBe(true);
   });
 
   test('keeps anonymous and async/generator declarations direct', async () => {
@@ -774,7 +836,7 @@ describe('shared app evaluation policy', () => {
     let generation = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         setupAttempts += 1;
       }
       if (method === 'Runtime.evaluate' &&
@@ -806,7 +868,7 @@ describe('shared app evaluation policy', () => {
     let setupAttempts = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         setupAttempts += 1;
         if (setupAttempts === 1) throw new Error('WebSocket closed');
       }
@@ -946,7 +1008,7 @@ describe('shared app evaluation policy', () => {
     transport.send = async (method, params) => {
       const result = await originalSend(method, params);
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         generation += 1;
       }
       return result;
@@ -974,7 +1036,7 @@ describe('shared app evaluation policy', () => {
     const originalSend = transport.send;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(globalThis')) {
+          String(params?.expression).includes('Object.defineProperty(root')) {
         mailboxSetups += 1;
       }
       return originalSend(method, params);
@@ -1100,7 +1162,7 @@ describe('shared app evaluation policy', () => {
       send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>) => {
         calls.push({ method, options });
         if (method === 'Runtime.evaluate' &&
-            String(params?.expression).includes('Object.defineProperty(globalThis')) {
+            String(params?.expression).includes('Object.defineProperty(root')) {
           return { result: { value: true } };
         }
         if (method === 'Runtime.evaluate') {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -394,7 +394,7 @@ describe('shared app evaluation policy', () => {
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'));
     expect(sourceCall?.params.awaitPromise).toBe(false);
-    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
     expect(calls.filter((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'))).toHaveLength(1);
@@ -447,39 +447,49 @@ describe('shared app evaluation policy', () => {
     const { transport } = vmTransport();
     const evalInApp = createAppEvaluator(transport, lifecycle());
     await expect(evalInApp(
-      `globalThis.observedPromises = [];
-       const originalThen = Promise.prototype.then;
-       globalThis.originalThen = originalThen;
-       Promise.prototype.then = function(...args) {
-         if (this.marker) globalThis.observedPromises.push(this.marker);
-         return originalThen.apply(this, args);
+      `globalThis.observedThenables = [];
+       globalThis.markedThenable = function(value, marker) {
+         return { then: function(resolve) {
+           globalThis.observedThenables.push(marker);
+           resolve(value);
+         }};
        };
-       function marked(value, marker) { value.marker = marker; return value; }
        for (let index = 0; index < 2; index += 1) {
-         if (index === 0) marked(Promise.resolve('discarded loop value'), 'discarded');
-         else marked(Promise.resolve('final loop completion'), 'final');
+         if (index === 0) markedThenable('discarded loop value', 'discarded-loop');
+         else markedThenable('final loop completion', 'final');
        }`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('final loop completion');
-    expect(transport.context.observedPromises).toContain('final');
-    expect(transport.context.observedPromises).not.toContain('discarded');
+    expect(transport.context.observedThenables).toEqual(['final']);
     await expect(evalInApp(
-      `marked(Promise.resolve('discarded branch value'), 'discarded-branch');
-       if (false) Promise.resolve('untaken');`,
+      `markedThenable('discarded branch value', 'discarded-branch');
+       if (false) markedThenable('untaken', 'untaken');`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBeUndefined();
     await expect(evalInApp(
       `while (true) {
-         marked(Promise.resolve('discarded break value'), 'discarded-break');
+         markedThenable('discarded break value', 'discarded-break');
          if (true) break;
        }`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBeUndefined();
-    expect(transport.context.observedPromises).not.toContain('discarded-branch');
-    expect(transport.context.observedPromises).not.toContain('discarded-break');
-    await expect(evalInApp('Promise.prototype.then = globalThis.originalThen; void 0;', {
-      awaitPromise: false,
-    })).resolves.toBeUndefined();
+    expect(transport.context.observedThenables).toEqual(['final']);
+    await expect(evalInApp(
+      'let index = 0; while (index < 2) { index += 1; if (index === 1) Promise.resolve("first"); }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      "let switchIndex = 0; while (switchIndex++ < 2) { switch (switchIndex) { case 1: Promise.resolve('kept'); break; default: continue; } }",
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      "let mixedIndex = 0; while (mixedIndex++ < 2) { if (mixedIndex === 1) Promise.resolve('first'); if (false) Promise.resolve('never'); continue; }",
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBeUndefined();
+    await expect(evalInApp(
+      "let continueIndex = 0; while (continueIndex++ < 2) { Promise.resolve('kept'); continue; }",
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('kept');
   });
 
   test('uses the intrinsic global when the source shadows globalThis', async () => {
@@ -561,6 +571,21 @@ describe('shared app evaluation policy', () => {
     }
   });
 
+  test('leaves discarded prior values untransformed before empty catch or finally statements', async () => {
+    for (const source of [
+      "Promise.resolve('discarded'); try {} finally {}",
+      "Promise.resolve('discarded'); try {} catch {}",
+      "Promise.resolve('discarded'); try {} catch (error) {} finally {}",
+    ]) {
+      const { cdp, calls } = cdpHarness({ result: { value: undefined } });
+      await evaluateAppScriptCompletion(cdp, source, {
+        observePromiseRejection: true,
+        completionKey: 'empty-completion',
+      });
+      expect(calls[0]?.params?.expression).toBe(source);
+    }
+  });
+
   test('retains labeled break paths through finalizers and nested switches', async () => {
     const sources = [
       'const flag = true; L: { try { throw 1; } finally { if (flag) break L; } } Promise.reject(new Error("outer labeled completion rejection"));',
@@ -617,6 +642,8 @@ describe('shared app evaluation policy', () => {
     await expect(evaluate(
       'let i = 0; while (i < 1) { i += 1; if (true) continue; Promise.resolve("unreachable after continue"); }',
     )).resolves.toBeUndefined();
+    await expect(evaluate('1; L: { 2; if (false) break L; {} }'))
+      .resolves.toBeUndefined();
   });
 
   test('keeps guarded values only when a finally exit is not taken', async () => {
@@ -650,7 +677,7 @@ describe('shared app evaluation policy', () => {
     const sourceCall = calls.find((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('trailing declaration rejection'));
-    expect(String(sourceCall?.params.expression)).toContain('PromiseCtor.prototype.then.call');
+    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
   });
 
   test('does not invoke a native Promise subclass then override during observation', async () => {
@@ -673,6 +700,28 @@ describe('shared app evaluation policy', () => {
     // The wrapper uses the intrinsic method; only SETTLE_REMOTE's single
     // assimilation invokes the subclass override.
     expect(transport.context).toHaveProperty('thenOverrideCalls', 1);
+  });
+
+  test('settles a Promise after the source clears the global Promise constructor', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      `const value = Promise.resolve(11);
+       globalThis.Promise = null;
+       value;`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(11);
+  });
+
+  test('settles a Promise after the source patches its Promise prototype', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      `const value = Promise.resolve(12);
+       Promise.prototype.then = function() { throw new Error('patched then'); };
+       value;`,
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(12);
   });
 
   test('keeps declaration-form scripts in the direct evaluation scope', async () => {
@@ -802,7 +851,7 @@ describe('shared app evaluation policy', () => {
     })).resolves.toBe(6);
     expect(calls.some((call) =>
       call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('PromiseCtor.prototype.then.call'))).toBe(true);
+      String(call.params.expression).includes('promiseThen.call'))).toBe(true);
   });
 
   test('keeps anonymous and async/generator declarations direct', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -394,7 +394,7 @@ describe('shared app evaluation policy', () => {
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'));
     expect(sourceCall?.params.awaitPromise).toBe(false);
-    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
+    expect(String(sourceCall?.params.expression)).toContain('state.observe(value)');
     expect(calls.filter((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('immediate rejection'))).toHaveLength(1);
@@ -465,27 +465,29 @@ describe('shared app evaluation policy', () => {
       `markedThenable('discarded branch value', 'discarded-branch');
        if (false) markedThenable('untaken', 'untaken');`,
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('discarded branch value');
     await expect(evalInApp(
       `while (true) {
          markedThenable('discarded break value', 'discarded-break');
          if (true) break;
        }`,
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
-    expect(transport.context.observedThenables).toEqual(['final']);
+    )).resolves.toBe('discarded break value');
+    expect(transport.context.observedThenables).toEqual([
+      'final', 'discarded-branch', 'discarded-break',
+    ]);
     await expect(evalInApp(
       'let index = 0; while (index < 2) { index += 1; if (index === 1) Promise.resolve("first"); }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe(2);
     await expect(evalInApp(
       "let switchIndex = 0; while (switchIndex++ < 2) { switch (switchIndex) { case 1: Promise.resolve('kept'); break; default: continue; } }",
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('kept');
     await expect(evalInApp(
       "let mixedIndex = 0; while (mixedIndex++ < 2) { if (mixedIndex === 1) Promise.resolve('first'); if (false) Promise.resolve('never'); continue; }",
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('first');
     await expect(evalInApp(
       "let continueIndex = 0; while (continueIndex++ < 2) { Promise.resolve('kept'); continue; }",
       { awaitPromise: true, timeout: 1000 },
@@ -531,6 +533,10 @@ describe('shared app evaluation policy', () => {
       awaitPromise: true,
       timeout: 1000,
     })).resolves.toBe(9);
+    await expect(evalInApp('#! /usr/bin/env node\nPromise.resolve(10)', {
+      awaitPromise: true,
+      timeout: 1000,
+    })).resolves.toBe(10);
   });
 
   test('observes completion Promises through control-flow statements before a delayed response', async () => {
@@ -571,7 +577,7 @@ describe('shared app evaluation policy', () => {
     }
   });
 
-  test('leaves discarded prior values untransformed before empty catch or finally statements', async () => {
+  test('retains prior values through empty catch and finally statements', async () => {
     for (const source of [
       "Promise.resolve('discarded'); try {} finally {}",
       "Promise.resolve('discarded'); try {} catch {}",
@@ -582,7 +588,8 @@ describe('shared app evaluation policy', () => {
         observePromiseRejection: true,
         completionKey: 'empty-completion',
       });
-      expect(calls[0]?.params?.expression).toBe(source);
+      expect(calls[0]?.params?.expression).not.toBe(source);
+      expect(String(calls[0]?.params?.expression)).toContain('Promise.resolve');
     }
   });
 
@@ -615,35 +622,62 @@ describe('shared app evaluation policy', () => {
     }
   });
 
-  test('matches native empty completions across untaken branches and exits', async () => {
+  test('matches Hermes completion inheritance across control-flow paths', async () => {
     const evaluate = (source: string) => createAppEvaluator(vmTransport().transport, lifecycle())(
       source,
       { awaitPromise: true, timeout: 1000 },
     );
 
-    await expect(evaluate('Promise.resolve("discarded"); if (false) 2')).resolves.toBeUndefined();
+    await expect(evaluate('Promise.resolve("discarded"); if (false) 2')).resolves.toBe('discarded');
     await expect(evaluate('while (false) Promise.resolve("discarded")')).resolves.toBeUndefined();
     await expect(evaluate('for (let i = 0; i < 0; i += 1) Promise.resolve("discarded")'))
       .resolves.toBeUndefined();
     await expect(evaluate('while (true) { Promise.resolve("direct"); break; }'))
       .resolves.toBe('direct');
     await expect(evaluate('while (true) { Promise.resolve("conditional"); if (true) break; }'))
-      .resolves.toBeUndefined();
+      .resolves.toBe('conditional');
     await expect(evaluate(
       'let i = 0; while (i < 2) { i += 1; if (i === 1) { Promise.resolve("discarded"); continue; } Promise.resolve("final"); }',
     )).resolves.toBe('final');
     await expect(evaluate('switch (1) { case 1: Promise.resolve("direct"); break; }'))
       .resolves.toBe('direct');
     await expect(evaluate('switch (1) { case 1: Promise.resolve("conditional"); if (true) break; }'))
-      .resolves.toBeUndefined();
+      .resolves.toBe('conditional');
+    await expect(evaluate(
+      'let continueIndex = 0; while (continueIndex++ < 1) { Promise.resolve("conditional continue"); if (true) continue; }',
+    )).resolves.toBe('conditional continue');
+    await expect(evaluate(
+      'let outerIndex = 0; outer: while (outerIndex++ < 2) { if (outerIndex === 1) Promise.resolve("nested value"); else for (let inner = 0; inner < 0; inner += 1) {} }',
+    )).resolves.toBe('nested value');
+    await expect(evaluate(
+      'let emptyIndex = 0; while (emptyIndex++ < 2) { if (emptyIndex === 1) Promise.resolve("empty iteration"); else {} }',
+    )).resolves.toBe('empty iteration');
+    await expect(evaluate(
+      'L: { Promise.resolve("label break"); if (true) break L; Promise.resolve("unreachable"); }',
+    )).resolves.toBe('label break');
+    await expect(evaluate(
+      'L: { Promise.resolve("try break"); try {} finally { if (true) break L; } }',
+    )).resolves.toBe('try break');
+    await expect(evaluate(
+      'L: { Promise.resolve("try catch break"); try { throw new Error("stop"); } catch { if (true) break L; } }',
+    )).resolves.toBe('try catch break');
+    await expect(evaluate(
+      'L: switch (1) { case 1: Promise.resolve("switch label"); if (true) break L; }',
+    )).resolves.toBe('switch label');
+    await expect(evaluate(
+      'L: switch (1) { case 1: try { Promise.resolve("switch finally"); } finally { if (true) break L; } }',
+    )).resolves.toBe('switch finally');
+    await expect(evaluate(
+      'let loopIndex = 0; while (loopIndex++ < 1) { Promise.resolve("loop abrupt"); if (true) break; }',
+    )).resolves.toBe('loop abrupt');
     await expect(evaluate(
       'while (true) { if (true) break; Promise.resolve("unreachable after break"); }',
     )).resolves.toBeUndefined();
     await expect(evaluate(
       'let i = 0; while (i < 1) { i += 1; if (true) continue; Promise.resolve("unreachable after continue"); }',
-    )).resolves.toBeUndefined();
+    )).resolves.toBe(1);
     await expect(evaluate('1; L: { 2; if (false) break L; {} }'))
-      .resolves.toBeUndefined();
+      .resolves.toBe(2);
   });
 
   test('keeps guarded values only when a finally exit is not taken', async () => {
@@ -651,7 +685,7 @@ describe('shared app evaluation policy', () => {
     await expect(taken(
       'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('guarded');
 
     const skipped = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(skipped(
@@ -663,7 +697,7 @@ describe('shared app evaluation policy', () => {
     await expect(continued(
       'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { if (i === 1) continue outer; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBeUndefined();
+    )).resolves.toBe('guarded');
   });
 
   test('observes a completion expression before trailing declarations', async () => {
@@ -677,7 +711,7 @@ describe('shared app evaluation policy', () => {
     const sourceCall = calls.find((call) =>
       call.method === 'Runtime.evaluate' &&
       String(call.params.expression).includes('trailing declaration rejection'));
-    expect(String(sourceCall?.params.expression)).toContain('promiseThen.call');
+    expect(String(sourceCall?.params.expression)).toContain('state.observe(value)');
   });
 
   test('does not invoke a native Promise subclass then override during observation', async () => {
@@ -722,6 +756,23 @@ describe('shared app evaluation policy', () => {
        value;`,
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe(12);
+  });
+
+  test('settles through the realm after an earlier evaluation poisons Promise.then', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(
+      'Promise.prototype.then = function() { throw new Error("poisoned then"); }; 0;',
+      { awaitPromise: false, timeout: 1000 },
+    )).resolves.toBe(0);
+    await expect(evalInApp(
+      'Promise.resolve(42);',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(42);
+    await expect(evalInApp(
+      'Promise.reject(new Error("poisoned rejection"));',
+      { awaitPromise: true, timeout: 1000 },
+    )).rejects.toThrow('poisoned rejection');
   });
 
   test('keeps declaration-form scripts in the direct evaluation scope', async () => {
@@ -851,7 +902,7 @@ describe('shared app evaluation policy', () => {
     })).resolves.toBe(6);
     expect(calls.some((call) =>
       call.method === 'Runtime.evaluate' &&
-      String(call.params.expression).includes('promiseThen.call'))).toBe(true);
+      String(call.params.expression).includes('state.observe(value)'))).toBe(true);
   });
 
   test('keeps anonymous and async/generator declarations direct', async () => {
@@ -1024,7 +1075,7 @@ describe('shared app evaluation policy', () => {
     expect(calls.length).toBeGreaterThan(2);
   });
 
-  test('leaves a pre-dispatch settlement loss pending without replay', async () => {
+  test('survives a lost redundant settlement response without replaying the source', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     let settlementAttempts = 0;
@@ -1041,7 +1092,7 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp(
       'globalThis.executionCount = (globalThis.executionCount || 0) + 1; Promise.resolve(executionCount);',
       { awaitPromise: true, timeout: 40 },
-    )).rejects.toThrow('timed out');
+    )).resolves.toBe(1);
     expect(transport.context).toHaveProperty('executionCount', 1);
     expect(state.state().reconnectCount).toBe(1);
     expect(settlementAttempts).toBe(1);

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -698,6 +698,36 @@ describe('shared app evaluation policy', () => {
       'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { if (i === 1) continue outer; } }',
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('guarded');
+
+    const skippedAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(skippedAfterValue(
+      'globalThis.flag = false; L: try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const takenAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(takenAfterValue(
+      'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { Promise.resolve("finalizer exit"); if (flag) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('finalizer exit');
+
+    const skippedContinueAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(skippedContinueAfterValue(
+      'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (i > 1) continue outer; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const nested = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nested(
+      'L: try { Promise.resolve("guarded"); } finally { try { Promise.resolve("discarded outer finalizer"); } finally { Promise.resolve("discarded inner finalizer"); if (false) break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const directive = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(directive(
+      'L: try { Promise.resolve("guarded"); } finally { "use strict"; Promise.resolve("discarded finalizer"); if (false) break L; }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
   });
 
   test('observes a completion expression before trailing declarations', async () => {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -545,7 +545,7 @@ describe('shared app evaluation policy', () => {
       'if (true) Promise.reject(new Error("if completion rejection"));',
       'if (false) {} else Promise.reject(new Error("else completion rejection"));',
       'try { Promise.reject(new Error("try completion rejection")); } finally {}',
-      'try { Promise.reject(new Error("try/finally completion rejection")); } finally { Promise.resolve(1); }',
+      'try { Promise.resolve(1); } finally { Promise.reject(new Error("try/finally completion rejection")); }',
       'switch (1) { case 1: Promise.resolve(1); case 2: Promise.reject(new Error("switch completion rejection")); break; }',
     ];
     let unhandledRejections = 0;
@@ -680,7 +680,29 @@ describe('shared app evaluation policy', () => {
       .resolves.toBe(2);
   });
 
-  test('keeps guarded values only when a finally exit is not taken', async () => {
+  test('returns normal finally values as direct Hermes evaluation does', async () => {
+    for (const source of [
+      'try { 1; } finally { 2; }',
+      'L: try { 1; } finally { 2; if (false) break L; }',
+      'try { Promise.resolve(1); } finally { Promise.resolve(2); }',
+      'L: try { Promise.resolve(1); } finally { Promise.resolve(2); if (false) break L; }',
+      'L: { try { Promise.resolve(1); break L; } finally { Promise.resolve(2); } }',
+    ]) {
+      const evaluate = createAppEvaluator(vmTransport().transport, lifecycle());
+      await expect(evaluate(source, { awaitPromise: true, timeout: 1000 })).resolves.toBe(2);
+    }
+  });
+
+  test('does not observe a guarded thenable replaced by a normal finalizer', async () => {
+    const evaluate = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(evaluate(
+      'this.finallyThenCalls = 0; try { ({ then(resolve) { finallyThenCalls += 1; resolve(1); } }); } finally { Promise.resolve(2); }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe(2);
+    await expect(evaluate('finallyThenCalls', { awaitPromise: true, timeout: 1000 })).resolves.toBe(0);
+  });
+
+  test('preserves the last reached Hermes value through normal and abrupt finalizers', async () => {
     const taken = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(taken(
       'globalThis.flag = true; L: try { Promise.resolve("guarded"); } finally { if (flag) break L; }',
@@ -703,7 +725,7 @@ describe('shared app evaluation policy', () => {
     await expect(skippedAfterValue(
       'globalThis.flag = false; L: try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (flag) break L; }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded finalizer');
 
     const takenAfterValue = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(takenAfterValue(
@@ -715,19 +737,19 @@ describe('shared app evaluation policy', () => {
     await expect(skippedContinueAfterValue(
       'let i = 0; outer: while (i < 1) { i += 1; try { Promise.resolve("guarded"); } finally { Promise.resolve("discarded finalizer"); if (i > 1) continue outer; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded finalizer');
 
     const nested = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(nested(
       'L: try { Promise.resolve("guarded"); } finally { try { Promise.resolve("discarded outer finalizer"); } finally { Promise.resolve("discarded inner finalizer"); if (false) break L; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded inner finalizer');
 
     const directive = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(directive(
       'L: try { Promise.resolve("guarded"); } finally { "use strict"; Promise.resolve("discarded finalizer"); if (false) break L; }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('guarded');
+    )).resolves.toBe('discarded finalizer');
 
     const nestedFinallyExit = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(nestedFinallyExit(
@@ -739,7 +761,7 @@ describe('shared app evaluation policy', () => {
     await expect(nestedConditionalFinallyExit(
       'globalThis.flag = false; L: try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { if (flag) break L; } }',
       { awaitPromise: true, timeout: 1000 },
-    )).resolves.toBe('outer');
+    )).resolves.toBe('inner');
 
     const nestedFinallyContinue = createAppEvaluator(vmTransport().transport, lifecycle());
     await expect(nestedFinallyContinue(

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, test } from 'bun:test';
 import vm from 'node:vm';
-import { createAppEvaluator, evaluateAppScript } from './evaluate-app.js';
+import {
+  createAppEvaluator,
+  evaluateAppScript,
+  evaluateAppScriptCompletion,
+} from './evaluate-app.js';
 
 function cdpHarness(response: unknown) {
-  const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const calls: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
   const cdp = {
-    send: async (method: string, params?: Record<string, unknown>) => {
-      calls.push({ method, params });
+    send: async (
+      method: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => {
+      calls.push({ method, params, options });
       if (response instanceof Error) throw response;
       return response;
     },
@@ -27,6 +39,7 @@ describe('raw app evaluation', () => {
         awaitPromise: false,
         timeout: 1234,
       },
+      options: { timeoutMs: 1234 },
     }]);
   });
 
@@ -38,6 +51,27 @@ describe('raw app evaluation', () => {
     expect(calls).toHaveLength(1);
   });
 
+  test('keeps the engine timeout with a remote completion group', async () => {
+    const { cdp, calls } = cdpHarness({
+      result: { type: 'object', subtype: 'promise', objectId: 'promise-1' },
+    });
+    await expect(evaluateAppScriptCompletion(cdp, 'Promise.resolve(42)', {
+      timeout: 321,
+      objectGroup: 'group-1',
+    })).resolves.toEqual({ objectId: 'promise-1' });
+    expect(calls[0]).toEqual({
+      method: 'Runtime.evaluate',
+      params: {
+        expression: 'Promise.resolve(42)',
+        returnByValue: false,
+        awaitPromise: false,
+        timeout: 321,
+        objectGroup: 'group-1',
+      },
+      options: { timeoutMs: 321 },
+    });
+  });
+
   test('propagates an ambiguous transport failure after one dispatch', async () => {
     const { cdp, calls } = cdpHarness(new Error('WebSocket closed'));
     await expect(evaluateAppScript(cdp, 'increment();')).rejects.toThrow('WebSocket closed');
@@ -47,19 +81,52 @@ describe('raw app evaluation', () => {
 
 function vmTransport() {
   let appGlobal = vm.createContext({ setTimeout, clearTimeout });
-  const calls: Array<Record<string, unknown>> = [];
+  let nextObjectId = 0;
+  let remoteObjects = new Map<string, unknown>();
+  const calls: Array<{
+    method: string;
+    params: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
   const transport = {
-    send: async (_method: string, params?: Record<string, unknown>) => {
-      calls.push(params ?? {});
-      const result = new vm.Script(String(params?.expression)).runInContext(appGlobal);
-      return {
-        result: {
-          value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)),
-        },
-      };
+    send: async (
+      method: string,
+      params?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => {
+      const actualParams = params ?? {};
+      calls.push({ method, params: actualParams, options });
+      if (method === 'Runtime.evaluate') {
+        const result = new vm.Script(String(actualParams.expression)).runInContext(appGlobal);
+        if (actualParams.returnByValue === false && result !== null &&
+            (typeof result === 'object' || typeof result === 'function')) {
+          const objectId = `remote-${++nextObjectId}`;
+          remoteObjects.set(objectId, result);
+          return {
+            result: {
+              type: 'object',
+              subtype: result instanceof Promise ? 'promise' : undefined,
+              objectId,
+            },
+          };
+        }
+        return {
+          result: {
+            value: result === undefined ? undefined : JSON.parse(JSON.stringify(result)),
+          },
+        };
+      }
+      if (method === 'Runtime.callFunctionOn') {
+        const object = remoteObjects.get(String(actualParams.objectId));
+        const fn = new vm.Script(`(${String(actualParams.functionDeclaration)})`).runInContext(appGlobal) as Function;
+        fn.call(object, ...((actualParams.arguments as Array<{ value: unknown }> | undefined)?.map((arg) => arg.value) ?? []));
+        return { result: { value: true } };
+      }
+      return { result: { value: undefined } };
     },
     replaceContext() {
       appGlobal = vm.createContext({ setTimeout, clearTimeout });
+      remoteObjects = new Map();
     },
     get context() {
       return appGlobal;
@@ -86,6 +153,28 @@ function lifecycle(overrides: Partial<{
 }
 
 describe('shared app evaluation policy', () => {
+  test('passes only the remaining deadline to transport after connection setup', async () => {
+    const { cdp, calls } = cdpHarness({ result: { value: 42 } });
+    const evaluate = createAppEvaluator(cdp, lifecycle({
+      ensureConnected: async () => { await new Promise((resolve) => setTimeout(resolve, 30)); },
+    }));
+    const deadline = Date.now() + 200;
+    expect(await evaluate('42', { timeout: 200, deadline })).toBe(42);
+    expect(calls[0].options?.timeoutMs).toBeGreaterThan(0);
+    expect(calls[0].options?.timeoutMs).toBeLessThanOrEqual(175);
+  });
+
+  test('does not dispatch after connection setup outlives the caller deadline', async () => {
+    const { cdp, calls } = cdpHarness({ result: { value: 42 } });
+    const evaluate = createAppEvaluator(cdp, lifecycle({
+      ensureConnected: async () => { await new Promise((resolve) => setTimeout(resolve, 50)); },
+    }));
+    await expect(evaluate('mutate()', { awaitPromise: true, timeout: 10 })).rejects.toThrow('timed out');
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate')).toHaveLength(0);
+    expect(calls).toHaveLength(1); // bounded late-completion group cleanup
+  });
+
   test('does not replay a script after an ambiguous initial dispatch', async () => {
     const { transport, calls } = vmTransport();
     const initialContext = transport.context;
@@ -93,7 +182,8 @@ describe('shared app evaluation policy', () => {
     const originalSend = transport.send;
     transport.send = async (method, params) => {
       const result = await originalSend(method, params);
-      if (first) {
+      if (first && method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('executionCount')) {
         first = false;
         throw new Error('WebSocket closed');
       }
@@ -106,7 +196,8 @@ describe('shared app evaluation policy', () => {
       { awaitPromise: true, timeout: 1000 },
     )).rejects.toThrow('WebSocket closed');
     expect(initialContext).toHaveProperty('executionCount', 1);
-    expect(calls).toHaveLength(2); // initial dispatch plus mailbox cleanup
+    expect(calls.filter((call) => call.method === 'Runtime.evaluate' &&
+      String(call.params.expression).includes('executionCount'))).toHaveLength(1);
   });
 
   test('reconnects mailbox reads without replaying the original source', async () => {
@@ -114,7 +205,8 @@ describe('shared app evaluation policy', () => {
     let firstPoll = true;
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (firstPoll && calls.length === 1) {
+      if (firstPoll && method === 'Runtime.evaluate' &&
+          String(params?.expression).includes('return { status:')) {
         firstPoll = false;
         throw new Error('WebSocket closed');
       }
@@ -154,14 +246,16 @@ describe('shared app evaluation policy', () => {
     expect(initialContext).toHaveProperty('executionCount', 1);
     expect(state.state().reconnectCount).toBe(0);
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.awaitPromise).toBe(false);
+    expect(calls[0]?.params.awaitPromise).toBe(false);
   });
 
   test('reports a lost mailbox when reconnect lands in a new app context', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 1) transport.replaceContext();
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        transport.replaceContext();
+      }
       return originalSend(method, params);
     };
     const evalInApp = createAppEvaluator(transport, lifecycle());
@@ -186,14 +280,16 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('new Promise(() => {})', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2); // stalled setup plus bounded group cleanup
   });
 
   test('bounds a stalled mailbox poll and does not wait for cleanup', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 1) return new Promise(() => {});
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        return new Promise(() => {});
+      }
       return originalSend(method, params);
     };
     const started = Date.now();
@@ -202,15 +298,17 @@ describe('shared app evaluation policy', () => {
     await expect(evalInApp('Promise.resolve(1)', { awaitPromise: true, timeout: 40 }))
       .rejects.toThrow('timed out');
     expect(Date.now() - started).toBeLessThan(500);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(4); // setup, source, stalled poll, and bounded cleanup
   });
 
   test('bounds reconnect recovery after a dropped mailbox read', async () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 0) return originalSend(method, params);
-      throw new Error('WebSocket closed');
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('return { status:')) {
+        throw new Error('WebSocket closed');
+      }
+      return originalSend(method, params);
     };
     const state = lifecycle({ reconnect: async () => new Promise(() => {}) });
     const started = Date.now();
@@ -225,7 +323,9 @@ describe('shared app evaluation policy', () => {
     const { transport, calls } = vmTransport();
     const originalSend = transport.send;
     transport.send = async (method, params) => {
-      if (calls.length === 2) return new Promise(() => {});
+      if (method === 'Runtime.evaluate' && String(params?.expression).includes('clearTimeout(state.timer)')) {
+        return new Promise(() => {});
+      }
       return originalSend(method, params);
     };
     const started = Date.now();

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -859,6 +859,57 @@ describe('shared app evaluation policy', () => {
     )).rejects.toThrow('poisoned rejection');
   });
 
+  test('keeps the awaited mailbox hidden and read-only with normal intrinsics', async () => {
+    const { transport } = vmTransport();
+    const evalInApp = createAppEvaluator(transport, lifecycle());
+    await expect(evalInApp(`(function() {
+      var prefix = '__METRO_MCP_ASYNC_';
+      var key = Object.getOwnPropertyNames(this).find(name => name.startsWith(prefix));
+      var descriptor = Object.getOwnPropertyDescriptor(this, key);
+      var iterated = [];
+      for (var name in this) if (name.startsWith(prefix)) iterated.push(name);
+      return {
+        enumerable: descriptor.enumerable,
+        writable: descriptor.writable,
+        configurable: descriptor.configurable,
+        keys: Object.keys(this).filter(name => name.startsWith(prefix)),
+        iterated: iterated
+      };
+    })()`, { awaitPromise: true, timeout: 1000 })).resolves.toEqual({
+      enumerable: false, writable: false, configurable: true, keys: [], iterated: [],
+    });
+  });
+
+  test('creates a mailbox after an earlier evaluation mutates Object globals', async () => {
+    for (const mutation of [
+      'Object.defineProperty = null; 0;',
+      'Object = null; 0;',
+      'Object.defineProperty = function() {}; 0;',
+    ]) {
+      const { transport } = vmTransport();
+      const evalInApp = createAppEvaluator(transport, lifecycle());
+      await expect(evalInApp(mutation, { awaitPromise: true, timeout: 1000 }))
+        .resolves.toBe(0);
+      await expect(evalInApp(
+        'Promise.resolve(13);',
+        { awaitPromise: true, timeout: 1000 },
+      )).resolves.toBe(13);
+      await expect(evalInApp(`(function() {
+        var root = this;
+        var keys = Reflect.ownKeys(root).filter(name => typeof name === 'string' && name.startsWith('__METRO_MCP_ASYNC_'));
+        return {
+          found: keys.length > 0,
+          hidden: keys.every(function(key) {
+            var descriptor = Reflect.getOwnPropertyDescriptor(root, key);
+            return descriptor.enumerable === false && descriptor.writable === false;
+          })
+        };
+      })()`, { awaitPromise: true, timeout: 1000 })).resolves.toEqual({
+        found: true, hidden: true,
+      });
+    }
+  });
+
   test('keeps declaration-form scripts in the direct evaluation scope', async () => {
     const { transport } = vmTransport();
     const evalInApp = createAppEvaluator(transport, lifecycle());
@@ -1070,7 +1121,7 @@ describe('shared app evaluation policy', () => {
     let generation = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         setupAttempts += 1;
       }
       if (method === 'Runtime.evaluate' &&
@@ -1102,7 +1153,7 @@ describe('shared app evaluation policy', () => {
     let setupAttempts = 0;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         setupAttempts += 1;
         if (setupAttempts === 1) throw new Error('WebSocket closed');
       }
@@ -1293,7 +1344,7 @@ describe('shared app evaluation policy', () => {
     transport.send = async (method, params) => {
       const result = await originalSend(method, params);
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         generation += 1;
       }
       return result;
@@ -1321,7 +1372,7 @@ describe('shared app evaluation policy', () => {
     const originalSend = transport.send;
     transport.send = async (method, params) => {
       if (method === 'Runtime.evaluate' &&
-          String(params?.expression).includes('Object.defineProperty(root')) {
+          String(params?.expression).includes("status: 'pending'")) {
         mailboxSetups += 1;
       }
       return originalSend(method, params);
@@ -1447,7 +1498,7 @@ describe('shared app evaluation policy', () => {
       send: async (method: string, params?: Record<string, unknown>, options?: Record<string, unknown>) => {
         calls.push({ method, options });
         if (method === 'Runtime.evaluate' &&
-            String(params?.expression).includes('Object.defineProperty(root')) {
+            String(params?.expression).includes("status: 'pending'")) {
           return { result: { value: true } };
         }
         if (method === 'Runtime.evaluate') {

--- a/src/utils/evaluate-app.test.ts
+++ b/src/utils/evaluate-app.test.ts
@@ -728,6 +728,48 @@ describe('shared app evaluation policy', () => {
       'L: try { Promise.resolve("guarded"); } finally { "use strict"; Promise.resolve("discarded finalizer"); if (false) break L; }',
       { awaitPromise: true, timeout: 1000 },
     )).resolves.toBe('guarded');
+
+    const nestedFinallyExit = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nestedFinallyExit(
+      'L: try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('inner');
+
+    const nestedConditionalFinallyExit = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nestedConditionalFinallyExit(
+      'globalThis.flag = false; L: try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { if (flag) break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('outer');
+
+    const nestedFinallyContinue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(nestedFinallyContinue(
+      'let i = 0; L: while (i < 1) { i += 1; try { Promise.resolve("outer"); } finally { try { Promise.resolve("inner"); } finally { continue L; } } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('inner');
+
+    const conditionalGuardedBreak = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(conditionalGuardedBreak(
+      'globalThis.flag = true; L: { Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const emptyGuardedBreak = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(emptyGuardedBreak(
+      'globalThis.flag = false; L: { Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { break L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('before');
+
+    const conditionalGuardedContinue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(conditionalGuardedContinue(
+      'globalThis.flag = true; let i = 0; L: while (i < 1) { i += 1; Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { continue L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('guarded');
+
+    const emptyGuardedContinue = createAppEvaluator(vmTransport().transport, lifecycle());
+    await expect(emptyGuardedContinue(
+      'globalThis.flag = false; let i = 0; L: while (i < 1) { i += 1; Promise.resolve("before"); try { if (flag) Promise.resolve("guarded"); else {} } finally { continue L; } }',
+      { awaitPromise: true, timeout: 1000 },
+    )).resolves.toBe('before');
   });
 
   test('observes a completion expression before trailing declarations', async () => {

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -169,6 +169,22 @@ function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath
   };
 }
 
+function inheritEmptyExit(prior: CompletionPath, path: ExitPath): ExitPath {
+  if (!path.empty || !path.inherit) return path;
+  return {
+    expressions: [...prior.expressions, ...path.expressions],
+    clearRanges: [...prior.clearRanges],
+    empty: prior.empty && path.empty,
+    normal: path.normal,
+    label: path.label,
+    inherit: path.inherit,
+  };
+}
+
+function inheritEmptyExits(prior: CompletionPath, paths: ExitPath[]): ExitPath[] {
+  return paths.map((path) => inheritEmptyExit(prior, path));
+}
+
 function mergeCompletions(left: Completion, right: Completion): Completion {
   const merged = mergePaths(left, right);
   return {
@@ -250,15 +266,23 @@ function completionForStatement(statement: StatementLike): Completion {
       const guarded = mergeCompletions(body, handler);
       if (!statement.finalizer) return guarded;
       const finalizer = completionForStatement(statement.finalizer as StatementLike);
-      if (!finalizer.normal) return finalizer;
+      const finalizerBreaks = inheritEmptyExits(guarded, finalizer.breaks);
+      const finalizerContinues = inheritEmptyExits(guarded, finalizer.continues);
+      if (!finalizer.normal) {
+        return {
+          ...finalizer,
+          breaks: finalizerBreaks,
+          continues: finalizerContinues,
+        };
+      }
       // A normal `finally` completion is UpdateEmpty: its expression value is
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
       const applied = applyFinallyCompletion(guarded, finalizer);
       return {
         ...applied,
-        breaks: [...guarded.breaks, ...finalizer.breaks],
-        continues: [...guarded.continues, ...finalizer.continues],
+        breaks: [...guarded.breaks, ...finalizerBreaks],
+        continues: [...guarded.continues, ...finalizerContinues],
       };
     }
     case 'LabeledStatement':
@@ -329,15 +353,11 @@ function completionForStatements(statements: StatementLike[]): Completion {
     const next = completionForStatement(statement);
     const breaks: ExitPath[] = [
       ...completion.breaks,
-      ...next.breaks.map((path) => path.empty && path.inherit
-        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
-        : path),
+      ...inheritEmptyExits(completion, next.breaks),
     ];
     const continues: ExitPath[] = [
       ...completion.continues,
-      ...next.continues.map((path) => path.empty && path.inherit
-        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
-        : path),
+      ...inheritEmptyExits(completion, next.continues),
     ];
     if (!next.normal) {
       return { ...next, breaks, continues };

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -130,12 +130,6 @@ type Completion = CompletionPath & {
   breaks: ExitPath[];
   continues: ExitPath[];
 };
-type FinallyRestore = {
-  entry: number;
-  exit: number;
-  slot: string;
-};
-
 const emptyCompletion = (): Completion => ({
   expressions: [],
   clearRanges: [],
@@ -153,16 +147,6 @@ const abruptCompletion = (): Completion => ({
   breaks: [],
   continues: [],
 });
-
-function applyFinallyCompletion(
-  guarded: Completion,
-  _finalizer: Completion,
-): CompletionPath {
-  // A normal finally completion is always discarded by TryStatement. The
-  // guarded completion is returned whether the finalizer's own completion is
-  // empty, undefined, or a value; only an abrupt finalizer replaces it.
-  return guarded;
-}
 
 function completionFromExit(path: ExitPath): CompletionPath {
   return path.inherit ? { ...path, clearRanges: [] } : path;
@@ -292,12 +276,13 @@ function completionForStatement(statement: StatementLike): Completion {
           continues: finalizerContinues,
         };
       }
-      // A normal `finally` completion is UpdateEmpty: its expression value is
-      // discarded, while the prior try/catch completion is retained. This is
-      // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
-      const applied = applyFinallyCompletion(guarded, finalizer);
+      // Hermes retains the last reached expression, including a normally
+      // completing finalizer. Capture both paths in execution order so an
+      // empty finalizer inherits the guarded value and a valued one replaces it.
       return {
-        ...applied,
+        ...mergePaths(guarded, finalizer),
+        empty: guarded.empty && finalizer.empty,
+        normal: guarded.normal,
         breaks: [...guarded.breaks, ...finalizerBreaks],
         continues: [...guarded.continues, ...finalizerContinues],
       };
@@ -388,74 +373,6 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
-function collectFinallyRestores(
-  statement: StatementLike,
-  restores: FinallyRestore[] = [],
-): FinallyRestore[] {
-  switch (statement.type) {
-    case 'BlockStatement':
-      for (const child of (statement.body as StatementLike[] | undefined) ?? []) {
-        collectFinallyRestores(child, restores);
-      }
-      break;
-    case 'IfStatement':
-      collectFinallyRestores(statement.consequent as StatementLike, restores);
-      if (statement.alternate) {
-        collectFinallyRestores(statement.alternate as StatementLike, restores);
-      }
-      break;
-    case 'TryStatement': {
-      collectFinallyRestores(statement.block as StatementLike, restores);
-      const handler = statement.handler as { body: StatementLike } | null | undefined;
-      if (handler) collectFinallyRestores(handler.body, restores);
-      const finalizer = statement.finalizer as StatementLike | null | undefined;
-      if (finalizer) {
-        const completion = completionForStatement(finalizer);
-        const hasEscapingValue = [...completion.breaks, ...completion.continues]
-          .some((path) => path.expressions.length > 0);
-        const start = finalizer.start;
-        const end = finalizer.end;
-        if (
-          completion.normal &&
-          hasEscapingValue &&
-          typeof start === 'number' &&
-          typeof end === 'number'
-        ) {
-          const directives = (finalizer.directives as Array<{ end?: number | null }> | undefined) ?? [];
-          restores.push({
-            entry: directives.length > 0
-              ? directives[directives.length - 1]!.end as number
-              : start + 1,
-            exit: end - 1,
-            slot: `finally:${start}:${end}`,
-          });
-        }
-        collectFinallyRestores(finalizer, restores);
-      }
-      break;
-    }
-    case 'LabeledStatement':
-    case 'WithStatement':
-    case 'ForStatement':
-    case 'ForInStatement':
-    case 'ForOfStatement':
-    case 'WhileStatement':
-    case 'DoWhileStatement':
-      collectFinallyRestores(statement.body as StatementLike, restores);
-      break;
-    case 'SwitchStatement':
-      for (const switchCase of (
-        statement.cases as Array<{ consequent: StatementLike[] }> | undefined
-      ) ?? []) {
-        for (const child of switchCase.consequent) {
-          collectFinallyRestores(child, restores);
-        }
-      }
-      break;
-  }
-  return restores;
-}
-
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -498,21 +415,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
-  const finallyRestores = collectFinallyRestores({
-    type: 'BlockStatement',
-    body: ast.program.body as StatementLike[],
-  });
-  const saveFinallyCompletion = (slot: string): string => `(function(root) {
-    var state = root[${keyLiteral}];
-    if (state) state[${JSON.stringify(slot)}] = state.completionValue;
-  })(this)`;
-  const restoreFinallyCompletion = (slot: string): string => `(function(root) {
-    var state = root[${keyLiteral}];
-    if (state) {
-      state.completionValue = state[${JSON.stringify(slot)}];
-      delete state[${JSON.stringify(slot)}];
-    }
-  })(this)`;
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -527,15 +429,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
-    ...finallyRestores.flatMap(({ entry, exit, slot }) => [{
-      start: exit,
-      end: exit,
-      replacement: `;\n${restoreFinallyCompletion(slot)};\n`,
-    }, {
-      start: entry,
-      end: entry,
-      replacement: `;\n${saveFinallyCompletion(slot)};\n`,
-    }]),
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
     transformed = transformed.slice(0, start) + replacement +

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -185,6 +185,11 @@ function inheritEmptyExits(prior: CompletionPath, paths: ExitPath[]): ExitPath[]
   return paths.map((path) => inheritEmptyExit(prior, path));
 }
 
+function completionWithEscapingValues(completion: Completion): CompletionPath {
+  return [...completion.breaks, ...completion.continues]
+    .reduce(mergePaths, completion);
+}
+
 function mergeCompletions(left: Completion, right: Completion): Completion {
   const merged = mergePaths(left, right);
   return {
@@ -266,8 +271,9 @@ function completionForStatement(statement: StatementLike): Completion {
       const guarded = mergeCompletions(body, handler);
       if (!statement.finalizer) return guarded;
       const finalizer = completionForStatement(statement.finalizer as StatementLike);
-      const finalizerBreaks = inheritEmptyExits(guarded, finalizer.breaks);
-      const finalizerContinues = inheritEmptyExits(guarded, finalizer.continues);
+      const guardedWithEscapingValues = completionWithEscapingValues(guarded);
+      const finalizerBreaks = inheritEmptyExits(guardedWithEscapingValues, finalizer.breaks);
+      const finalizerContinues = inheritEmptyExits(guardedWithEscapingValues, finalizer.continues);
       if (!finalizer.normal) {
         return {
           ...finalizer,

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -156,42 +156,27 @@ export function createAppEvaluator(
     options: { timeout?: number; deadline: number },
   ): Promise<boolean> => {
     const remaining = Math.max(1, options.deadline - Date.now());
-    let settled = false;
-    let released = false;
-    try {
-      const result = (await cdp.send(
-        'Runtime.callFunctionOn',
-        {
-          objectId,
-          functionDeclaration: SETTLE_REMOTE_FUNCTION,
-          arguments: [{ value: mailboxKey }],
-          returnByValue: true,
-        },
-        { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
-      )) as Record<string, unknown>;
-      if (result.exceptionDetails) {
-        throw new Error(
-          extractCDPExceptionMessage(
-            result.exceptionDetails as Record<string, unknown>,
-          ),
-        );
-      }
-      settled = ((result.result as Record<string, unknown> | undefined)?.value !== false);
-    } finally {
-      // The completion handle is only needed while its settlement callback is
-      // being attached. Releasing it avoids retaining every awaited Promise.
-      try {
-        await cdp.send(
-          'Runtime.releaseObject',
-          { objectId },
-          { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
-        );
-        released = true;
-      } catch {
-        // The object group cleanup in awaitAppResult remains the fallback.
-      }
+    const result = (await cdp.send(
+      'Runtime.callFunctionOn',
+      {
+        objectId,
+        functionDeclaration: SETTLE_REMOTE_FUNCTION,
+        arguments: [{ value: mailboxKey }],
+        returnByValue: true,
+      },
+      { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+    )) as Record<string, unknown>;
+    if (result.exceptionDetails) {
+      throw new Error(
+        extractCDPExceptionMessage(
+          result.exceptionDetails as Record<string, unknown>,
+        ),
+      );
     }
-    return settled && released;
+    // Keep the unique object group responsible for cleanup. Its separately
+    // bounded release runs after mailbox settlement, so handle cleanup cannot
+    // delay polling or leave a detached, permanently pending transport call.
+    return false;
   };
 
   const releaseObjectGroup = async (

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -50,7 +50,9 @@ function isDefinitivePreDispatchFailure(error: unknown): boolean {
   return (
     error instanceof Error &&
     !(error instanceof AppEvaluationError) &&
-    error.message === 'Not connected to CDP target'
+    (error.message === 'Not connected to CDP target' ||
+      error.message ===
+        'Not connected to Metro. Use list_devices to check connection status.')
   );
 }
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -101,6 +101,8 @@ async function sendRuntimeEvaluate(
 
 type StatementLike = {
   type: string;
+  start?: number | null;
+  end?: number | null;
   body?: unknown;
   expression?: ExpressionLike;
   [key: string]: unknown;
@@ -108,10 +110,12 @@ type StatementLike = {
 type ExpressionLike = { start: number | null; end: number | null };
 type CompletionPath = {
   expressions: ExpressionLike[];
+  clearRanges: Array<{ start: number; end: number; kind: 'break' | 'continue'; label: string | null }>;
   empty: boolean;
+  undefined: boolean;
   normal: boolean;
 };
-type ExitPath = CompletionPath & { label: string | null };
+type ExitPath = CompletionPath & { label: string | null; inherit: boolean };
 type Completion = CompletionPath & {
   breaks: ExitPath[];
   continues: ExitPath[];
@@ -119,7 +123,9 @@ type Completion = CompletionPath & {
 
 const emptyCompletion = (): Completion => ({
   expressions: [],
+  clearRanges: [],
   empty: true,
+  undefined: false,
   normal: true,
   breaks: [],
   continues: [],
@@ -127,16 +133,71 @@ const emptyCompletion = (): Completion => ({
 
 const abruptCompletion = (): Completion => ({
   expressions: [],
+  clearRanges: [],
   empty: false,
+  undefined: false,
   normal: false,
   breaks: [],
   continues: [],
 });
 
+const undefinedCompletion = (): Completion => ({
+  expressions: [],
+  clearRanges: [],
+  empty: false,
+  undefined: true,
+  normal: true,
+  breaks: [],
+  continues: [],
+});
+
+function normalizeControlCompletion(completion: Completion): Completion {
+  return {
+    ...completion,
+    empty: false,
+    undefined: completion.undefined || completion.empty,
+  };
+}
+
+function asFinallyCompletion(completion: Completion): Completion {
+  // A normal finalizer uses UpdateEmpty. Control statements such as an
+  // untaken if/loop therefore preserve the guarded completion in a finally
+  // clause, even though they produce undefined at script level.
+  return {
+    ...completion,
+    empty: completion.empty || completion.undefined,
+    undefined: false,
+  };
+}
+
+function applyFinallyCompletion(
+  guarded: Completion,
+  _finalizer: Completion,
+): CompletionPath {
+  // A normal finally completion is always discarded by TryStatement. The
+  // guarded completion is returned whether the finalizer's own completion is
+  // empty, undefined, or a value; only an abrupt finalizer replaces it.
+  return guarded;
+}
+
+function markNonInheritingExits(completion: Completion): Completion {
+  return {
+    ...completion,
+    breaks: completion.breaks.map((path) => ({ ...path, inherit: false })),
+    continues: completion.continues.map((path) => ({ ...path, inherit: false })),
+  };
+}
+
+function completionFromExit(path: ExitPath): CompletionPath {
+  return path.inherit ? { ...path, clearRanges: [] } : path;
+}
+
 function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath {
   return {
     expressions: [...left.expressions, ...right.expressions],
+    clearRanges: [...left.clearRanges, ...right.clearRanges],
     empty: left.empty || right.empty,
+    undefined: left.undefined || right.undefined,
     normal: left.normal || right.normal,
   };
 }
@@ -154,7 +215,7 @@ function consumeBreaks(completion: Completion, label: string | null = null): Com
   let normal: CompletionPath = completion;
   const remaining: ExitPath[] = [];
   for (const path of completion.breaks) {
-    if (path.label === label) normal = mergePaths(normal, path);
+    if (path.label === label) normal = mergePaths(normal, completionFromExit(path));
     else remaining.push(path);
   }
   return { ...normal, breaks: remaining, continues: completion.continues };
@@ -165,11 +226,11 @@ function consumeLoopExits(completion: Completion): Completion {
   const breaks: ExitPath[] = [];
   const continues: ExitPath[] = [];
   for (const path of completion.breaks) {
-    if (path.label === null) normal = mergePaths(normal, path);
+    if (path.label === null) normal = mergePaths(normal, completionFromExit(path));
     else breaks.push(path);
   }
   for (const path of completion.continues) {
-    if (path.label === null) normal = mergePaths(normal, path);
+    if (path.label === null) normal = mergePaths(normal, completionFromExit(path));
     else continues.push(path);
   }
   return { ...normal, breaks, continues };
@@ -180,7 +241,7 @@ function consumeLabelExits(completion: Completion, label: string): Completion {
   let normal: CompletionPath = afterBreaks;
   const continues: ExitPath[] = [];
   for (const path of afterBreaks.continues) {
-    if (path.label === label) normal = mergePaths(normal, path);
+    if (path.label === label) normal = mergePaths(normal, completionFromExit(path));
     else continues.push(path);
   }
   return { ...normal, breaks: afterBreaks.breaks, continues };
@@ -197,7 +258,9 @@ function completionForStatement(statement: StatementLike): Completion {
     case 'ExpressionStatement':
       return statement.expression ? {
         expressions: [statement.expression],
+        clearRanges: [],
         empty: false,
+        undefined: false,
         normal: true,
         breaks: [],
         continues: [],
@@ -210,8 +273,10 @@ function completionForStatement(statement: StatementLike): Completion {
       const consequent = completionForStatement(statement.consequent as StatementLike);
       const alternate = statement.alternate
         ? completionForStatement(statement.alternate as StatementLike)
-        : emptyCompletion();
-      return mergeCompletions(consequent, alternate);
+        : undefinedCompletion();
+      return normalizeControlCompletion(markNonInheritingExits(
+        mergeCompletions(consequent, alternate),
+      ));
     }
     case 'TryStatement': {
       const body = completionForStatement(statement.block as StatementLike);
@@ -219,16 +284,25 @@ function completionForStatement(statement: StatementLike): Completion {
         ? completionForStatement((statement.handler as { body: StatementLike }).body)
         : abruptCompletion();
       const guarded = mergeCompletions(body, handler);
-      if (!statement.finalizer) return guarded;
-      const finalizer = completionForStatement(statement.finalizer as StatementLike);
+      if (!statement.finalizer) return normalizeControlCompletion(guarded);
+      const finalizer = asFinallyCompletion(
+        completionForStatement(statement.finalizer as StatementLike),
+      );
       if (!finalizer.normal) return finalizer;
       // A normal `finally` completion is UpdateEmpty: its expression value is
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
+      const applied = applyFinallyCompletion(guarded, finalizer);
       return {
-        ...guarded,
-        breaks: [...guarded.breaks, ...finalizer.breaks],
-        continues: [...guarded.continues, ...finalizer.continues],
+        ...applied,
+        breaks: [
+          ...guarded.breaks,
+          ...finalizer.breaks.map((path) => ({ ...path, inherit: false })),
+        ],
+        continues: [
+          ...guarded.continues,
+          ...finalizer.continues.map((path) => ({ ...path, inherit: false })),
+        ],
       };
     }
     case 'LabeledStatement':
@@ -237,42 +311,61 @@ function completionForStatement(statement: StatementLike): Completion {
         (statement.label as { name: string } | null | undefined)?.name ?? '',
       );
     case 'WithStatement':
-      return completionForStatement(statement.body as StatementLike);
+      return normalizeControlCompletion(markNonInheritingExits(
+        completionForStatement(statement.body as StatementLike),
+      ));
     case 'SwitchStatement': {
       const cases = (statement.cases as Array<{ consequent: StatementLike[] }> | undefined) ?? [];
-      let completion = emptyCompletion();
+      let completion = undefinedCompletion();
       for (let index = 0; index < cases.length; index += 1) {
         const caseCompletion = completionForStatements(
           cases.slice(index).flatMap((entry) => entry.consequent),
         );
         completion = mergeCompletions(
           completion,
-          consumeBreaks(caseCompletion),
+          normalizeControlCompletion(consumeBreaks(caseCompletion)),
         );
       }
-      return completion;
+      return normalizeControlCompletion(completion);
     }
     case 'ForStatement':
     case 'ForInStatement':
     case 'ForOfStatement':
     case 'WhileStatement':
     case 'DoWhileStatement':
-      return mergeCompletions(
-        consumeLoopExits(completionForStatement(statement.body as StatementLike)),
-        emptyCompletion(),
+      const body = normalizeControlCompletion(
+        completionForStatement(statement.body as StatementLike),
       );
+      const loop = consumeLoopExits(body);
+      return statement.type === 'DoWhileStatement'
+        ? normalizeControlCompletion(loop)
+        : normalizeControlCompletion(mergeCompletions(loop, undefinedCompletion()));
     case 'ThrowStatement':
     case 'ReturnStatement':
       return abruptCompletion();
     case 'BreakStatement':
       return {
         ...abruptCompletion(),
-        breaks: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+        breaks: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          inherit: true,
+          clearRanges: [{
+            start: statement.start as number,
+            end: statement.end as number,
+            kind: 'break',
+            label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          }] }],
       };
     case 'ContinueStatement':
       return {
         ...abruptCompletion(),
-        continues: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+        continues: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          inherit: true,
+          clearRanges: [{
+            start: statement.start as number,
+            end: statement.end as number,
+            kind: 'continue',
+            label: (statement.label as { name: string } | null | undefined)?.name ?? null,
+          }] }],
       };
     default:
       return abruptCompletion();
@@ -285,11 +378,15 @@ function completionForStatements(statements: StatementLike[]): Completion {
     const next = completionForStatement(statement);
     const breaks: ExitPath[] = [
       ...completion.breaks,
-      ...next.breaks.map((path) => path.empty ? { ...completion, label: path.label } : path),
+      ...next.breaks.map((path) => path.empty && path.inherit
+        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
+        : path),
     ];
     const continues: ExitPath[] = [
       ...completion.continues,
-      ...next.continues.map((path) => path.empty ? { ...completion, label: path.label } : path),
+      ...next.continues.map((path) => path.empty && path.inherit
+        ? { ...completion, label: path.label, inherit: path.inherit, clearRanges: [...completion.clearRanges] }
+        : path),
     ];
     if (!next.normal) {
       return { ...next, breaks, continues };
@@ -326,6 +423,10 @@ function promiseObservationExpression(expression: string, completionKey?: string
   if (!completionKey) return expression;
   const key = completionKey;
   const keyLiteral = JSON.stringify(key);
+  const clearCompletion = `(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) state.completionValue = void 0;
+  })(this)`;
   const capture = (candidate: string): string => `(function(root, value) {
     var state = root[${keyLiteral}];
     if (state) state.completionValue = value;
@@ -333,11 +434,31 @@ function promiseObservationExpression(expression: string, completionKey?: string
   })(this, (\n    ${candidate}
   ))`;
   let transformed = expression;
-  for (const { start, end } of candidates
-    .map(({ start, end }) => ({ start: start as number, end: end as number }))
-    .sort((left, right) => right.start - left.start)) {
-    const candidate = expression.slice(start, end);
-    transformed = transformed.slice(0, start) + capture(candidate) + transformed.slice(end);
+  const clearRanges = completion.clearRanges.filter((range, index, all) =>
+    all.findIndex((other) =>
+      other.start === range.start &&
+      other.end === range.end &&
+      other.kind === range.kind &&
+      other.label === range.label,
+    ) === index,
+  );
+  const replacements = [
+    ...candidates.map(({ start, end }) => ({
+      start: start as number,
+      end: end as number,
+      replacement: capture(expression.slice(start as number, end as number)),
+    })),
+    ...clearRanges.map(({ start, end, kind, label }) => ({
+      start,
+      end,
+      // A plain block keeps an unlabeled break/continue targeted at its
+      // original enclosing switch or loop. An artificial loop here would
+      // capture that exit and change the caller's control flow.
+      replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
+    })),
+  ].sort((left, right) => right.start - left.start);
+  for (const { start, end, replacement } of replacements) {
+    transformed = transformed.slice(0, start) + replacement + transformed.slice(end);
   }
   const directives = (ast.program.directives as Array<{
     end?: number | null;
@@ -346,12 +467,9 @@ function promiseObservationExpression(expression: string, completionKey?: string
   const directiveEnd = directives.length > 0
     ? directives[directives.length - 1]!.end as number
     : 0;
-  const initialValue = directives.length > 0
-    ? JSON.stringify(directives[directives.length - 1]!.value?.value)
-    : 'void 0';
   const setup = `;\n(function(root) {
     var state = root[${keyLiteral}];
-    if (state) state.completionValue = ${initialValue};
+    if (state) state.completionValue = void 0;
   })(this);\n`;
   transformed = transformed.slice(0, directiveEnd) + setup + transformed.slice(directiveEnd);
   const observe = `(function(root) {
@@ -523,7 +641,10 @@ export function createAppEvaluator(
     let sourceGeneration = options?.generation;
     const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
       const recovered = await ensureConnectedForDispatch(options);
-      if (recovered && options?.retryMailboxSetup) {
+      const generationChanged = sourceGeneration !== undefined &&
+        lifecycle.getGeneration &&
+        sourceGeneration !== lifecycle.getGeneration();
+      if ((recovered || generationChanged) && options?.retryMailboxSetup) {
         if (options.deadline === undefined) {
           throw new Error('App evaluation retry requires a deadline');
         }
@@ -532,11 +653,8 @@ export function createAppEvaluator(
           deadline: options.deadline,
         });
       }
-      if (
-        sourceGeneration !== undefined &&
-        lifecycle.getGeneration &&
-        sourceGeneration !== lifecycle.getGeneration()
-      ) {
+      if (sourceGeneration !== undefined && lifecycle.getGeneration &&
+          sourceGeneration !== lifecycle.getGeneration()) {
         throw new Error('App evaluation context changed before source dispatch');
       }
       const timeout = boundedRequestTimeout(options);

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -59,6 +59,17 @@ function isServerDisconnectedError(error: unknown): boolean {
     error.message === 'Not connected to Metro. Use list_devices to check connection status.';
 }
 
+// A Runtime.evaluate completion handle belongs to the runtime generation that
+// created it. Reconnects can invalidate that handle after the source has
+// already started observing its completion in the mailbox. In that case the
+// mailbox is still the only safe source of the result; calling the source or
+// the stale handle again could replay user code or a thenable.
+function isStaleRemoteHandleError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /(?:cannot|could not|can't) find (?:the )?(?:remote )?object with given id/i.test(error.message) ||
+    /(?:invalid|unknown|stale) (?:remote )?object(?: handle)?/i.test(error.message);
+}
+
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
@@ -798,6 +809,10 @@ export function createAppEvaluator(
     try {
       return await attachRemoteSettlement();
     } catch (error) {
+      // A reconnect can invalidate the completion handle after the source has
+      // run. Its transformed observation is already attached to the mailbox,
+      // so continue polling rather than trying to reattach or replay it.
+      if (isStaleRemoteHandleError(error)) return false;
       if (!isTransportError(error)) throw error;
       // The request may have run the user's thenable before its response was
       // lost. Remote handles are invalid after reconnect, so replaying this

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -23,15 +23,20 @@ export interface AppEvaluationLifecycle {
 }
 
 /** An exception returned by the app runtime, after Runtime.evaluate ran. */
-class AppEvaluationError extends Error {
+export class AppEvaluationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'AppEvaluationError';
   }
 }
 
+/** Identify an exception returned by the app after Runtime.evaluate ran. */
+export function isAppEvaluationError(error: unknown): boolean {
+  return error instanceof AppEvaluationError;
+}
+
 function isTransportError(error: unknown): boolean {
-  if (error instanceof AppEvaluationError) return false;
+  if (isAppEvaluationError(error)) return false;
   return (
     error instanceof Error &&
     (error.message === 'WebSocket closed' ||
@@ -48,7 +53,7 @@ function isTransportError(error: unknown): boolean {
 function isDefinitivePreDispatchFailure(error: unknown): boolean {
   return (
     error instanceof Error &&
-    !(error instanceof AppEvaluationError) &&
+    !isAppEvaluationError(error) &&
     error.message === 'Not connected to CDP target'
   );
 }

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -303,7 +303,7 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
-function promiseObservationExpression(expression: string): string {
+function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
     ast = parse(expression, { sourceType: 'script' });
@@ -312,29 +312,59 @@ function promiseObservationExpression(expression: string): string {
   }
   const completion = completionForStatements(ast.program.body as StatementLike[]);
   if (!completion.normal || completion.expressions.length === 0) return expression;
-  const edits = completion.expressions
+  const candidates = completion.expressions
     .filter(({ start, end }) => start !== null && end !== null)
-    .map(({ start, end }) => ({ start: start as number, end: end as number }))
-    .filter((edit, index, all) =>
-      all.findIndex((candidate) => candidate.start === edit.start && candidate.end === edit.end) === index,
-    )
-    .sort((left, right) => right.start - left.start);
-  let transformed = expression;
-  for (const { start, end } of edits) {
-    const candidate = expression.slice(start, end);
-    const observer = `(function observePromise(value) {
-      try {
-        var PromiseCtor = globalThis.Promise;
-        if (PromiseCtor) {
-          PromiseCtor.prototype.then.call(value, function() {}, function() {});
-        }
-      } catch (_) {}
-      return value;
-    })((${candidate}
+    .filter((candidate, index, all) =>
+      all.findIndex((other) =>
+        other.start === candidate.start && other.end === candidate.end,
+      ) === index,
+    );
+  if (candidates.length === 0) return expression;
+  // Awaited evaluation always supplies the already-expiring mailbox key. If
+  // this low-level helper is called without one, leave the source untouched
+  // rather than creating state that cannot be cleaned up on an exception.
+  if (!completionKey) return expression;
+  const key = completionKey;
+  const keyLiteral = JSON.stringify(key);
+  const capture = (candidate: string): string => `(function(root, value) {
+    var state = root[${keyLiteral}];
+    if (state) state.completionValue = value;
+    return value;
+  })(this, (\n    ${candidate}
   ))`;
-    transformed = transformed.slice(0, start) + observer + transformed.slice(end);
+  let transformed = expression;
+  for (const { start, end } of candidates
+    .map(({ start, end }) => ({ start: start as number, end: end as number }))
+    .sort((left, right) => right.start - left.start)) {
+    const candidate = expression.slice(start, end);
+    transformed = transformed.slice(0, start) + capture(candidate) + transformed.slice(end);
   }
-  return transformed;
+  const directives = (ast.program.directives as Array<{
+    end?: number | null;
+    value?: { value?: unknown };
+  }> | undefined) ?? [];
+  const directiveEnd = directives.length > 0
+    ? directives[directives.length - 1]!.end as number
+    : 0;
+  const initialValue = directives.length > 0
+    ? JSON.stringify(directives[directives.length - 1]!.value?.value)
+    : 'void 0';
+  const setup = `;\n(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) state.completionValue = ${initialValue};
+  })(this);\n`;
+  transformed = transformed.slice(0, directiveEnd) + setup + transformed.slice(directiveEnd);
+  const observe = `(function(root) {
+    var state = root[${keyLiteral}];
+    var value = state ? state.completionValue : void 0;
+    try {
+      var PromiseCtor = root && root.Promise;
+      if (PromiseCtor) PromiseCtor.prototype.then.call(value, function() {}, function() {});
+    } catch (_) {}
+    if (state) state.completionValue = void 0;
+    return value;
+  })(this)`;
+  return `${transformed}\n;\n${observe}`;
 }
 
 /**
@@ -367,11 +397,11 @@ export async function evaluateAppScript(
 export async function evaluateAppScriptCompletion(
   cdp: Pick<CDPConnection, 'send'>,
   expression: string,
-  options?: EvalOptions & { observePromiseRejection?: boolean },
+  options?: EvalOptions & { observePromiseRejection?: boolean; completionKey?: string },
 ): Promise<AppEvaluationCompletion> {
   const result = await sendRuntimeEvaluate(cdp, {
     expression: options?.observePromiseRejection
-      ? promiseObservationExpression(expression)
+      ? promiseObservationExpression(expression, options.completionKey)
       : expression,
     returnByValue: false,
     awaitPromise: false,
@@ -390,10 +420,11 @@ export async function evaluateAppScriptCompletion(
 }
 
 const SETTLE_REMOTE_FUNCTION = `function(key) {
-  var state = globalThis[key];
+  var root = (function() { return this; })();
+  var state = root[key];
   if (!state) return false;
   function fulfill(value) {
-    if (globalThis[key] !== state) return;
+    if (root[key] !== state) return;
     state.unserializableValue = undefined;
     if (typeof value === 'number') {
       if (value !== value) state.unserializableValue = 'NaN';
@@ -418,7 +449,7 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     return 'Promise rejected with an unstringifiable reason';
   }
   function reject(error) {
-    if (globalThis[key] !== state) return;
+    if (root[key] !== state) return;
     state.error = rejectionMessage(error);
     state.status = 'rejected';
   }
@@ -426,7 +457,7 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     // Assimilate arbitrary thenables exactly once. Calling this.then
     // directly would accept a second callback or a nested thenable as the
     // final value, unlike JavaScript Promise resolution.
-    Promise.resolve(this).then(fulfill, reject);
+    root.Promise.resolve(this).then(fulfill, reject);
   } catch (error) { reject(error); }
   return true;
 }`;
@@ -482,6 +513,7 @@ export function createAppEvaluator(
       timeout?: number;
       deadline?: number;
       objectGroup?: string;
+      completionKey?: string;
       generation?: number;
       retryMailboxSetup?: (
         options: { timeout?: number; deadline: number },
@@ -512,6 +544,7 @@ export function createAppEvaluator(
         timeout,
         objectGroup: options?.objectGroup,
         observePromiseRejection: true,
+        completionKey: options?.completionKey,
       });
     };
     try {

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -32,6 +32,14 @@ function isTransportError(error: unknown): boolean {
   );
 }
 
+// Metro Bridge uses this exact error when it rejects a request before writing
+// anything to the target. It is safe to retry that request once after
+// connection recovery; errors such as WebSocket closed can follow a request
+// that already ran and must remain one-shot.
+function isDefinitivePreDispatchFailure(error: unknown): boolean {
+  return error instanceof Error && error.message === 'Not connected to CDP target';
+}
+
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
@@ -166,19 +174,35 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
 
 /**
  * Create the shared PluginContext evaluator policy. The raw primitive above
- * remains one-shot; only mailbox reads are eligible for reconnect/retry.
+ * remains one-shot after dispatch; a definitive pre-dispatch disconnect may
+ * be recovered once, while mailbox reads also have their safe retry policy.
  */
 export function createAppEvaluator(
   cdp: Pick<CDPConnection, 'send'>,
   lifecycle: AppEvaluationLifecycle,
 ): (expression: string, options?: EvalOptions) => Promise<unknown> {
-  const rawEvaluate = async (
+  const rawEvaluateOnce = async (
     expression: string,
     options?: EvalOptions,
   ): Promise<unknown> => {
     await lifecycle.ensureConnected(options?.deadline);
     const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
+  };
+
+  const rawEvaluate = async (
+    expression: string,
+    options?: EvalOptions,
+  ): Promise<unknown> => {
+    try {
+      return await rawEvaluateOnce(expression, options);
+    } catch (error) {
+      if (!isDefinitivePreDispatchFailure(error)) throw error;
+      // The Bridge rejected before writing Runtime.evaluate, so reconnecting
+      // and issuing this one request cannot replay caller code.
+      await recoverTransport(options?.deadline, options?.timeout);
+      return rawEvaluateOnce(expression, options);
+    }
   };
 
   const evaluateScript = async (
@@ -188,36 +212,75 @@ export function createAppEvaluator(
       deadline?: number;
       objectGroup?: string;
       generation?: number;
+      retryMailboxSetup?: (
+        options: { timeout?: number; deadline: number },
+      ) => Promise<number | undefined>;
     },
   ): Promise<AppEvaluationCompletion> => {
-    await lifecycle.ensureConnected(options?.deadline);
-    if (
-      options?.generation !== undefined &&
-      lifecycle.getGeneration &&
-      options.generation !== lifecycle.getGeneration()
-    ) {
-      throw new Error('App evaluation context changed before source dispatch');
+    let sourceGeneration = options?.generation;
+    const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
+      await lifecycle.ensureConnected(options?.deadline);
+      if (
+        sourceGeneration !== undefined &&
+        lifecycle.getGeneration &&
+        sourceGeneration !== lifecycle.getGeneration()
+      ) {
+        throw new Error('App evaluation context changed before source dispatch');
+      }
+      const timeout = boundedRequestTimeout(options);
+      return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+    };
+    try {
+      return await evaluateOnce();
+    } catch (error) {
+      if (!isDefinitivePreDispatchFailure(error)) throw error;
+      await recoverTransport(options?.deadline, options?.timeout);
+      if (options?.retryMailboxSetup) {
+        if (options.deadline === undefined) {
+          throw new Error('App evaluation retry requires a deadline');
+        }
+        sourceGeneration = await options.retryMailboxSetup({
+          timeout: options.timeout,
+          deadline: options.deadline,
+        });
+      }
+      return evaluateOnce();
     }
-    const timeout = boundedRequestTimeout(options);
-    return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
   };
 
   const setupMailbox = async (
     expression: string,
     options: { timeout?: number; deadline: number },
   ): Promise<number | undefined> => {
-    await lifecycle.ensureConnected(options.deadline);
-    const generation = lifecycle.getGeneration?.();
-    const timeout = boundedRequestTimeout(options);
-    await evaluateAppScript(cdp, expression, { timeout });
-    if (
-      generation !== undefined &&
-      lifecycle.getGeneration &&
-      generation !== lifecycle.getGeneration()
-    ) {
-      throw new Error('App evaluation context changed during mailbox setup');
+    const setupOnce = async (): Promise<number | undefined> => {
+      await lifecycle.ensureConnected(options.deadline);
+      const generation = lifecycle.getGeneration?.();
+      const timeout = boundedRequestTimeout(options);
+      await evaluateAppScript(cdp, expression, { timeout });
+      if (
+        generation !== undefined &&
+        lifecycle.getGeneration &&
+        generation !== lifecycle.getGeneration()
+      ) {
+        throw new Error('App evaluation context changed during mailbox setup');
+      }
+      return generation;
+    };
+
+    try {
+      return await setupOnce();
+    } catch (error) {
+      if (!isTransportError(error)) throw error;
+      // Mailbox setup happens before the caller source is dispatched. A lost
+      // setup response can therefore be retried safely after one bounded
+      // reconnect, even when the first setup may already have installed the
+      // mailbox in the old runtime.
+      await recoverTransport(options.deadline, options.timeout);
+      if (Date.now() >= options.deadline) {
+        throw timeoutError(options.timeout ?? 10_000);
+      }
+      return setupOnce();
     }
-    return generation;
   };
 
   const settleRemote = async (

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -139,9 +139,20 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     state.value = state.unserializableValue === undefined ? value : undefined;
     state.status = 'fulfilled';
   }
+  function rejectionMessage(error) {
+    var message;
+    try {
+      if (error !== null && error !== undefined) message = error.message;
+    } catch (_) {}
+    if (message !== undefined && message !== null) {
+      try { return String(message); } catch (_) {}
+    }
+    try { return String(error); } catch (_) {}
+    return 'Promise rejected with an unstringifiable reason';
+  }
   function reject(error) {
     if (globalThis[key] !== state) return;
-    state.error = String(error && error.message || error);
+    state.error = rejectionMessage(error);
     state.status = 'rejected';
   }
   try {
@@ -250,7 +261,7 @@ export function createAppEvaluator(
       // transport and continue mailbox polling; a pre-dispatch loss remains
       // pending and is allowed to time out.
       await awaitPromiseBeforeDeadline(
-        recoverTransport(options.deadline),
+        recoverTransport(options.deadline, options.timeout),
         options.deadline,
         options.timeout ?? 10_000,
       );
@@ -272,11 +283,16 @@ export function createAppEvaluator(
     );
   };
 
-  async function recoverTransport(deadline?: number): Promise<void> {
+  async function recoverTransport(deadline?: number, timeout = 10_000): Promise<void> {
+    if (deadline !== undefined && Date.now() >= deadline) {
+      throw timeoutError(timeout);
+    }
     if (lifecycle.isReconnecting()) {
       await lifecycle.waitForReconnect(deadline);
     } else {
-      await lifecycle.reconnect();
+      const reconnect = lifecycle.reconnect();
+      if (deadline === undefined) await reconnect;
+      else await awaitPromiseBeforeDeadline(reconnect, deadline, timeout);
     }
   }
 
@@ -288,7 +304,10 @@ export function createAppEvaluator(
       return await rawEvaluate(expression, options);
     } catch (error) {
       if (!isTransportError(error)) throw error;
-      await recoverTransport(options?.deadline);
+      await recoverTransport(options?.deadline, options?.timeout);
+      if (options?.deadline !== undefined && Date.now() >= options.deadline) {
+        throw timeoutError(options.timeout ?? 10_000);
+      }
       // This expression is a mailbox read. The original caller source is
       // never passed here after Runtime.evaluate has been dispatched.
       return rawEvaluate(expression, options);

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,5 +1,8 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
-import { extractCDPExceptionMessage } from './cdp.js';
+import {
+  decodeCDPUnserializableValue,
+  extractCDPExceptionMessage,
+} from './cdp.js';
 import {
   awaitAppResult,
   awaitPromiseBeforeDeadline,
@@ -33,21 +36,20 @@ function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
 }
 
-function decodeUnserializableValue(value: unknown): unknown {
-  if (value === 'NaN') return Number.NaN;
-  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
-  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
-  if (value === '-0') return -0;
-  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
-    return BigInt(value.slice(0, -1));
-  }
-  throw new Error('Unsupported CDP unserializable value');
-}
-
 function remoteObjectValue(remote: Record<string, unknown>): unknown {
   return Object.prototype.hasOwnProperty.call(remote, 'unserializableValue')
-    ? decodeUnserializableValue(remote.unserializableValue)
+    ? decodeCDPUnserializableValue(remote.unserializableValue)
     : remote.value;
+}
+
+function boundedRequestTimeout(options?: {
+  timeout?: number;
+  deadline?: number;
+}): number | undefined {
+  if (options?.deadline === undefined) return options?.timeout;
+  const remaining = options.deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(options.timeout ?? 10_000);
+  return Math.min(options.timeout ?? 10_000, Math.max(1, remaining));
 }
 
 async function sendRuntimeEvaluate(
@@ -164,12 +166,7 @@ export function createAppEvaluator(
     options?: EvalOptions,
   ): Promise<unknown> => {
     await lifecycle.ensureConnected();
-    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw timeoutError(options.timeout ?? 10_000);
-    }
-    const timeout = options?.deadline === undefined
-      ? options?.timeout
-      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
   };
 
@@ -190,12 +187,7 @@ export function createAppEvaluator(
     ) {
       throw new Error('App evaluation context changed before source dispatch');
     }
-    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw timeoutError(options.timeout ?? 10_000);
-    }
-    const timeout = options?.deadline === undefined
-      ? options?.timeout
-      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    const timeout = boundedRequestTimeout(options);
     return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
   };
 
@@ -204,14 +196,8 @@ export function createAppEvaluator(
     options: { timeout?: number; deadline: number },
   ): Promise<number | undefined> => {
     await lifecycle.ensureConnected();
-    if (Date.now() >= options.deadline) {
-      throw timeoutError(options.timeout ?? 10_000);
-    }
     const generation = lifecycle.getGeneration?.();
-    const timeout = Math.min(
-      options.timeout ?? 10_000,
-      Math.max(1, options.deadline - Date.now()),
-    );
+    const timeout = boundedRequestTimeout(options);
     await evaluateAppScript(cdp, expression, { timeout });
     if (
       generation !== undefined &&

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -22,7 +22,16 @@ export interface AppEvaluationLifecycle {
   getGeneration?: () => number;
 }
 
+/** An exception returned by the app runtime, after Runtime.evaluate ran. */
+class AppEvaluationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AppEvaluationError';
+  }
+}
+
 function isTransportError(error: unknown): boolean {
+  if (error instanceof AppEvaluationError) return false;
   return (
     error instanceof Error &&
     (error.message === 'WebSocket closed' ||
@@ -37,7 +46,11 @@ function isTransportError(error: unknown): boolean {
 // connection recovery; errors such as WebSocket closed can follow a request
 // that already ran and must remain one-shot.
 function isDefinitivePreDispatchFailure(error: unknown): boolean {
-  return error instanceof Error && error.message === 'Not connected to CDP target';
+  return (
+    error instanceof Error &&
+    !(error instanceof AppEvaluationError) &&
+    error.message === 'Not connected to CDP target'
+  );
 }
 
 function timeoutError(timeout: number): Error {
@@ -71,7 +84,7 @@ async function sendRuntimeEvaluate(
     timeout === undefined ? undefined : { timeoutMs: timeout },
   )) as Record<string, unknown>;
   if (result.exceptionDetails) {
-    throw new Error(
+    throw new AppEvaluationError(
       extractCDPExceptionMessage(
         result.exceptionDetails as Record<string, unknown>,
       ),
@@ -302,7 +315,7 @@ export function createAppEvaluator(
         { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
       )) as Record<string, unknown>;
       if (result.exceptionDetails) {
-        throw new Error(
+        throw new AppEvaluationError(
           extractCDPExceptionMessage(
             result.exceptionDetails as Record<string, unknown>,
           ),
@@ -390,6 +403,7 @@ export function createAppEvaluator(
           releaseObjectGroup,
           getRuntimeGeneration: lifecycle.getGeneration,
           setupMailbox,
+          deadline: options.deadline,
         },
       );
     }

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -119,6 +119,11 @@ type Completion = CompletionPath & {
   breaks: ExitPath[];
   continues: ExitPath[];
 };
+type FinallyRestore = {
+  entry: number;
+  exit: number;
+  slot: string;
+};
 
 const emptyCompletion = (): Completion => ({
   expressions: [],
@@ -346,6 +351,74 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
+function collectFinallyRestores(
+  statement: StatementLike,
+  restores: FinallyRestore[] = [],
+): FinallyRestore[] {
+  switch (statement.type) {
+    case 'BlockStatement':
+      for (const child of (statement.body as StatementLike[] | undefined) ?? []) {
+        collectFinallyRestores(child, restores);
+      }
+      break;
+    case 'IfStatement':
+      collectFinallyRestores(statement.consequent as StatementLike, restores);
+      if (statement.alternate) {
+        collectFinallyRestores(statement.alternate as StatementLike, restores);
+      }
+      break;
+    case 'TryStatement': {
+      collectFinallyRestores(statement.block as StatementLike, restores);
+      const handler = statement.handler as { body: StatementLike } | null | undefined;
+      if (handler) collectFinallyRestores(handler.body, restores);
+      const finalizer = statement.finalizer as StatementLike | null | undefined;
+      if (finalizer) {
+        const completion = completionForStatement(finalizer);
+        const hasEscapingValue = [...completion.breaks, ...completion.continues]
+          .some((path) => path.expressions.length > 0);
+        const start = finalizer.start;
+        const end = finalizer.end;
+        if (
+          completion.normal &&
+          hasEscapingValue &&
+          typeof start === 'number' &&
+          typeof end === 'number'
+        ) {
+          const directives = (finalizer.directives as Array<{ end?: number | null }> | undefined) ?? [];
+          restores.push({
+            entry: directives.length > 0
+              ? directives[directives.length - 1]!.end as number
+              : start + 1,
+            exit: end - 1,
+            slot: `finally:${start}:${end}`,
+          });
+        }
+        collectFinallyRestores(finalizer, restores);
+      }
+      break;
+    }
+    case 'LabeledStatement':
+    case 'WithStatement':
+    case 'ForStatement':
+    case 'ForInStatement':
+    case 'ForOfStatement':
+    case 'WhileStatement':
+    case 'DoWhileStatement':
+      collectFinallyRestores(statement.body as StatementLike, restores);
+      break;
+    case 'SwitchStatement':
+      for (const switchCase of (
+        statement.cases as Array<{ consequent: StatementLike[] }> | undefined
+      ) ?? []) {
+        for (const child of switchCase.consequent) {
+          collectFinallyRestores(child, restores);
+        }
+      }
+      break;
+  }
+  return restores;
+}
+
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -388,6 +461,21 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
+  const finallyRestores = collectFinallyRestores({
+    type: 'BlockStatement',
+    body: ast.program.body as StatementLike[],
+  });
+  const saveFinallyCompletion = (slot: string): string => `(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) state[${JSON.stringify(slot)}] = state.completionValue;
+  })(this)`;
+  const restoreFinallyCompletion = (slot: string): string => `(function(root) {
+    var state = root[${keyLiteral}];
+    if (state) {
+      state.completionValue = state[${JSON.stringify(slot)}];
+      delete state[${JSON.stringify(slot)}];
+    }
+  })(this)`;
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -402,6 +490,15 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
+    ...finallyRestores.flatMap(({ entry, exit, slot }) => [{
+      start: exit,
+      end: exit,
+      replacement: `;\n${restoreFinallyCompletion(slot)};\n`,
+    }, {
+      start: entry,
+      end: entry,
+      replacement: `;\n${saveFinallyCompletion(slot)};\n`,
+    }]),
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
     transformed = transformed.slice(0, start) + replacement +

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -15,6 +15,8 @@ export interface AppEvaluationLifecycle {
   reconnect(): Promise<void>;
   /** Whether a reconnect attempt is already running. */
   isReconnecting(): boolean;
+  /** Monotonic runtime generation; changes invalidate remote handles. */
+  getGeneration?: () => number;
 }
 
 function isTransportError(error: unknown): boolean {
@@ -29,6 +31,23 @@ function isTransportError(error: unknown): boolean {
 
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
+}
+
+function decodeUnserializableValue(value: unknown): unknown {
+  if (value === 'NaN') return Number.NaN;
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY;
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY;
+  if (value === '-0') return -0;
+  if (typeof value === 'string' && /^-?(?:0|[1-9]\d*)n$/.test(value)) {
+    return BigInt(value.slice(0, -1));
+  }
+  throw new Error('Unsupported CDP unserializable value');
+}
+
+function remoteObjectValue(remote: Record<string, unknown>): unknown {
+  return Object.prototype.hasOwnProperty.call(remote, 'unserializableValue')
+    ? decodeUnserializableValue(remote.unserializableValue)
+    : remote.value;
 }
 
 async function sendRuntimeEvaluate(
@@ -70,7 +89,7 @@ export async function evaluateAppScript(
     awaitPromise: false,
     ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
   }, options?.timeout);
-  return (result.result as Record<string, unknown>).value;
+  return remoteObjectValue((result.result ?? {}) as Record<string, unknown>);
 }
 
 /**
@@ -91,13 +110,14 @@ export async function evaluateAppScriptCompletion(
     ...(options?.objectGroup ? { objectGroup: options.objectGroup } : {}),
   }, options?.timeout);
   const remote = (result.result ?? {}) as Record<string, unknown>;
+  const value = remoteObjectValue(remote);
   if (typeof remote.objectId === 'string') {
     return {
       objectId: remote.objectId,
-      ...(remote.value === undefined ? {} : { value: remote.value }),
+      ...(value === undefined ? {} : { value }),
     };
   }
-  return { value: remote.value };
+  return { value };
 }
 
 const SETTLE_REMOTE_FUNCTION = `function(key) {
@@ -105,7 +125,16 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
   if (!state) return false;
   function fulfill(value) {
     if (globalThis[key] !== state) return;
-    state.value = value;
+    state.unserializableValue = undefined;
+    if (typeof value === 'number') {
+      if (value !== value) state.unserializableValue = 'NaN';
+      else if (value === Infinity) state.unserializableValue = 'Infinity';
+      else if (value === -Infinity) state.unserializableValue = '-Infinity';
+      else if (value === 0 && 1 / value === -Infinity) state.unserializableValue = '-0';
+    } else if (typeof value === 'bigint') {
+      state.unserializableValue = String(value) + 'n';
+    }
+    state.value = state.unserializableValue === undefined ? value : undefined;
     state.status = 'fulfilled';
   }
   function reject(error) {
@@ -146,9 +175,21 @@ export function createAppEvaluator(
 
   const evaluateScript = async (
     expression: string,
-    options?: { timeout?: number; deadline?: number; objectGroup?: string },
+    options?: {
+      timeout?: number;
+      deadline?: number;
+      objectGroup?: string;
+      generation?: number;
+    },
   ): Promise<AppEvaluationCompletion> => {
     await lifecycle.ensureConnected();
+    if (
+      options?.generation !== undefined &&
+      lifecycle.getGeneration &&
+      options.generation !== lifecycle.getGeneration()
+    ) {
+      throw new Error('App evaluation context changed before source dispatch');
+    }
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
       throw timeoutError(options.timeout ?? 10_000);
     }
@@ -156,6 +197,30 @@ export function createAppEvaluator(
       ? options?.timeout
       : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
     return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+  };
+
+  const setupMailbox = async (
+    expression: string,
+    options: { timeout?: number; deadline: number },
+  ): Promise<number | undefined> => {
+    await lifecycle.ensureConnected();
+    if (Date.now() >= options.deadline) {
+      throw timeoutError(options.timeout ?? 10_000);
+    }
+    const generation = lifecycle.getGeneration?.();
+    const timeout = Math.min(
+      options.timeout ?? 10_000,
+      Math.max(1, options.deadline - Date.now()),
+    );
+    await evaluateAppScript(cdp, expression, { timeout });
+    if (
+      generation !== undefined &&
+      lifecycle.getGeneration &&
+      generation !== lifecycle.getGeneration()
+    ) {
+      throw new Error('App evaluation context changed during mailbox setup');
+    }
+    return generation;
   };
 
   const settleRemote = async (
@@ -193,10 +258,11 @@ export function createAppEvaluator(
       return await attachRemoteSettlement();
     } catch (error) {
       if (!isTransportError(error)) throw error;
-      // Attaching the same settlement callback twice is safe: it only writes
-      // the private mailbox and never re-runs the caller's source. Bound the
-      // reconnect itself by the same deadline as the attach and re-check it
-      // before dispatching the retry, since reconnect may finish late.
+      // The request may have run the user's thenable before its response was
+      // lost. Remote handles are invalid after reconnect, so replaying this
+      // callFunctionOn could invoke a side-effecting thenable twice. Recover
+      // transport and continue mailbox polling; a pre-dispatch loss remains
+      // pending and is allowed to time out.
       await awaitPromiseBeforeDeadline(
         recoverTransport(),
         options.deadline,
@@ -205,7 +271,7 @@ export function createAppEvaluator(
       if (Date.now() >= options.deadline) {
         throw timeoutError(options.timeout ?? 10_000);
       }
-      return attachRemoteSettlement();
+      return false;
     }
   };
 
@@ -254,6 +320,8 @@ export function createAppEvaluator(
           evaluateScript,
           settleRemote,
           releaseObjectGroup,
+          getRuntimeGeneration: lifecycle.getGeneration,
+          setupMailbox,
         },
       );
     }

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -112,7 +112,6 @@ type CompletionPath = {
   expressions: ExpressionLike[];
   clearRanges: Array<{ start: number; end: number; kind: 'break' | 'continue'; label: string | null }>;
   empty: boolean;
-  undefined: boolean;
   normal: boolean;
 };
 type ExitPath = CompletionPath & { label: string | null; inherit: boolean };
@@ -125,7 +124,6 @@ const emptyCompletion = (): Completion => ({
   expressions: [],
   clearRanges: [],
   empty: true,
-  undefined: false,
   normal: true,
   breaks: [],
   continues: [],
@@ -135,40 +133,10 @@ const abruptCompletion = (): Completion => ({
   expressions: [],
   clearRanges: [],
   empty: false,
-  undefined: false,
   normal: false,
   breaks: [],
   continues: [],
 });
-
-const undefinedCompletion = (): Completion => ({
-  expressions: [],
-  clearRanges: [],
-  empty: false,
-  undefined: true,
-  normal: true,
-  breaks: [],
-  continues: [],
-});
-
-function normalizeControlCompletion(completion: Completion): Completion {
-  return {
-    ...completion,
-    empty: false,
-    undefined: completion.undefined || completion.empty,
-  };
-}
-
-function asFinallyCompletion(completion: Completion): Completion {
-  // A normal finalizer uses UpdateEmpty. Control statements such as an
-  // untaken if/loop therefore preserve the guarded completion in a finally
-  // clause, even though they produce undefined at script level.
-  return {
-    ...completion,
-    empty: completion.empty || completion.undefined,
-    undefined: false,
-  };
-}
 
 function applyFinallyCompletion(
   guarded: Completion,
@@ -180,14 +148,6 @@ function applyFinallyCompletion(
   return guarded;
 }
 
-function markNonInheritingExits(completion: Completion): Completion {
-  return {
-    ...completion,
-    breaks: completion.breaks.map((path) => ({ ...path, inherit: false })),
-    continues: completion.continues.map((path) => ({ ...path, inherit: false })),
-  };
-}
-
 function completionFromExit(path: ExitPath): CompletionPath {
   return path.inherit ? { ...path, clearRanges: [] } : path;
 }
@@ -196,11 +156,10 @@ function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath
   return {
     expressions: [...left.expressions, ...right.expressions],
     clearRanges: [...left.clearRanges, ...right.clearRanges],
-    // A merged path is empty only when every contributing completion is
-    // empty. An explicit undefined completion from a catch/finally or a later
-    // empty loop iteration must replace an earlier value.
-    empty: left.empty && right.empty,
-    undefined: left.undefined || right.undefined,
+    // Hermes reports the previous value for an empty control-flow path. Keep
+    // empty completion inheritance here; the mailbox starts empty for each
+    // evaluation, so this cannot leak a prior request's value.
+    empty: left.empty || right.empty,
     normal: left.normal || right.normal,
   };
 }
@@ -263,7 +222,6 @@ function completionForStatement(statement: StatementLike): Completion {
         expressions: [statement.expression],
         clearRanges: [],
         empty: false,
-        undefined: false,
         normal: true,
         breaks: [],
         continues: [],
@@ -276,10 +234,8 @@ function completionForStatement(statement: StatementLike): Completion {
       const consequent = completionForStatement(statement.consequent as StatementLike);
       const alternate = statement.alternate
         ? completionForStatement(statement.alternate as StatementLike)
-        : undefinedCompletion();
-      return normalizeControlCompletion(markNonInheritingExits(
-        mergeCompletions(consequent, alternate),
-      ));
+        : emptyCompletion();
+      return mergeCompletions(consequent, alternate);
     }
     case 'TryStatement': {
       const body = completionForStatement(statement.block as StatementLike);
@@ -287,27 +243,18 @@ function completionForStatement(statement: StatementLike): Completion {
         ? completionForStatement((statement.handler as { body: StatementLike }).body)
         : abruptCompletion();
       const guarded = mergeCompletions(body, handler);
-      if (!statement.finalizer) return normalizeControlCompletion(guarded);
-      const finalizer = asFinallyCompletion(
-        completionForStatement(statement.finalizer as StatementLike),
-      );
+      if (!statement.finalizer) return guarded;
+      const finalizer = completionForStatement(statement.finalizer as StatementLike);
       if (!finalizer.normal) return finalizer;
       // A normal `finally` completion is UpdateEmpty: its expression value is
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
       const applied = applyFinallyCompletion(guarded, finalizer);
-      const result = {
+      return {
         ...applied,
-        breaks: [
-          ...guarded.breaks,
-          ...finalizer.breaks.map((path) => ({ ...path, inherit: false })),
-        ],
-        continues: [
-          ...guarded.continues,
-          ...finalizer.continues.map((path) => ({ ...path, inherit: false })),
-        ],
+        breaks: [...guarded.breaks, ...finalizer.breaks],
+        continues: [...guarded.continues, ...finalizer.continues],
       };
-      return result.normal ? normalizeControlCompletion(result) : result;
     }
     case 'LabeledStatement':
       return consumeLabelExits(
@@ -315,35 +262,30 @@ function completionForStatement(statement: StatementLike): Completion {
         (statement.label as { name: string } | null | undefined)?.name ?? '',
       );
     case 'WithStatement':
-      return normalizeControlCompletion(markNonInheritingExits(
-        completionForStatement(statement.body as StatementLike),
-      ));
+      return completionForStatement(statement.body as StatementLike);
     case 'SwitchStatement': {
       const cases = (statement.cases as Array<{ consequent: StatementLike[] }> | undefined) ?? [];
-      let completion = undefinedCompletion();
+      let completion = emptyCompletion();
       for (let index = 0; index < cases.length; index += 1) {
         const caseCompletion = completionForStatements(
           cases.slice(index).flatMap((entry) => entry.consequent),
         );
         completion = mergeCompletions(
           completion,
-          normalizeControlCompletion(consumeBreaks(caseCompletion)),
+          consumeBreaks(caseCompletion),
         );
       }
-      return normalizeControlCompletion(completion);
+      return completion;
     }
     case 'ForStatement':
     case 'ForInStatement':
     case 'ForOfStatement':
     case 'WhileStatement':
     case 'DoWhileStatement':
-      const body = normalizeControlCompletion(
-        completionForStatement(statement.body as StatementLike),
+      return mergeCompletions(
+        consumeLoopExits(completionForStatement(statement.body as StatementLike)),
+        emptyCompletion(),
       );
-      const loop = consumeLoopExits(body);
-      return statement.type === 'DoWhileStatement'
-        ? normalizeControlCompletion(loop)
-        : normalizeControlCompletion(mergeCompletions(loop, undefinedCompletion()));
     case 'ThrowStatement':
     case 'ReturnStatement':
       return abruptCompletion();
@@ -404,85 +346,6 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
-type SourceInsertion = { start: number; end?: number; replacement: string };
-
-function collectLoopEntryInsertions(
-  statement: StatementLike,
-  clearCompletion: string,
-  insertions: SourceInsertion[],
-): void {
-  const visit = (child: unknown): void => {
-    if (child && typeof child === 'object' && 'type' in child) {
-      collectLoopEntryInsertions(child as StatementLike, clearCompletion, insertions);
-    }
-  };
-  const visitList = (children: unknown): void => {
-    if (Array.isArray(children)) children.forEach(visit);
-  };
-
-  switch (statement.type) {
-    case 'BlockStatement':
-      visitList(statement.body);
-      return;
-    case 'IfStatement':
-      visit(statement.consequent);
-      visit(statement.alternate);
-      return;
-    case 'TryStatement':
-      visit(statement.block);
-      visit((statement.handler as { body?: unknown } | null | undefined)?.body);
-      visit(statement.finalizer);
-      return;
-    case 'LabeledStatement':
-    case 'WithStatement':
-      visit(statement.body);
-      return;
-    case 'SwitchStatement':
-      for (const switchCase of (statement.cases as Array<{ consequent?: unknown }> | undefined) ?? []) {
-        visitList(switchCase.consequent);
-      }
-      return;
-    case 'ForStatement':
-    case 'ForInStatement':
-    case 'ForOfStatement':
-    case 'WhileStatement':
-    case 'DoWhileStatement': {
-      const body = statement.body as StatementLike | undefined;
-      if (body?.start !== null && body?.start !== undefined &&
-          body.end !== null && body.end !== undefined) {
-        const bodyCompletion = completionForStatement(body);
-        // Each iteration computes a fresh body completion. A reached
-        // candidate immediately replaces this reset; a runtime path that
-        // reaches none of the candidates completes with undefined instead of
-        // leaking a value from an earlier iteration.
-        if (bodyCompletion.expressions.length === 0) {
-          visit(body);
-          return;
-        }
-        if (body.type === 'BlockStatement') {
-          const directives = (body.directives as Array<{ end?: number | null }> | undefined) ?? [];
-          const entry = directives.length > 0
-            ? directives[directives.length - 1]!.end
-            : (body.start as number) + 1;
-          if (entry !== null && entry !== undefined) {
-            insertions.push({ start: entry, replacement: ` ${clearCompletion}; ` });
-          }
-        } else {
-          insertions.push({
-            start: body.start as number,
-            replacement: `{ ${clearCompletion}; `,
-          });
-          insertions.push({ start: body.end as number, replacement: ' }' });
-        }
-      }
-      visit(body);
-      return;
-    }
-    default:
-      return;
-  }
-}
-
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -525,10 +388,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
-  const loopInsertions: SourceInsertion[] = [];
-  for (const statement of ast.program.body as StatementLike[]) {
-    collectLoopEntryInsertions(statement, clearCompletion, loopInsertions);
-  }
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -543,7 +402,6 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
-    ...loopInsertions,
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
     transformed = transformed.slice(0, start) + replacement +
@@ -556,19 +414,23 @@ function promiseObservationExpression(expression: string, completionKey?: string
   const directiveEnd = directives.length > 0
     ? directives[directives.length - 1]!.end as number
     : 0;
+  // Babel stores a hashbang separately from the program body. Keep it as the
+  // first source line when inserting mailbox setup or the generated script
+  // becomes invalid JavaScript.
+  const prefixEnd = Math.max(directiveEnd, ast.program.interpreter?.end ?? 0);
   const setup = `;\n(function(root) {
     var state = root[${keyLiteral}];
     if (state) state.completionValue = void 0;
   })(this);\n`;
-  transformed = transformed.slice(0, directiveEnd) + setup + transformed.slice(directiveEnd);
+  transformed = transformed.slice(0, prefixEnd) + setup + transformed.slice(prefixEnd);
   const observe = `(function(root) {
     var state = root[${keyLiteral}];
     var value = state ? state.completionValue : void 0;
     try {
-      var PromiseCtor = state && (state.promiseConstructor || root.Promise);
-      var promiseThen = (state && state.promiseThen) ||
-        (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
-      if (promiseThen) promiseThen.call(value, function() {}, function() {});
+      // Start the mailbox's single realm-internal assimilation in the same
+      // JavaScript job, so an immediately rejected completion is observed
+      // before Runtime.evaluate returns.
+      if (state && typeof state.observe === 'function') state.observe(value);
     } catch (_) {}
     if (state) state.completionValue = void 0;
     return value;
@@ -632,49 +494,12 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
   var root = (function() { return this; })();
   var state = root[key];
   if (!state) return false;
-  function fulfill(value) {
-    if (root[key] !== state) return;
-    state.unserializableValue = undefined;
-    if (typeof value === 'number') {
-      if (value !== value) state.unserializableValue = 'NaN';
-      else if (value === Infinity) state.unserializableValue = 'Infinity';
-      else if (value === -Infinity) state.unserializableValue = '-Infinity';
-      else if (value === 0 && 1 / value === -Infinity) state.unserializableValue = '-0';
-    } else if (typeof value === 'bigint') {
-      state.unserializableValue = String(value) + 'n';
-    }
-    state.value = state.unserializableValue === undefined ? value : undefined;
-    state.status = 'fulfilled';
-  }
-  function rejectionMessage(error) {
-    var message;
-    try {
-      if (error !== null && error !== undefined) message = error.message;
-    } catch (_) {}
-    if (message !== undefined && message !== null) {
-      try { return String(message); } catch (_) {}
-    }
-    try { return String(error); } catch (_) {}
-    return 'Promise rejected with an unstringifiable reason';
-  }
-  function reject(error) {
-    if (root[key] !== state) return;
-    state.error = rejectionMessage(error);
-    state.status = 'rejected';
-  }
   try {
-    // Assimilate arbitrary thenables exactly once. Calling this.then
-    // directly would accept a second callback or a nested thenable as the
-    // final value, unlike JavaScript Promise resolution.
-    var PromiseCtor = state.promiseConstructor || root.Promise;
-    var promiseResolve = state.promiseResolve || (PromiseCtor && PromiseCtor.resolve);
-    if (!promiseResolve) throw new Error('Promise constructor unavailable');
-    var resolved = promiseResolve.call(PromiseCtor, this);
-    var promiseThen = state.promiseThen ||
-      (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
-    if (!promiseThen) throw new Error('Promise then unavailable');
-    promiseThen.call(resolved, fulfill, reject);
-  } catch (error) { reject(error); }
+    // Transformed sources start this before Runtime.evaluate returns. Sources
+    // that could not be transformed start the same one-shot assimilation here.
+    if (typeof state.observe !== 'function') return false;
+    state.observe(this);
+  } catch (_) { return false; }
   return true;
 }`;
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -440,13 +440,15 @@ export function createAppEvaluator(
   cdp: Pick<CDPConnection, 'send'>,
   lifecycle: AppEvaluationLifecycle,
 ): (expression: string, options?: EvalOptions) => Promise<unknown> {
-  const ensureConnectedForDispatch = async (options?: EvalOptions): Promise<void> => {
+  const ensureConnectedForDispatch = async (options?: EvalOptions): Promise<boolean> => {
     try {
       await lifecycle.ensureConnected(options?.deadline);
+      return false;
     } catch (error) {
       if (!isServerDisconnectedError(error)) throw error;
       await recoverTransport(options?.deadline, options?.timeout);
       await lifecycle.ensureConnected(options?.deadline);
+      return true;
     }
   };
 
@@ -488,7 +490,16 @@ export function createAppEvaluator(
   ): Promise<AppEvaluationCompletion> => {
     let sourceGeneration = options?.generation;
     const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
-      await ensureConnectedForDispatch(options);
+      const recovered = await ensureConnectedForDispatch(options);
+      if (recovered && options?.retryMailboxSetup) {
+        if (options.deadline === undefined) {
+          throw new Error('App evaluation retry requires a deadline');
+        }
+        sourceGeneration = await options.retryMailboxSetup({
+          timeout: options.timeout,
+          deadline: options.deadline,
+        });
+      }
       if (
         sourceGeneration !== undefined &&
         lifecycle.getGeneration &&

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -11,9 +11,9 @@ import {
 
 export interface AppEvaluationLifecycle {
   /** Ensure a request can be sent before it is dispatched. */
-  ensureConnected(): Promise<void>;
+  ensureConnected(deadline?: number): Promise<void>;
   /** Wait for an already running reconnect attempt. */
-  waitForReconnect(): Promise<void>;
+  waitForReconnect(deadline?: number): Promise<void>;
   /** Start a reconnect attempt when a safe mailbox read loses transport. */
   reconnect(): Promise<void>;
   /** Whether a reconnect attempt is already running. */
@@ -165,7 +165,7 @@ export function createAppEvaluator(
     expression: string,
     options?: EvalOptions,
   ): Promise<unknown> => {
-    await lifecycle.ensureConnected();
+    await lifecycle.ensureConnected(options?.deadline);
     const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
   };
@@ -179,7 +179,7 @@ export function createAppEvaluator(
       generation?: number;
     },
   ): Promise<AppEvaluationCompletion> => {
-    await lifecycle.ensureConnected();
+    await lifecycle.ensureConnected(options?.deadline);
     if (
       options?.generation !== undefined &&
       lifecycle.getGeneration &&
@@ -195,7 +195,7 @@ export function createAppEvaluator(
     expression: string,
     options: { timeout?: number; deadline: number },
   ): Promise<number | undefined> => {
-    await lifecycle.ensureConnected();
+    await lifecycle.ensureConnected(options.deadline);
     const generation = lifecycle.getGeneration?.();
     const timeout = boundedRequestTimeout(options);
     await evaluateAppScript(cdp, expression, { timeout });
@@ -250,7 +250,7 @@ export function createAppEvaluator(
       // transport and continue mailbox polling; a pre-dispatch loss remains
       // pending and is allowed to time out.
       await awaitPromiseBeforeDeadline(
-        recoverTransport(),
+        recoverTransport(options.deadline),
         options.deadline,
         options.timeout ?? 10_000,
       );
@@ -272,9 +272,9 @@ export function createAppEvaluator(
     );
   };
 
-  async function recoverTransport(): Promise<void> {
+  async function recoverTransport(deadline?: number): Promise<void> {
     if (lifecycle.isReconnecting()) {
-      await lifecycle.waitForReconnect();
+      await lifecycle.waitForReconnect(deadline);
     } else {
       await lifecycle.reconnect();
     }
@@ -288,7 +288,7 @@ export function createAppEvaluator(
       return await rawEvaluate(expression, options);
     } catch (error) {
       if (!isTransportError(error)) throw error;
-      await recoverTransport();
+      await recoverTransport(options?.deadline);
       // This expression is a mailbox read. The original caller source is
       // never passed here after Runtime.evaluate has been dispatched.
       return rawEvaluate(expression, options);

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,6 +1,6 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
 import { extractCDPExceptionMessage } from './cdp.js';
-import { awaitAppResult } from './await-app-result.js';
+import { awaitAppResult, type AppEvaluationCompletion } from './await-app-result.js';
 
 export interface AppEvaluationLifecycle {
   /** Ensure a request can be sent before it is dispatched. */
@@ -23,6 +23,26 @@ function isTransportError(error: unknown): boolean {
   );
 }
 
+async function sendRuntimeEvaluate(
+  cdp: Pick<CDPConnection, 'send'>,
+  params: Record<string, unknown>,
+  timeout?: number,
+): Promise<Record<string, unknown>> {
+  const result = (await cdp.send(
+    'Runtime.evaluate',
+    params,
+    timeout === undefined ? undefined : { timeoutMs: timeout },
+  )) as Record<string, unknown>;
+  if (result.exceptionDetails) {
+    throw new Error(
+      extractCDPExceptionMessage(
+        result.exceptionDetails as Record<string, unknown>,
+      ),
+    );
+  }
+  return result;
+}
+
 /**
  * Send one Runtime.evaluate request and return its by-value completion value.
  *
@@ -36,21 +56,63 @@ export async function evaluateAppScript(
   expression: string,
   options?: EvalOptions,
 ): Promise<unknown> {
-  const result = (await cdp.send('Runtime.evaluate', {
+  const result = await sendRuntimeEvaluate(cdp, {
     expression,
     returnByValue: true,
     awaitPromise: false,
-    timeout: options?.timeout,
-  })) as Record<string, unknown>;
-  if (result.exceptionDetails) {
-    throw new Error(
-      extractCDPExceptionMessage(
-        result.exceptionDetails as Record<string, unknown>,
-      ),
-    );
-  }
+    ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
+  }, options?.timeout);
   return (result.result as Record<string, unknown>).value;
 }
+
+/**
+ * Execute a script once and retain its remote completion object. Keeping the
+ * Runtime.evaluate request separate from mailbox setup is what preserves
+ * normal script completion and declaration semantics on persistent runtimes.
+ */
+export async function evaluateAppScriptCompletion(
+  cdp: Pick<CDPConnection, 'send'>,
+  expression: string,
+  options?: EvalOptions,
+): Promise<AppEvaluationCompletion> {
+  const result = await sendRuntimeEvaluate(cdp, {
+    expression,
+    returnByValue: false,
+    awaitPromise: false,
+    ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
+    ...(options?.objectGroup ? { objectGroup: options.objectGroup } : {}),
+  }, options?.timeout);
+  const remote = (result.result ?? {}) as Record<string, unknown>;
+  if (typeof remote.objectId === 'string') {
+    return {
+      objectId: remote.objectId,
+      ...(remote.value === undefined ? {} : { value: remote.value }),
+    };
+  }
+  return { value: remote.value };
+}
+
+const SETTLE_REMOTE_FUNCTION = `function(key) {
+  var state = globalThis[key];
+  if (!state) return false;
+  function fulfill(value) {
+    if (globalThis[key] !== state) return;
+    state.value = value;
+    state.status = 'fulfilled';
+  }
+  function reject(error) {
+    if (globalThis[key] !== state) return;
+    state.error = String(error && error.message || error);
+    state.status = 'rejected';
+  }
+  try {
+    // Assimilate arbitrary thenables exactly once. Calling this.then
+    // directly would accept a second callback or a nested thenable as the
+    // final value, unlike JavaScript Promise resolution.
+    Promise.resolve(this).then(fulfill, reject);
+  } catch (error) { reject(error); }
+  return true;
+}`;
 
 /**
  * Create the shared PluginContext evaluator policy. The raw primitive above
@@ -68,7 +130,79 @@ export function createAppEvaluator(
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
       throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
     }
-    return evaluateAppScript(cdp, expression, options);
+    const timeout = options?.deadline === undefined
+      ? options?.timeout
+      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    return evaluateAppScript(cdp, expression, { ...options, timeout });
+  };
+
+  const evaluateScript = async (
+    expression: string,
+    options?: { timeout?: number; deadline?: number; objectGroup?: string },
+  ): Promise<AppEvaluationCompletion> => {
+    await lifecycle.ensureConnected();
+    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
+      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+    }
+    const timeout = options?.deadline === undefined
+      ? options?.timeout
+      : Math.min(options.timeout ?? 10_000, Math.max(1, options.deadline - Date.now()));
+    return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+  };
+
+  const settleRemote = async (
+    objectId: string,
+    mailboxKey: string,
+    options: { timeout?: number; deadline: number },
+  ): Promise<boolean> => {
+    const remaining = Math.max(1, options.deadline - Date.now());
+    let settled = false;
+    let released = false;
+    try {
+      const result = (await cdp.send(
+        'Runtime.callFunctionOn',
+        {
+          objectId,
+          functionDeclaration: SETTLE_REMOTE_FUNCTION,
+          arguments: [{ value: mailboxKey }],
+          returnByValue: true,
+        },
+        { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+      )) as Record<string, unknown>;
+      if (result.exceptionDetails) {
+        throw new Error(
+          extractCDPExceptionMessage(
+            result.exceptionDetails as Record<string, unknown>,
+          ),
+        );
+      }
+      settled = ((result.result as Record<string, unknown> | undefined)?.value !== false);
+    } finally {
+      // The completion handle is only needed while its settlement callback is
+      // being attached. Releasing it avoids retaining every awaited Promise.
+      try {
+        await cdp.send(
+          'Runtime.releaseObject',
+          { objectId },
+          { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+        );
+        released = true;
+      } catch {
+        // The object group cleanup in awaitAppResult remains the fallback.
+      }
+    }
+    return settled && released;
+  };
+
+  const releaseObjectGroup = async (
+    objectGroup: string,
+    options: { timeout?: number },
+  ): Promise<void> => {
+    await cdp.send(
+      'Runtime.releaseObjectGroup',
+      { objectGroup },
+      { timeoutMs: options.timeout ?? 500 },
+    );
   };
 
   async function recoverTransport(): Promise<void> {
@@ -100,7 +234,12 @@ export function createAppEvaluator(
         rawEvaluate,
         expression,
         options.timeout ?? 10_000,
-        { pollEvaluate: retryMailboxRead },
+        {
+          pollEvaluate: retryMailboxRead,
+          evaluateScript,
+          settleRemote,
+          releaseObjectGroup,
+        },
       );
     }
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,6 +1,10 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
 import { extractCDPExceptionMessage } from './cdp.js';
-import { awaitAppResult, type AppEvaluationCompletion } from './await-app-result.js';
+import {
+  awaitAppResult,
+  awaitPromiseBeforeDeadline,
+  type AppEvaluationCompletion,
+} from './await-app-result.js';
 
 export interface AppEvaluationLifecycle {
   /** Ensure a request can be sent before it is dispatched. */
@@ -25,24 +29,6 @@ function isTransportError(error: unknown): boolean {
 
 function timeoutError(timeout: number): Error {
   return new Error(`App evaluation timed out after ${timeout}ms`);
-}
-
-async function awaitBeforeDeadline<T>(
-  operation: Promise<T>,
-  deadline: number,
-  timeout: number,
-): Promise<T> {
-  const remaining = deadline - Date.now();
-  if (remaining <= 0) throw timeoutError(timeout);
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadlineReached = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
-  });
-  try {
-    return await Promise.race([operation, deadlineReached]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
 }
 
 async function sendRuntimeEvaluate(
@@ -150,7 +136,7 @@ export function createAppEvaluator(
   ): Promise<unknown> => {
     await lifecycle.ensureConnected();
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+      throw timeoutError(options.timeout ?? 10_000);
     }
     const timeout = options?.deadline === undefined
       ? options?.timeout
@@ -164,7 +150,7 @@ export function createAppEvaluator(
   ): Promise<AppEvaluationCompletion> => {
     await lifecycle.ensureConnected();
     if (options?.deadline !== undefined && Date.now() >= options.deadline) {
-      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+      throw timeoutError(options.timeout ?? 10_000);
     }
     const timeout = options?.deadline === undefined
       ? options?.timeout
@@ -177,7 +163,7 @@ export function createAppEvaluator(
     mailboxKey: string,
     options: { timeout?: number; deadline: number },
   ): Promise<boolean> => {
-    const attach = async (): Promise<boolean> => {
+    const attachRemoteSettlement = async (): Promise<boolean> => {
       const remaining = options.deadline - Date.now();
       if (remaining <= 0) throw timeoutError(options.timeout ?? 10_000);
       const result = (await cdp.send(
@@ -204,14 +190,14 @@ export function createAppEvaluator(
     };
 
     try {
-      return await attach();
+      return await attachRemoteSettlement();
     } catch (error) {
       if (!isTransportError(error)) throw error;
       // Attaching the same settlement callback twice is safe: it only writes
       // the private mailbox and never re-runs the caller's source. Bound the
       // reconnect itself by the same deadline as the attach and re-check it
       // before dispatching the retry, since reconnect may finish late.
-      await awaitBeforeDeadline(
+      await awaitPromiseBeforeDeadline(
         recoverTransport(),
         options.deadline,
         options.timeout ?? 10_000,
@@ -219,7 +205,7 @@ export function createAppEvaluator(
       if (Date.now() >= options.deadline) {
         throw timeoutError(options.timeout ?? 10_000);
       }
-      return attach();
+      return attachRemoteSettlement();
     }
   };
 

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -23,6 +23,28 @@ function isTransportError(error: unknown): boolean {
   );
 }
 
+function timeoutError(timeout: number): Error {
+  return new Error(`App evaluation timed out after ${timeout}ms`);
+}
+
+async function awaitBeforeDeadline<T>(
+  operation: Promise<T>,
+  deadline: number,
+  timeout: number,
+): Promise<T> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw timeoutError(timeout);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadlineReached = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError(timeout)), remaining);
+  });
+  try {
+    return await Promise.race([operation, deadlineReached]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function sendRuntimeEvaluate(
   cdp: Pick<CDPConnection, 'send'>,
   params: Record<string, unknown>,
@@ -155,28 +177,50 @@ export function createAppEvaluator(
     mailboxKey: string,
     options: { timeout?: number; deadline: number },
   ): Promise<boolean> => {
-    const remaining = Math.max(1, options.deadline - Date.now());
-    const result = (await cdp.send(
-      'Runtime.callFunctionOn',
-      {
-        objectId,
-        functionDeclaration: SETTLE_REMOTE_FUNCTION,
-        arguments: [{ value: mailboxKey }],
-        returnByValue: true,
-      },
-      { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
-    )) as Record<string, unknown>;
-    if (result.exceptionDetails) {
-      throw new Error(
-        extractCDPExceptionMessage(
-          result.exceptionDetails as Record<string, unknown>,
-        ),
+    const attach = async (): Promise<boolean> => {
+      const remaining = options.deadline - Date.now();
+      if (remaining <= 0) throw timeoutError(options.timeout ?? 10_000);
+      const result = (await cdp.send(
+        'Runtime.callFunctionOn',
+        {
+          objectId,
+          functionDeclaration: SETTLE_REMOTE_FUNCTION,
+          arguments: [{ value: mailboxKey }],
+          returnByValue: true,
+        },
+        { timeoutMs: Math.min(options.timeout ?? remaining, remaining) },
+      )) as Record<string, unknown>;
+      if (result.exceptionDetails) {
+        throw new Error(
+          extractCDPExceptionMessage(
+            result.exceptionDetails as Record<string, unknown>,
+          ),
+        );
+      }
+      // Keep the unique object group responsible for cleanup. Its separately
+      // bounded release runs after mailbox settlement, so handle cleanup cannot
+      // delay polling or leave a detached, permanently pending transport call.
+      return false;
+    };
+
+    try {
+      return await attach();
+    } catch (error) {
+      if (!isTransportError(error)) throw error;
+      // Attaching the same settlement callback twice is safe: it only writes
+      // the private mailbox and never re-runs the caller's source. Bound the
+      // reconnect itself by the same deadline as the attach and re-check it
+      // before dispatching the retry, since reconnect may finish late.
+      await awaitBeforeDeadline(
+        recoverTransport(),
+        options.deadline,
+        options.timeout ?? 10_000,
       );
+      if (Date.now() >= options.deadline) {
+        throw timeoutError(options.timeout ?? 10_000);
+      }
+      return attach();
     }
-    // Keep the unique object group responsible for cleanup. Its separately
-    // bounded release runs after mailbox settlement, so handle cleanup cannot
-    // delay polling or leave a detached, permanently pending transport call.
-    return false;
   };
 
   const releaseObjectGroup = async (

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,0 +1,112 @@
+import type { CDPConnection, EvalOptions } from '../plugin.js';
+import { extractCDPExceptionMessage } from './cdp.js';
+import { awaitAppResult } from './await-app-result.js';
+
+export interface AppEvaluationLifecycle {
+  /** Ensure a request can be sent before it is dispatched. */
+  ensureConnected(): Promise<void>;
+  /** Wait for an already running reconnect attempt. */
+  waitForReconnect(): Promise<void>;
+  /** Start a reconnect attempt when a safe mailbox read loses transport. */
+  reconnect(): Promise<void>;
+  /** Whether a reconnect attempt is already running. */
+  isReconnecting(): boolean;
+}
+
+function isTransportError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === 'WebSocket closed' ||
+      error.message === 'Not connected to CDP target' ||
+      error.message ===
+        'Not connected to Metro. Use list_devices to check connection status.')
+  );
+}
+
+/**
+ * Send one Runtime.evaluate request and return its by-value completion value.
+ *
+ * This intentionally has no reconnect or retry policy. A transport error after
+ * dispatch cannot tell us whether the app ran the script, so replaying it could
+ * duplicate a mutation. Retry policy belongs to callers that know their read
+ * is safe, such as mailbox polling.
+ */
+export async function evaluateAppScript(
+  cdp: Pick<CDPConnection, 'send'>,
+  expression: string,
+  options?: EvalOptions,
+): Promise<unknown> {
+  const result = (await cdp.send('Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+    awaitPromise: false,
+    timeout: options?.timeout,
+  })) as Record<string, unknown>;
+  if (result.exceptionDetails) {
+    throw new Error(
+      extractCDPExceptionMessage(
+        result.exceptionDetails as Record<string, unknown>,
+      ),
+    );
+  }
+  return (result.result as Record<string, unknown>).value;
+}
+
+/**
+ * Create the shared PluginContext evaluator policy. The raw primitive above
+ * remains one-shot; only mailbox reads are eligible for reconnect/retry.
+ */
+export function createAppEvaluator(
+  cdp: Pick<CDPConnection, 'send'>,
+  lifecycle: AppEvaluationLifecycle,
+): (expression: string, options?: EvalOptions) => Promise<unknown> {
+  const rawEvaluate = async (
+    expression: string,
+    options?: EvalOptions,
+  ): Promise<unknown> => {
+    await lifecycle.ensureConnected();
+    if (options?.deadline !== undefined && Date.now() >= options.deadline) {
+      throw new Error(`App evaluation timed out after ${options.timeout ?? 10_000}ms`);
+    }
+    return evaluateAppScript(cdp, expression, options);
+  };
+
+  async function recoverTransport(): Promise<void> {
+    if (lifecycle.isReconnecting()) {
+      await lifecycle.waitForReconnect();
+    } else {
+      await lifecycle.reconnect();
+    }
+  }
+
+  const retryMailboxRead = async (
+    expression: string,
+    options?: EvalOptions,
+  ): Promise<unknown> => {
+    try {
+      return await rawEvaluate(expression, options);
+    } catch (error) {
+      if (!isTransportError(error)) throw error;
+      await recoverTransport();
+      // This expression is a mailbox read. The original caller source is
+      // never passed here after Runtime.evaluate has been dispatched.
+      return rawEvaluate(expression, options);
+    }
+  };
+
+  return async (expression: string, options?: EvalOptions): Promise<unknown> => {
+    if (options?.awaitPromise) {
+      return awaitAppResult(
+        rawEvaluate,
+        expression,
+        options.timeout ?? 10_000,
+        { pollEvaluate: retryMailboxRead },
+      );
+    }
+
+    // Runtime.evaluate is one-shot for all scripts. A transport failure after
+    // dispatch is ambiguous, so retrying here could replay a mutation. The
+    // awaitPromise:false option only changes completion handling.
+    return rawEvaluate(expression, options);
+  };
+}

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -50,10 +50,13 @@ function isDefinitivePreDispatchFailure(error: unknown): boolean {
   return (
     error instanceof Error &&
     !(error instanceof AppEvaluationError) &&
-    (error.message === 'Not connected to CDP target' ||
-      error.message ===
-        'Not connected to Metro. Use list_devices to check connection status.')
+    error.message === 'Not connected to CDP target'
   );
+}
+
+function isServerDisconnectedError(error: unknown): boolean {
+  return error instanceof Error &&
+    error.message === 'Not connected to Metro. Use list_devices to check connection status.';
 }
 
 function timeoutError(timeout: number): Error {
@@ -437,11 +440,21 @@ export function createAppEvaluator(
   cdp: Pick<CDPConnection, 'send'>,
   lifecycle: AppEvaluationLifecycle,
 ): (expression: string, options?: EvalOptions) => Promise<unknown> {
+  const ensureConnectedForDispatch = async (options?: EvalOptions): Promise<void> => {
+    try {
+      await lifecycle.ensureConnected(options?.deadline);
+    } catch (error) {
+      if (!isServerDisconnectedError(error)) throw error;
+      await recoverTransport(options?.deadline, options?.timeout);
+      await lifecycle.ensureConnected(options?.deadline);
+    }
+  };
+
   const rawEvaluateOnce = async (
     expression: string,
     options?: EvalOptions,
   ): Promise<unknown> => {
-    await lifecycle.ensureConnected(options?.deadline);
+    await ensureConnectedForDispatch(options);
     const timeout = boundedRequestTimeout(options);
     return evaluateAppScript(cdp, expression, { ...options, timeout });
   };
@@ -475,7 +488,7 @@ export function createAppEvaluator(
   ): Promise<AppEvaluationCompletion> => {
     let sourceGeneration = options?.generation;
     const evaluateOnce = async (): Promise<AppEvaluationCompletion> => {
-      await lifecycle.ensureConnected(options?.deadline);
+      await ensureConnectedForDispatch(options);
       if (
         sourceGeneration !== undefined &&
         lifecycle.getGeneration &&

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -196,7 +196,10 @@ function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath
   return {
     expressions: [...left.expressions, ...right.expressions],
     clearRanges: [...left.clearRanges, ...right.clearRanges],
-    empty: left.empty || right.empty,
+    // A merged path is empty only when every contributing completion is
+    // empty. An explicit undefined completion from a catch/finally or a later
+    // empty loop iteration must replace an earlier value.
+    empty: left.empty && right.empty,
     undefined: left.undefined || right.undefined,
     normal: left.normal || right.normal,
   };
@@ -293,7 +296,7 @@ function completionForStatement(statement: StatementLike): Completion {
       // discarded, while the prior try/catch completion is retained. This is
       // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
       const applied = applyFinallyCompletion(guarded, finalizer);
-      return {
+      const result = {
         ...applied,
         breaks: [
           ...guarded.breaks,
@@ -304,6 +307,7 @@ function completionForStatement(statement: StatementLike): Completion {
           ...finalizer.continues.map((path) => ({ ...path, inherit: false })),
         ],
       };
+      return result.normal ? normalizeControlCompletion(result) : result;
     }
     case 'LabeledStatement':
       return consumeLabelExits(
@@ -400,6 +404,85 @@ function completionForStatements(statements: StatementLike[]): Completion {
   return completion;
 }
 
+type SourceInsertion = { start: number; end?: number; replacement: string };
+
+function collectLoopEntryInsertions(
+  statement: StatementLike,
+  clearCompletion: string,
+  insertions: SourceInsertion[],
+): void {
+  const visit = (child: unknown): void => {
+    if (child && typeof child === 'object' && 'type' in child) {
+      collectLoopEntryInsertions(child as StatementLike, clearCompletion, insertions);
+    }
+  };
+  const visitList = (children: unknown): void => {
+    if (Array.isArray(children)) children.forEach(visit);
+  };
+
+  switch (statement.type) {
+    case 'BlockStatement':
+      visitList(statement.body);
+      return;
+    case 'IfStatement':
+      visit(statement.consequent);
+      visit(statement.alternate);
+      return;
+    case 'TryStatement':
+      visit(statement.block);
+      visit((statement.handler as { body?: unknown } | null | undefined)?.body);
+      visit(statement.finalizer);
+      return;
+    case 'LabeledStatement':
+    case 'WithStatement':
+      visit(statement.body);
+      return;
+    case 'SwitchStatement':
+      for (const switchCase of (statement.cases as Array<{ consequent?: unknown }> | undefined) ?? []) {
+        visitList(switchCase.consequent);
+      }
+      return;
+    case 'ForStatement':
+    case 'ForInStatement':
+    case 'ForOfStatement':
+    case 'WhileStatement':
+    case 'DoWhileStatement': {
+      const body = statement.body as StatementLike | undefined;
+      if (body?.start !== null && body?.start !== undefined &&
+          body.end !== null && body.end !== undefined) {
+        const bodyCompletion = completionForStatement(body);
+        // Each iteration computes a fresh body completion. A reached
+        // candidate immediately replaces this reset; a runtime path that
+        // reaches none of the candidates completes with undefined instead of
+        // leaking a value from an earlier iteration.
+        if (bodyCompletion.expressions.length === 0) {
+          visit(body);
+          return;
+        }
+        if (body.type === 'BlockStatement') {
+          const directives = (body.directives as Array<{ end?: number | null }> | undefined) ?? [];
+          const entry = directives.length > 0
+            ? directives[directives.length - 1]!.end
+            : (body.start as number) + 1;
+          if (entry !== null && entry !== undefined) {
+            insertions.push({ start: entry, replacement: ` ${clearCompletion}; ` });
+          }
+        } else {
+          insertions.push({
+            start: body.start as number,
+            replacement: `{ ${clearCompletion}; `,
+          });
+          insertions.push({ start: body.end as number, replacement: ' }' });
+        }
+      }
+      visit(body);
+      return;
+    }
+    default:
+      return;
+  }
+}
+
 function promiseObservationExpression(expression: string, completionKey?: string): string {
   let ast;
   try {
@@ -442,6 +525,10 @@ function promiseObservationExpression(expression: string, completionKey?: string
       other.label === range.label,
     ) === index,
   );
+  const loopInsertions: SourceInsertion[] = [];
+  for (const statement of ast.program.body as StatementLike[]) {
+    collectLoopEntryInsertions(statement, clearCompletion, loopInsertions);
+  }
   const replacements = [
     ...candidates.map(({ start, end }) => ({
       start: start as number,
@@ -456,9 +543,11 @@ function promiseObservationExpression(expression: string, completionKey?: string
       // capture that exit and change the caller's control flow.
       replacement: `{ ${clearCompletion}; ${kind}${label ? ` ${label}` : ''}; }`,
     })),
+    ...loopInsertions,
   ].sort((left, right) => right.start - left.start);
   for (const { start, end, replacement } of replacements) {
-    transformed = transformed.slice(0, start) + replacement + transformed.slice(end);
+    transformed = transformed.slice(0, start) + replacement +
+      transformed.slice(end === undefined ? start : end);
   }
   const directives = (ast.program.directives as Array<{
     end?: number | null;
@@ -476,8 +565,10 @@ function promiseObservationExpression(expression: string, completionKey?: string
     var state = root[${keyLiteral}];
     var value = state ? state.completionValue : void 0;
     try {
-      var PromiseCtor = root && root.Promise;
-      if (PromiseCtor) PromiseCtor.prototype.then.call(value, function() {}, function() {});
+      var PromiseCtor = state && (state.promiseConstructor || root.Promise);
+      var promiseThen = (state && state.promiseThen) ||
+        (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
+      if (promiseThen) promiseThen.call(value, function() {}, function() {});
     } catch (_) {}
     if (state) state.completionValue = void 0;
     return value;
@@ -575,7 +666,14 @@ const SETTLE_REMOTE_FUNCTION = `function(key) {
     // Assimilate arbitrary thenables exactly once. Calling this.then
     // directly would accept a second callback or a nested thenable as the
     // final value, unlike JavaScript Promise resolution.
-    root.Promise.resolve(this).then(fulfill, reject);
+    var PromiseCtor = state.promiseConstructor || root.Promise;
+    var promiseResolve = state.promiseResolve || (PromiseCtor && PromiseCtor.resolve);
+    if (!promiseResolve) throw new Error('Promise constructor unavailable');
+    var resolved = promiseResolve.call(PromiseCtor, this);
+    var promiseThen = state.promiseThen ||
+      (PromiseCtor && PromiseCtor.prototype && PromiseCtor.prototype.then);
+    if (!promiseThen) throw new Error('Promise then unavailable');
+    promiseThen.call(resolved, fulfill, reject);
   } catch (error) { reject(error); }
   return true;
 }`;

--- a/src/utils/evaluate-app.ts
+++ b/src/utils/evaluate-app.ts
@@ -1,4 +1,5 @@
 import type { CDPConnection, EvalOptions } from '../plugin.js';
+import { parse } from '@babel/parser';
 import {
   decodeCDPUnserializableValue,
   extractCDPExceptionMessage,
@@ -93,6 +94,244 @@ async function sendRuntimeEvaluate(
   return result;
 }
 
+type StatementLike = {
+  type: string;
+  body?: unknown;
+  expression?: ExpressionLike;
+  [key: string]: unknown;
+};
+type ExpressionLike = { start: number | null; end: number | null };
+type CompletionPath = {
+  expressions: ExpressionLike[];
+  empty: boolean;
+  normal: boolean;
+};
+type ExitPath = CompletionPath & { label: string | null };
+type Completion = CompletionPath & {
+  breaks: ExitPath[];
+  continues: ExitPath[];
+};
+
+const emptyCompletion = (): Completion => ({
+  expressions: [],
+  empty: true,
+  normal: true,
+  breaks: [],
+  continues: [],
+});
+
+const abruptCompletion = (): Completion => ({
+  expressions: [],
+  empty: false,
+  normal: false,
+  breaks: [],
+  continues: [],
+});
+
+function mergePaths(left: CompletionPath, right: CompletionPath): CompletionPath {
+  return {
+    expressions: [...left.expressions, ...right.expressions],
+    empty: left.empty || right.empty,
+    normal: left.normal || right.normal,
+  };
+}
+
+function mergeCompletions(left: Completion, right: Completion): Completion {
+  const merged = mergePaths(left, right);
+  return {
+    ...merged,
+    breaks: [...left.breaks, ...right.breaks],
+    continues: [...left.continues, ...right.continues],
+  };
+}
+
+function consumeBreaks(completion: Completion, label: string | null = null): Completion {
+  let normal: CompletionPath = completion;
+  const remaining: ExitPath[] = [];
+  for (const path of completion.breaks) {
+    if (path.label === label) normal = mergePaths(normal, path);
+    else remaining.push(path);
+  }
+  return { ...normal, breaks: remaining, continues: completion.continues };
+}
+
+function consumeLoopExits(completion: Completion): Completion {
+  let normal: CompletionPath = completion;
+  const breaks: ExitPath[] = [];
+  const continues: ExitPath[] = [];
+  for (const path of completion.breaks) {
+    if (path.label === null) normal = mergePaths(normal, path);
+    else breaks.push(path);
+  }
+  for (const path of completion.continues) {
+    if (path.label === null) normal = mergePaths(normal, path);
+    else continues.push(path);
+  }
+  return { ...normal, breaks, continues };
+}
+
+function consumeLabelExits(completion: Completion, label: string): Completion {
+  const afterBreaks = consumeBreaks(completion, label);
+  let normal: CompletionPath = afterBreaks;
+  const continues: ExitPath[] = [];
+  for (const path of afterBreaks.continues) {
+    if (path.label === label) normal = mergePaths(normal, path);
+    else continues.push(path);
+  }
+  return { ...normal, breaks: afterBreaks.breaks, continues };
+}
+
+function completionForStatement(statement: StatementLike): Completion {
+  switch (statement.type) {
+    case 'EmptyStatement':
+    case 'VariableDeclaration':
+    case 'FunctionDeclaration':
+    case 'ClassDeclaration':
+    case 'DebuggerStatement':
+      return emptyCompletion();
+    case 'ExpressionStatement':
+      return statement.expression ? {
+        expressions: [statement.expression],
+        empty: false,
+        normal: true,
+        breaks: [],
+        continues: [],
+      } : emptyCompletion();
+    case 'BlockStatement':
+      return Array.isArray(statement.body)
+        ? completionForStatements(statement.body as StatementLike[])
+        : emptyCompletion();
+    case 'IfStatement': {
+      const consequent = completionForStatement(statement.consequent as StatementLike);
+      const alternate = statement.alternate
+        ? completionForStatement(statement.alternate as StatementLike)
+        : emptyCompletion();
+      return mergeCompletions(consequent, alternate);
+    }
+    case 'TryStatement': {
+      const body = completionForStatement(statement.block as StatementLike);
+      const handler = statement.handler
+        ? completionForStatement((statement.handler as { body: StatementLike }).body)
+        : abruptCompletion();
+      const guarded = mergeCompletions(body, handler);
+      if (!statement.finalizer) return guarded;
+      const finalizer = completionForStatement(statement.finalizer as StatementLike);
+      if (!finalizer.normal) return finalizer;
+      // A normal `finally` completion is UpdateEmpty: its expression value is
+      // discarded, while the prior try/catch completion is retained. This is
+      // why `try { 1 } finally { 2 }` evaluates to 1 in a script.
+      return {
+        ...guarded,
+        breaks: [...guarded.breaks, ...finalizer.breaks],
+        continues: [...guarded.continues, ...finalizer.continues],
+      };
+    }
+    case 'LabeledStatement':
+      return consumeLabelExits(
+        completionForStatement(statement.body as StatementLike),
+        (statement.label as { name: string } | null | undefined)?.name ?? '',
+      );
+    case 'WithStatement':
+      return completionForStatement(statement.body as StatementLike);
+    case 'SwitchStatement': {
+      const cases = (statement.cases as Array<{ consequent: StatementLike[] }> | undefined) ?? [];
+      let completion = emptyCompletion();
+      for (let index = 0; index < cases.length; index += 1) {
+        const caseCompletion = completionForStatements(
+          cases.slice(index).flatMap((entry) => entry.consequent),
+        );
+        completion = mergeCompletions(
+          completion,
+          consumeBreaks(caseCompletion),
+        );
+      }
+      return completion;
+    }
+    case 'ForStatement':
+    case 'ForInStatement':
+    case 'ForOfStatement':
+    case 'WhileStatement':
+    case 'DoWhileStatement':
+      return mergeCompletions(
+        consumeLoopExits(completionForStatement(statement.body as StatementLike)),
+        emptyCompletion(),
+      );
+    case 'ThrowStatement':
+    case 'ReturnStatement':
+      return abruptCompletion();
+    case 'BreakStatement':
+      return {
+        ...abruptCompletion(),
+        breaks: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+      };
+    case 'ContinueStatement':
+      return {
+        ...abruptCompletion(),
+        continues: [{ ...emptyCompletion(), label: (statement.label as { name: string } | null | undefined)?.name ?? null }],
+      };
+    default:
+      return abruptCompletion();
+  }
+}
+
+function completionForStatements(statements: StatementLike[]): Completion {
+  let completion = emptyCompletion();
+  for (const statement of statements) {
+    const next = completionForStatement(statement);
+    const breaks: ExitPath[] = [
+      ...completion.breaks,
+      ...next.breaks.map((path) => path.empty ? { ...completion, label: path.label } : path),
+    ];
+    const continues: ExitPath[] = [
+      ...completion.continues,
+      ...next.continues.map((path) => path.empty ? { ...completion, label: path.label } : path),
+    ];
+    if (!next.normal) {
+      return { ...next, breaks, continues };
+    }
+    completion = {
+      ...(next.empty ? mergePaths(completion, next) : next),
+      breaks,
+      continues,
+    };
+  }
+  return completion;
+}
+
+function promiseObservationExpression(expression: string): string {
+  let ast;
+  try {
+    ast = parse(expression, { sourceType: 'script' });
+  } catch {
+    return expression;
+  }
+  const completion = completionForStatements(ast.program.body as StatementLike[]);
+  if (!completion.normal || completion.expressions.length === 0) return expression;
+  const edits = completion.expressions
+    .filter(({ start, end }) => start !== null && end !== null)
+    .map(({ start, end }) => ({ start: start as number, end: end as number }))
+    .filter((edit, index, all) =>
+      all.findIndex((candidate) => candidate.start === edit.start && candidate.end === edit.end) === index,
+    )
+    .sort((left, right) => right.start - left.start);
+  let transformed = expression;
+  for (const { start, end } of edits) {
+    const candidate = expression.slice(start, end);
+    const observer = `(function observePromise(value) {
+      try {
+        var PromiseCtor = globalThis.Promise;
+        if (PromiseCtor) {
+          PromiseCtor.prototype.then.call(value, function() {}, function() {});
+        }
+      } catch (_) {}
+      return value;
+    })((${candidate}
+  ))`;
+    transformed = transformed.slice(0, start) + observer + transformed.slice(end);
+  }
+  return transformed;
+}
+
 /**
  * Send one Runtime.evaluate request and return its by-value completion value.
  *
@@ -123,10 +362,12 @@ export async function evaluateAppScript(
 export async function evaluateAppScriptCompletion(
   cdp: Pick<CDPConnection, 'send'>,
   expression: string,
-  options?: EvalOptions,
+  options?: EvalOptions & { observePromiseRejection?: boolean },
 ): Promise<AppEvaluationCompletion> {
   const result = await sendRuntimeEvaluate(cdp, {
-    expression,
+    expression: options?.observePromiseRejection
+      ? promiseObservationExpression(expression)
+      : expression,
     returnByValue: false,
     awaitPromise: false,
     ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
@@ -241,7 +482,11 @@ export function createAppEvaluator(
         throw new Error('App evaluation context changed before source dispatch');
       }
       const timeout = boundedRequestTimeout(options);
-      return evaluateAppScriptCompletion(cdp, expression, { timeout, objectGroup: options?.objectGroup });
+      return evaluateAppScriptCompletion(cdp, expression, {
+        timeout,
+        objectGroup: options?.objectGroup,
+        observePromiseRejection: true,
+      });
     };
     try {
       return await evaluateOnce();

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -9,7 +9,7 @@ function fakeRunner() {
   return {
     calls,
     exec: async () => '',
-    execFile: async (command: string, args: string[]) => {
+    execFile: async (command: string, args: string[], _options?: { maxBuffer?: number; timeout?: number }) => {
       calls.push({ command, args });
       if (command === 'which' && args[0] !== 'idb') throw new Error('not found');
       if (args[args.length - 1] === '--version') return Buffer.from('1.0.0');
@@ -36,6 +36,105 @@ describe('native input providers', () => {
       { command: '/bin/echo', args: ['--version'] },
       { command: '/bin/echo', args: ['--version'] },
     ]);
+  });
+
+  test('bounds a SimView version probe and still dispatches through IDB', async () => {
+    const runner = fakeRunner();
+    const versionCalls: Array<{ command: string; args: string[]; timeout?: number }> = [];
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args, options) => {
+      if (command === '/bin/echo' && args.at(-1) === '--version') {
+        versionCalls.push({ command, args, timeout: options?.timeout });
+        return new Promise<never>(() => {});
+      }
+      return baseExecFile(command, args);
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => { throw new Error('unavailable SimView must not be connected'); },
+    });
+
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'version-timeout' }, 1, 2)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(versionCalls).toHaveLength(1);
+    expect(versionCalls[0]?.timeout).toBeGreaterThan(0);
+    expect(versionCalls[0]?.timeout).toBeLessThanOrEqual(20);
+  });
+
+  test('bounds slow SimView plugin discovery and still dispatches through IDB', async () => {
+    const runner = fakeRunner();
+    let directoryReads = 0;
+    const fileSystem = {
+      executable: async () => false,
+      readDirectory: async () => {
+        directoryReads += 1;
+        return new Promise<never>(() => {});
+      },
+      readFile: async () => '',
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewFileSystem: fileSystem,
+      simviewClientFactory: () => { throw new Error('unavailable SimView must not be connected'); },
+    });
+
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'filesystem-timeout' }, 1, 2)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(directoryReads).toBe(1);
+  });
+
+  test('keeps a PATH SimView ahead of a stalled plugin cache scan', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args, options) => {
+      if (command === 'which' && args[0] === 'simview') {
+        runner.calls.push({ command, args });
+        return Buffer.from('/usr/local/bin/simview');
+      }
+      return baseExecFile(command, args, options);
+    };
+    let directoryReads = 0;
+    const fileSystem = {
+      executable: async () => false,
+      readDirectory: async () => {
+        directoryReads += 1;
+        return new Promise<never>(() => {});
+      },
+      readFile: async () => '',
+    };
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:path-simview', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 100,
+      simviewFileSystem: fileSystem,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.tap({ platform: 'ios', id: 'path-simview' }, 1, 2)).resolves.toMatchObject({
+      backend: 'simview', status: 'handled', dispatched: true,
+    });
+    expect(directoryReads).toBe(0);
+    expect(runner.calls.some(({ command, args }) => command === 'which' && args[0] === 'simview')).toBe(true);
   });
 
   test('validates plugin manifests and discovers the newest installed SimView version', async () => {
@@ -422,6 +521,135 @@ describe('native input providers', () => {
     expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '1', '2', '--udid', 'device-a'] });
   });
 
+  test('bounds an initial SimView handshake and falls back to IDB', async () => {
+    const runner = fakeRunner();
+    let closed = 0;
+    let transportClosed = 0;
+    const client = {
+      connect: async () => new Promise<void>(() => {}),
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => ({ isError: true }),
+      close: async () => { closed += 1; return new Promise<never>(() => {}); },
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => ({ client, transport: { close: async () => { transportClosed += 1; return new Promise<never>(() => {}); } } }),
+    });
+
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(closed).toBe(1);
+    expect(transportClosed).toBe(1);
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '1', '2', '--udid', 'device-a'] });
+  });
+
+  test('detaches resources after repeated timed-out SimView handshakes', async () => {
+    const runner = fakeRunner();
+    let closed = 0;
+    let transportClosed = 0;
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => ({
+        client: {
+          connect: async () => new Promise<void>(() => {}),
+          listTools: async () => ({ tools: [] }),
+          callTool: async () => ({ isError: true }),
+          close: async () => { closed += 1; return new Promise<never>(() => {}); },
+        },
+        transport: { close: async () => { transportClosed += 1; return new Promise<never>(() => {}); } },
+      }),
+    });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(controller.tap({ platform: 'ios', id: `repeat-${attempt}` }, 1, 2)).resolves.toMatchObject({ backend: 'idb', status: 'handled' });
+    }
+    expect(closed).toBe(3);
+    expect(transportClosed).toBe(3);
+    expect((controller as unknown as { resources: Set<unknown> }).resources.size).toBe(0);
+    await controller.close();
+    expect(closed).toBe(3);
+    expect(transportClosed).toBe(3);
+  });
+
+  test('bounds a cached SimView state refresh, closes it, and falls back to IDB', async () => {
+    const runner = fakeRunner();
+    let stateReads = 0;
+    let closed = 0;
+    let transportClosed = 0;
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state' && ++stateReads > 2) return new Promise<never>(() => {});
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => { closed += 1; return new Promise<never>(() => {}); },
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => ({ client, transport: { close: async () => { transportClosed += 1; return new Promise<never>(() => {}); } } }),
+    });
+
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).resolves.toMatchObject({ backend: 'simview', status: 'handled' });
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 3, 4)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(closed).toBe(1);
+    expect(transportClosed).toBe(1);
+    expect(calls.filter((name) => name === 'tap')).toHaveLength(1);
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '3', '4', '--udid', 'device-a'] });
+  });
+
+  test('bounds a cached SimView observation refresh, closes it, and falls back to IDB', async () => {
+    const runner = fakeRunner();
+    let observations = 0;
+    let closed = 0;
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen' && ++observations > 2) return new Promise<never>(() => {});
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => { closed += 1; },
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).resolves.toMatchObject({ backend: 'simview', status: 'handled' });
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 3, 4)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(closed).toBe(1);
+    expect(calls.filter((name) => name === 'tap')).toHaveLength(1);
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '3', '4', '--udid', 'device-a'] });
+  });
+
   test('falls back to IDB when a cached SimView session refresh fails before dispatch', async () => {
     const runner = fakeRunner();
     const calls: string[] = [];
@@ -480,6 +708,95 @@ describe('native input providers', () => {
       backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
     });
     expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '50', '40', '--udid', 'device-a'] });
+  });
+
+  test('shares the discovery deadline with a stalled SimView semantic handshake', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === '/bin/echo' && args.at(-1) === '--version') {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return Buffer.from('0.4.0');
+      }
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'describe-all') {
+        return Buffer.from(JSON.stringify([{ label: 'Continue', frame: { x: 10, y: 20, width: 80, height: 40 } }]));
+      }
+      return baseExecFile(command, args);
+    };
+    const calls: string[] = [];
+    const client = {
+      connect: async () => { calls.push('connect'); await new Promise((resolve) => setTimeout(resolve, 50)); },
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'tap_element'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:semantic-handshake', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'find_elements') return { structuredContent: { matches: [{ ref: 'element:1' }] } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 60,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    const started = Date.now();
+    await expect(controller.tapLabel({ platform: 'ios', id: 'semantic-handshake' }, 'Continue')).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls).toContain('connect');
+    expect(calls).not.toContain('tap_element');
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args[1] === 'tap' && !args.includes('--help'))).toBe(true);
+  });
+
+  test('shares the discovery deadline with a stalled SimView semantic search', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === '/bin/echo' && args.at(-1) === '--version') {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return Buffer.from('0.4.0');
+      }
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'describe-all') {
+        return Buffer.from(JSON.stringify([{ label: 'Continue', frame: { x: 10, y: 20, width: 80, height: 40 } }]));
+      }
+      return baseExecFile(command, args);
+    };
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'long_press'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:semantic-search', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'find_elements') {
+          await new Promise((resolve) => setTimeout(resolve, 90));
+          return { structuredContent: { matches: [{ element: { frame: { x: 10, y: 20, width: 80, height: 40 } } }] } };
+        }
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 100,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    const started = Date.now();
+    await expect(controller.longPressLabel({ platform: 'ios', id: 'semantic-search' }, 'Continue', 800)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls.filter((name) => name === 'find_elements')).toHaveLength(1);
+    expect(calls).not.toContain('long_press');
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args[1] === 'tap' && args.includes('--duration'))).toBe(true);
   });
 
   test('reports IDB label discovery failures as not-sent before tap dispatch', async () => {
@@ -775,6 +1092,44 @@ describe('native input providers', () => {
     expect(response).toMatchObject({ backend: 'idb', status: 'handled', dispatch: 'submitted' });
     expect(calls.at(-2)?.args).toEqual(['--profile', 'fixture', 'describe', '--udid', 'fake-udid', '--json']);
     expect(calls.at(-1)?.args).toEqual(['--profile', 'fixture', 'ui', 'swipe', '201', '656', '201', '219', '--duration', '0.3', '--udid', 'fake-udid']);
+  });
+
+  test('does not retry stalled SimView geometry before falling back to IDB directional swipe', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'swipe'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'connect_device') return { structuredContent: { connected: true } };
+        if (name === 'get_simview_state') return new Promise<never>(() => {});
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === 'idb' && args[0] === 'describe') {
+        runner.calls.push({ command, args });
+        return Buffer.from(JSON.stringify({ screen_dimensions: { width_points: 402, height_points: 874 } }));
+      }
+      return baseExecFile(command, args);
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    const started = Date.now();
+    await expect(controller.swipeDirection({ platform: 'ios', id: 'fake-udid' }, 'up', 300)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls).toEqual(['connect_device', 'get_simview_state']);
+    expect(runner.calls.filter(({ command, args }) => command === 'idb' && args[0] === 'ui' && args[1] === 'swipe' && !args.includes('--help'))).toHaveLength(1);
   });
 
   test('uses the final Android override geometry for directional swipes', async () => {

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -66,6 +66,94 @@ describe('native input providers', () => {
     expect(versionCalls[0]?.timeout).toBeLessThanOrEqual(20);
   });
 
+  test('bounds a stalled IDB version probe', async () => {
+    const runner = fakeRunner();
+    const versionCalls: Array<{ timeout?: number }> = [];
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args, options) => {
+      if (command === 'idb' && args.at(-1) === '--version') {
+        versionCalls.push({ timeout: options?.timeout });
+        return new Promise<never>(() => {});
+      }
+      return baseExecFile(command, args, options);
+    };
+
+    const started = Date.now();
+    const providers = await discoverNativeProviders(
+      { config: { nativeBackend: 'idb', idbCommand: 'idb' }, runner },
+      Date.now() + 20,
+    );
+
+    expect(providers[0]).toMatchObject({ available: false });
+    expect(versionCalls).toHaveLength(1);
+    expect(versionCalls[0]?.timeout).toBeGreaterThan(0);
+    expect(versionCalls[0]?.timeout).toBeLessThanOrEqual(20);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test('bounds a stalled IDB help probe after a successful version check', async () => {
+    const runner = fakeRunner();
+    const helpCalls: Array<{ args: string[]; timeout?: number }> = [];
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args, options) => {
+      if (command === 'idb' && args.at(-1) === '--help') {
+        helpCalls.push({ args, timeout: options?.timeout });
+        return new Promise<never>(() => {});
+      }
+      return baseExecFile(command, args, options);
+    };
+
+    const started = Date.now();
+    const providers = await discoverNativeProviders(
+      { config: { nativeBackend: 'idb', idbCommand: 'idb' }, runner },
+      Date.now() + 20,
+    );
+
+    expect(providers[0]).toMatchObject({ available: false });
+    expect(helpCalls).toHaveLength(1);
+    expect(helpCalls[0]?.args).toEqual(['--help']);
+    expect(helpCalls[0]?.timeout).toBeGreaterThan(0);
+    expect(helpCalls[0]?.timeout).toBeLessThanOrEqual(20);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test('dispatches through SimView without probing a stalled IDB installation', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args, options) => {
+      if (command === 'which' && args[0] === 'simview') return Buffer.from('/usr/local/bin/simview');
+      if (command === 'idb' && args.at(-1) === '--version') return new Promise<never>(() => {});
+      return baseExecFile(command, args, options);
+    };
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:simview-first', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: 'simview', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+      simviewRequestTimeoutMs: 50,
+    });
+
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'simview-first' }, 1, 2)).resolves.toMatchObject({
+      backend: 'simview', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(calls).toContain('tap');
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args.at(-1) === '--version')).toBe(false);
+    await controller.close();
+  });
+
   test('bounds slow SimView plugin discovery and still dispatches through IDB', async () => {
     const runner = fakeRunner();
     let directoryReads = 0;
@@ -864,6 +952,86 @@ describe('native input providers', () => {
     expect(runner.calls.some(({ args }) => args[0] === 'ui' && args[1] === 'tap' && !args.includes('--help'))).toBe(false);
   });
 
+  test('bounds a stalled IDB accessibility read before label dispatch', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    const timeouts: number[] = [];
+    runner.execFile = async (command, args, options) => {
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'describe-all' && !args.includes('--help')) {
+        timeouts.push(options?.timeout ?? 0);
+        return new Promise<never>(() => {});
+      }
+      return baseExecFile(command, args, options);
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'idb', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+    });
+
+    const started = Date.now();
+    await expect(controller.tapLabel({ platform: 'ios', id: 'stalled-read' }, 'Continue'))
+      .resolves.toMatchObject({ backend: 'idb', status: 'failed', dispatch: 'not-sent' });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(timeouts).toHaveLength(1);
+    expect(timeouts[0]).toBeGreaterThan(0);
+    expect(timeouts[0]).toBeLessThanOrEqual(20);
+    expect(runner.calls.some(({ args }) => args[0] === 'ui' && args[1] === 'tap' && !args.includes('--help'))).toBe(false);
+  });
+
+  test('bounds a stalled IDB geometry read before directional swipe dispatch', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    const timeouts: number[] = [];
+    runner.execFile = async (command, args, options) => {
+      if (command === 'idb' && args[0] === 'describe' && !args.includes('--help')) {
+        timeouts.push(options?.timeout ?? 0);
+        return new Promise<never>(() => {});
+      }
+      return baseExecFile(command, args, options);
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'idb', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+    });
+
+    const started = Date.now();
+    await expect(controller.swipeDirection({ platform: 'ios', id: 'stalled-geometry' }, 'up', 300))
+      .resolves.toMatchObject({ backend: 'none', status: 'unavailable', dispatch: 'not-sent' });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(timeouts).toHaveLength(1);
+    expect(timeouts[0]).toBeGreaterThan(0);
+    expect(timeouts[0]).toBeLessThanOrEqual(20);
+    expect(runner.calls.some(({ args }) => args[0] === 'ui' && args[1] === 'swipe' && !args.includes('--help'))).toBe(false);
+  });
+
+  test('bounds a stalled IDB action as an uncertain dispatch', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    const timeouts: number[] = [];
+    runner.execFile = async (command, args, options) => {
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'tap' && !args.includes('--help')) {
+        timeouts.push(options?.timeout ?? 0);
+        return new Promise<never>(() => {});
+      }
+      return baseExecFile(command, args, options);
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'idb', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+    });
+
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'stalled-action' }, 1, 2))
+      .resolves.toMatchObject({ backend: 'idb', status: 'failed', dispatched: false, dispatch: 'unknown' });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(timeouts).toHaveLength(1);
+    expect(timeouts[0]).toBeGreaterThan(0);
+    expect(timeouts[0]).toBeLessThanOrEqual(20);
+  });
+
   test('does not report a coordinate action as handled when the receipt did not dispatch input', async () => {
     const runner = fakeRunner();
     const client = {
@@ -1241,6 +1409,61 @@ describe('native input providers', () => {
     });
     const response = await controller.tap({ platform: 'ios', id: 'fake-udid' }, 1, 2);
     expect(response).toMatchObject({ backend: 'simview', status: 'failed', dispatched: false, dispatch: 'unknown' });
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
+  });
+
+  test('bounds a stalled SimView action and never falls through after dispatch may have started', async () => {
+    const runner = fakeRunner();
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:stalled-simview', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'tap') return new Promise<never>(() => {});
+        return { structuredContent: { connected: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'ios', id: 'stalled-simview' }, 1, 2))
+      .resolves.toMatchObject({ backend: 'simview', status: 'failed', dispatched: false, dispatch: 'unknown' });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
+  });
+
+  test('bounds a stalled semantic SimView action and never falls through', async () => {
+    const runner = fakeRunner();
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'tap_element'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:stalled-semantic', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'find_elements') return { structuredContent: { matches: [{ ref: 'element:1' }] } };
+        if (name === 'tap_element') return new Promise<never>(() => {});
+        return { structuredContent: { connected: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewRequestTimeoutMs: 20,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    const started = Date.now();
+    await expect(controller.tapLabel({ platform: 'ios', id: 'stalled-semantic' }, 'Continue'))
+      .resolves.toMatchObject({ backend: 'simview', status: 'failed', dispatched: false, dispatch: 'unknown' });
+    expect(Date.now() - started).toBeLessThan(500);
     expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
   });
 

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -1,0 +1,546 @@
+import { describe, expect, test } from 'bun:test';
+import { chmod, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { NativeInputController, discoverNativeProviders, normalizeLogicalPoint } from './native-input.js';
+
+function fakeRunner() {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  return {
+    calls,
+    exec: async () => '',
+    execFile: async (command: string, args: string[]) => {
+      calls.push({ command, args });
+      if (command === 'which' && args[0] !== 'idb') throw new Error('not found');
+      if (args[args.length - 1] === '--version') return Buffer.from('1.0.0');
+      if (args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{describe-all,tap,text,swipe,button}');
+      if (args.at(-1) === '--help' && args.at(-2) === 'tap') return Buffer.from('--duration DURATION');
+      if (args.at(-1) === '--help' && args.at(-2) === 'swipe') return Buffer.from('--duration DURATION');
+      if (args.at(-1) === '--help' && args.at(-2) === 'button') return Buffer.from('{APPLE_PAY,HOME,LOCK,SIDE_BUTTON,SIRI}');
+      if (args.at(-1) === '--help') return Buffer.from('commands: ui describe');
+      return Buffer.from('{}');
+    },
+  };
+}
+
+describe('native input providers', () => {
+  test('discovers configured providers without invoking a shell', async () => {
+    const runner = fakeRunner();
+    const providers = await discoverNativeProviders({
+      config: { simviewCommand: '/bin/echo', idbCommand: '/bin/echo' },
+      runner,
+    });
+
+    expect(providers.every((provider) => provider.available)).toBe(true);
+    expect(runner.calls.filter(({ args }) => args.at(-1) === '--version')).toEqual([
+      { command: '/bin/echo', args: ['--version'] },
+      { command: '/bin/echo', args: ['--version'] },
+    ]);
+  });
+
+  test('validates plugin manifests and discovers the newest installed SimView version', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'metro-mcp-simview-'));
+    try {
+      for (const [version, valid] of [['0.3.0', false] as const, ['0.4.0', true] as const]) {
+        const install = join(root, version);
+        await mkdir(join(install, 'bin'), { recursive: true });
+        await mkdir(join(install, '.codex-plugin'));
+        await writeFile(join(install, 'bin/simview'), '#!/bin/sh\nprintf 0.4.0\n');
+        await chmod(join(install, 'bin/simview'), 0o755);
+        await writeFile(join(install, '.codex-plugin/plugin.json'), JSON.stringify({ name: valid ? 'simview' : 'other', repository: 'https://github.com/toolingtools/SimView' }));
+        await writeFile(join(install, '.mcp.json'), JSON.stringify({ mcpServers: { simview: { command: './bin/simview', args: ['mcp'] } } }));
+      }
+      const providers = await discoverNativeProviders({ config: { nativeBackend: 'simview' }, runner: fakeRunner(), simviewPluginRoots: [root] });
+      expect(providers).toHaveLength(1);
+      expect(providers[0]?.command).toBe(join(root, '0.4.0/bin/simview'));
+
+      const spaced = join(root, 'bin with space');
+      await writeFile(spaced, '#!/bin/sh\nprintf 0.4.0\n');
+      await chmod(spaced, 0o755);
+      const configuredRunner = fakeRunner();
+      const configured = await discoverNativeProviders({ config: { nativeBackend: 'simview', simviewCommand: spaced }, runner: configuredRunner });
+      expect(configured[0]?.command).toBe(spaced);
+      expect(configuredRunner.calls[0]).toEqual({ command: spaced, args: ['--version'] });
+      const argumentRunner = fakeRunner();
+      const withArgument = await discoverNativeProviders({ config: { nativeBackend: 'simview', simviewCommand: `${spaced} --test-mode` }, runner: argumentRunner });
+      expect(withArgument[0]).toMatchObject({ command: spaced, args: ['--test-mode'] });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('uses supported IDB syntax and concrete simulator UDID', async () => {
+    const runner = fakeRunner();
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'idb', idbCommand: 'idb' },
+      runner,
+    });
+    const target = { platform: 'ios' as const, id: 'FAKE-IOS-UDID' };
+
+    expect((await controller.tap(target, 12, 34)).status).toBe('handled');
+    expect((await controller.longPress(target, 12, 34, 800)).status).toBe('handled');
+    expect((await controller.swipe(target, { x: 10, y: 20 }, { x: 30, y: 40 }, 300)).status).toBe('handled');
+    expect((await controller.typeText(target, 'hello world')).status).toBe('handled');
+
+    expect(runner.calls.filter(({ args }) => args[0] === 'ui' && args.includes('--udid'))).toEqual([
+      { command: 'idb', args: ['ui', 'tap', '12', '34', '--udid', target.id] },
+      { command: 'idb', args: ['ui', 'tap', '12', '34', '--duration', '0.8', '--udid', target.id] },
+      { command: 'idb', args: ['ui', 'swipe', '10', '20', '30', '40', '--duration', '0.3', '--udid', target.id] },
+      { command: 'idb', args: ['ui', 'text', 'hello world', '--udid', target.id] },
+    ]);
+    expect(runner.calls.some(({ args }) => args.includes('--by-label') || args.includes('long-press'))).toBe(false);
+  });
+
+  test('rounds fractional logical points only at the IDB CLI boundary', async () => {
+    const runner = fakeRunner();
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: 'idb' }, runner });
+    const target = { platform: 'ios' as const, id: 'fractional-points' };
+    try {
+      await controller.tap(target, 12.2, 34.8);
+      await controller.longPress(target, 12.8, 34.2, 500);
+      await controller.swipe(target, { x: 10.4, y: 20.6 }, { x: 30.6, y: 40.4 }, 300);
+      expect(runner.calls.filter(({ args }) => args[0] === 'ui' && args.includes('--udid')).map(({ args }) => args.slice(0, args.indexOf('--udid')))).toEqual([
+        ['ui', 'tap', '12', '35'],
+        ['ui', 'tap', '13', '34', '--duration', '0.5'],
+        ['ui', 'swipe', '10', '21', '31', '40', '--duration', '0.3'],
+      ]);
+    } finally {
+      await controller.close();
+    }
+  });
+
+  test('accepts IDB versions without --version when read-only help exposes supported UI commands', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner = {
+      calls,
+      exec: async () => '',
+      execFile: async (command: string, args: string[]) => {
+        calls.push({ command, args });
+        if (args.at(-1) === '--version') throw new Error('unrecognized arguments: --version');
+        if (args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('describe-all tap text swipe button');
+        if (args.at(-1) === '--help') return Buffer.from('commands: describe ui list');
+        return Buffer.from('ok');
+      },
+    };
+    const providers = await discoverNativeProviders({ config: { nativeBackend: 'idb', idbCommand: '/bin/idb' }, runner });
+    expect(providers[0]).toMatchObject({ available: true });
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: '/bin/idb' }, runner });
+    expect((await controller.tap({ platform: 'ios', id: 'fake-udid' }, 1, 2)).status).toBe('handled');
+    expect(calls.map(({ args }) => args)).toContainEqual(['ui', 'tap', '1', '2', '--udid', 'fake-udid']);
+  });
+
+  test('rejects an IDB binary when both version and supported UI help probes fail', async () => {
+    const runner = {
+      calls: [] as Array<{ command: string; args: string[] }>,
+      exec: async () => '',
+      execFile: async (command: string, args: string[]) => {
+        runner.calls.push({ command, args });
+        throw new Error('unsupported');
+      },
+    };
+    const providers = await discoverNativeProviders({ config: { nativeBackend: 'idb', idbCommand: '/bin/idb' }, runner });
+    expect(providers[0]).toMatchObject({ available: false });
+  });
+
+  test('scopes Android actions to the selected serial and reports unsupported iOS buttons', async () => {
+    const runner = fakeRunner();
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: '/bin/echo' }, runner });
+    const android = { platform: 'android' as const, id: 'emulator-5556' };
+    expect((await controller.tap(android, 1, 2)).dispatched).toBe(true);
+    expect(runner.calls.at(-1)).toEqual({ command: 'adb', args: ['-s', android.id, 'shell', 'input', 'tap', '1', '2'] });
+    expect((await controller.typeText(android, `a b'c\\d$e;f`)).dispatched).toBe(true);
+    expect(runner.calls.at(-1)).toEqual({ command: 'adb', args: ['-s', android.id, 'shell', 'input', 'text', `'a%sb'\\''c\\d$e;f'`] });
+    expect((await controller.button({ platform: 'ios', id: 'ios-device' }, 'ENTER')).status).toBe('unsupported');
+  });
+
+  test('normalizes logical points using current device geometry and clamps edges', () => {
+    expect(normalizeLogicalPoint({ x: 540, y: 960 }, 1080, 1920)).toEqual({ x: 0.5, y: 0.5 });
+    expect(normalizeLogicalPoint({ x: -1, y: 3000 }, 1080, 1920)).toEqual({ x: 0, y: 1 });
+  });
+
+  test('serializes a shared SimView client, refreshes geometry, and closes once', async () => {
+    const runner = fakeRunner();
+    const calls: Array<{ name: string; arguments: Record<string, unknown> }> = [];
+    let closed = 0;
+    let connectedDevice = 'ios:device-a';
+    let factoryArgs: string[] = [];
+    let cleanup: (() => void | Promise<void>) | undefined;
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name, arguments: args }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push({ name, arguments: args });
+        if (name === 'connect_device') connectedDevice = String(args.deviceId);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: connectedDevice, capabilities: { input: { touch: true, text: 'unicode', buttons: ['home'] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true } };
+      },
+      close: async () => { closed += 1; },
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo mcp' },
+      runner,
+      registerCleanup: (callback) => { cleanup = callback; },
+      simviewClientFactory: (_command, args) => { factoryArgs = args; return { client, transport: { close: async () => {} } }; },
+    });
+    const first = controller.tap({ platform: 'ios', id: 'device-a' }, 200, 400);
+    const second = controller.tap({ platform: 'ios', id: 'device-b' }, 100, 200);
+    expect((await first).dispatch).toBe('submitted');
+    expect((await second).dispatch).toBe('submitted');
+    expect(calls.filter((call) => call.name === 'connect_device').map((call) => call.arguments.deviceId).sort()).toEqual(['ios:device-a', 'ios:device-b']);
+    expect(factoryArgs).toEqual(['mcp']);
+    expect(calls.filter((call) => call.name === 'tap').map((call) => call.arguments)).toContainEqual({ x: 0.5, y: 0.5 });
+    await cleanup?.();
+    await cleanup?.();
+    expect(closed).toBe(1);
+  });
+
+  test('rejects non-ASCII text when IDB is the selected backend', async () => {
+    const runner = fakeRunner();
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: '/bin/echo' }, runner });
+    const response = await controller.typeText({ platform: 'ios', id: 'fake-udid' }, 'café');
+    expect(response).toMatchObject({ backend: 'idb', status: 'unsupported', dispatch: 'not-sent' });
+    expect(runner.calls.some(({ args }) => args.includes('café'))).toBe(false);
+  });
+
+  test('invalidates a cached SimView session when a target switch cannot refresh state', async () => {
+    const runner = fakeRunner();
+    const connected: string[] = [];
+    let active = '';
+    let closed = 0;
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name, arguments: args }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'connect_device') { active = String(args.deviceId); connected.push(active); return { structuredContent: { connected: true } }; }
+        if (name === 'get_simview_state' && active === 'ios:device-b') return { isError: true };
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: active, capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true } };
+      },
+      close: async () => { closed += 1; },
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    expect((await controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).status).toBe('handled');
+    expect((await controller.tap({ platform: 'ios', id: 'device-b' }, 1, 2)).status).toBe('unavailable');
+    expect((await controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).status).toBe('handled');
+    expect(connected).toEqual(['ios:device-a', 'ios:device-b', 'ios:device-a']);
+    expect(closed).toBe(1);
+  });
+
+  test('stops on an explicit SimView rejection and does not call IDB', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: false } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    const response = await controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2);
+    expect(response).toMatchObject({ backend: 'simview', status: 'failed', dispatched: false, dispatch: 'not-sent' });
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
+    expect(calls).toContain('tap');
+  });
+
+  test('does not report a coordinate action as handled when the receipt did not dispatch input', async () => {
+    const runner = fakeRunner();
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: false } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).resolves.toMatchObject({
+      backend: 'simview', status: 'failed', dispatched: false, dispatch: 'not-sent',
+    });
+  });
+
+  test('uses the public semantic search match element ref and stops on tap uncertainty', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'tap_element'].map((name) => ({ name })) }),
+      callTool: async ({ name, arguments: args }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(`${name}:${JSON.stringify(args)}`);
+        if (name === 'connect_device') return { structuredContent: { connected: true } };
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { snapshot: { screen: { width: 402, height: 874 } } } };
+        if (name === 'find_elements') return { structuredContent: { matches: [{ ref: 'generation:node-1' }], count: 1 } };
+        return { isError: true, structuredContent: { interaction: { accepted: true, inputDispatched: true, retryInput: false } }, content: [{ type: 'text', text: 'action receipt unavailable' }] };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    const response = await controller.tapLabel({ platform: 'ios', id: 'device-a' }, 'Continue');
+    expect(response).toMatchObject({ backend: 'simview', status: 'failed', dispatched: true, dispatch: 'submitted' });
+    expect(calls).toContain('find_elements:{"name":"Continue","exact":true}');
+    expect(calls).toContain('tap_element:{"ref":"generation:node-1"}');
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
+  });
+
+  test('stops a raw SimView action when safeToContinue is false, even with a dispatch receipt', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: true, safeToContinue: false } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    const response = await controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2);
+    expect(response).toMatchObject({ backend: 'simview', status: 'failed', dispatched: true, dispatch: 'submitted' });
+    expect(calls).toContain('tap');
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
+  });
+
+  test('stops a semantic SimView action when nested safeToContinue is false', async () => {
+    const runner = fakeRunner();
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'tap_element'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'find_elements') return { structuredContent: { matches: [{ ref: 'element:1' }] } };
+        return { structuredContent: { interaction: { accepted: true, inputDispatched: true, safeToContinue: false } } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    await expect(controller.tapLabel({ platform: 'ios', id: 'device-a' }, 'Continue')).resolves.toMatchObject({
+      backend: 'simview', status: 'failed', dispatched: true, dispatch: 'submitted',
+    });
+  });
+
+  test('retains partial IDB capabilities and refuses unsupported operations before dispatch', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner = {
+      calls,
+      exec: async () => '',
+      execFile: async (command: string, args: string[]) => {
+        calls.push({ command, args });
+        if (args.at(-1) === '--version') return Buffer.from('1.0.0');
+        if (args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{describe-all,tap,text,swipe,button}');
+        if (args.at(-1) === '--help' && args.at(-2) === 'tap') return Buffer.from('tap options without duration');
+        if (args.at(-1) === '--help' && args.at(-2) === 'swipe') return Buffer.from('swipe options without duration');
+        if (args.at(-1) === '--help' && args.at(-2) === 'button') return Buffer.from('{HOME}');
+        if (args.at(-1) === '--help') return Buffer.from('commands: ui describe');
+        return Buffer.from('ok');
+      },
+    };
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: '/bin/idb' }, runner });
+    const target = { platform: 'ios' as const, id: 'partial-idb' };
+    expect((await controller.tap(target, 1, 2)).status).toBe('handled');
+    expect((await controller.typeText(target, 'hello')).status).toBe('handled');
+    expect((await controller.longPress(target, 1, 2, 500)).status).toBe('unsupported');
+    expect((await controller.swipe(target, { x: 1, y: 2 }, { x: 3, y: 4 }, 500)).status).toBe('unsupported');
+    expect((await controller.button(target, 'HOME')).status).toBe('handled');
+    expect((await controller.button(target, 'POWER')).status).toBe('unsupported');
+    const dispatches = calls.filter(({ args }) => args.includes('--udid'));
+    expect(dispatches).toHaveLength(3);
+    expect(dispatches.some(({ args }) => args.includes('--duration'))).toBe(false);
+  });
+
+  test('does not dispatch IDB text when the UI help omits text', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner = {
+      calls,
+      exec: async () => '',
+      execFile: async (command: string, args: string[]) => {
+        calls.push({ command, args });
+        if (args.at(-1) === '--version') throw new Error('no version command');
+        if (args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{tap}');
+        if (args.at(-1) === '--help' && args.at(-2) === 'tap') return Buffer.from('--duration DURATION');
+        if (args.at(-1) === '--help') return Buffer.from('commands: ui describe');
+        return Buffer.from('ok');
+      },
+    };
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: '/bin/idb' }, runner });
+    const response = await controller.typeText({ platform: 'ios', id: 'missing-text' }, 'hello');
+    expect(response).toMatchObject({ backend: 'idb', status: 'unsupported', dispatch: 'not-sent' });
+    expect(calls.some(({ args }) => args.includes('--udid'))).toBe(false);
+  });
+
+  test('derives IDB directional swipes from the reported point geometry', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner = {
+      calls,
+      exec: async () => '',
+      execFile: async (command: string, args: string[]) => {
+        calls.push({ command, args });
+        if (args.at(-1) === '--version') return Buffer.from('1.0.0');
+        if (args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{describe-all,tap,text,swipe}');
+        if (args.at(-1) === '--help' && args.at(-2) === 'tap') return Buffer.from('--duration DURATION');
+        if (args.at(-1) === '--help' && args.at(-2) === 'swipe') return Buffer.from('--duration DURATION');
+        if (args.at(-1) === '--help') return Buffer.from('commands: ui describe');
+        if (args.includes('describe')) return Buffer.from(JSON.stringify({ screen_dimensions: { width_points: 402, height_points: 874 } }));
+        return Buffer.from('ok');
+      },
+    };
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: '/bin/echo --profile fixture' }, runner });
+    const response = await controller.swipeDirection({ platform: 'ios', id: 'fake-udid' }, 'up', 300);
+    expect(response).toMatchObject({ backend: 'idb', status: 'handled', dispatch: 'submitted' });
+    expect(calls.at(-2)?.args).toEqual(['--profile', 'fixture', 'describe', '--udid', 'fake-udid', '--json']);
+    expect(calls.at(-1)?.args).toEqual(['--profile', 'fixture', 'ui', 'swipe', '201', '656', '201', '219', '--duration', '0.3', '--udid', 'fake-udid']);
+  });
+
+  test('uses the final Android override geometry for directional swipes', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner = {
+      calls,
+      exec: async () => '',
+      execFile: async (command: string, args: string[]) => {
+        calls.push({ command, args });
+        if (command === 'adb' && args.at(-1) === 'size') return Buffer.from('Physical size: 1080x1920\nOverride size: 414x896\n');
+        return Buffer.from('ok');
+      },
+    };
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb' }, runner });
+    await controller.swipeDirection({ platform: 'android', id: 'emulator' }, 'up', 300);
+    expect(calls.at(-1)?.args).toEqual(['-s', 'emulator', 'shell', 'input', 'swipe', '207', '672', '207', '224', '300']);
+  });
+
+  test('treats a transport failure during dispatch as unknown and never falls through', async () => {
+    const runner = fakeRunner();
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:fake-udid', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'connect_device') return { structuredContent: { accepted: true } };
+        throw new Error('connection lost after dispatch');
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    const response = await controller.tap({ platform: 'ios', id: 'fake-udid' }, 1, 2);
+    expect(response).toMatchObject({ backend: 'simview', status: 'failed', dispatched: false, dispatch: 'unknown' });
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
+  });
+
+  test('closes a SimView client when initialization fails before a session is owned', async () => {
+    const runner = fakeRunner();
+    let closed = 0;
+    const client = {
+      connect: async () => { throw new Error('MCP handshake failed'); },
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => ({ isError: true }),
+      close: async () => { closed += 1; },
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    const response = await controller.tap({ platform: 'ios', id: 'fake-udid' }, 1, 2);
+    expect(response).toMatchObject({ backend: 'simview', status: 'unavailable', dispatch: 'not-sent' });
+    expect(closed).toBe(1);
+  });
+
+  test('does not block shutdown on an in-flight native call', async () => {
+    const runner = fakeRunner();
+    let closed = 0;
+    let transportClosed = 0;
+    let dispatchStarted: () => void = () => {};
+    const started = new Promise<void>((resolve) => { dispatchStarted = resolve; });
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:fake-udid', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'tap') { dispatchStarted(); return new Promise<never>(() => {}); }
+        return { structuredContent: { connected: true } };
+      },
+      close: async () => { closed += 1; },
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => { transportClosed += 1; } } }),
+    });
+    void controller.tap({ platform: 'ios', id: 'fake-udid' }, 1, 2);
+    await started;
+    await Promise.race([controller.close(), new Promise((_, reject) => setTimeout(() => reject(new Error('shutdown timed out')), 1500))]);
+    expect(closed).toBe(1);
+    expect(transportClosed).toBe(1);
+    await controller.close();
+    expect(closed).toBe(1);
+    expect(transportClosed).toBe(1);
+  });
+
+  test('closes a client tracked before a never-resolving connection settles', async () => {
+    const runner = fakeRunner();
+    let clientClosed = 0;
+    let transportClosed = 0;
+    const client = {
+      connect: async () => new Promise<void>(() => {}),
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => ({ isError: true }),
+      close: async () => { clientClosed += 1; },
+    };
+    const transport = { close: async () => { transportClosed += 1; } };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport }),
+    });
+    const action = controller.tap({ platform: 'ios', id: 'fake-udid' }, 1, 2);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await Promise.race([controller.close(), new Promise((_, reject) => setTimeout(() => reject(new Error('shutdown timed out')), 1500))]);
+    expect(clientClosed).toBe(1);
+    expect(transportClosed).toBe(1);
+    await controller.close();
+    expect(clientClosed).toBe(1);
+    expect(transportClosed).toBe(1);
+    void action;
+  });
+});

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -257,6 +257,92 @@ describe('native input providers', () => {
     expect(calls).toContain('tap');
   });
 
+  test('falls back to IDB when SimView cannot connect before dispatch', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'connect_device') return { isError: true };
+        return { structuredContent: {} };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(calls).toEqual(['connect_device']);
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '1', '2', '--udid', 'device-a'] });
+  });
+
+  test('falls back to IDB when a cached SimView session refresh fails before dispatch', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    let refreshes = 0;
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state' && ++refreshes > 2) return { isError: true };
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', capabilities: { input: { touch: true, text: 'unicode', buttons: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).resolves.toMatchObject({ backend: 'simview', status: 'handled' });
+    await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 3, 4)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(calls.filter((name) => name === 'tap')).toHaveLength(1);
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '3', '4', '--udid', 'device-a'] });
+  });
+
+  test('falls back to IDB label lookup when SimView cannot connect before dispatch', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'describe-all') {
+        return Buffer.from(JSON.stringify([{ label: 'Continue', frame: { x: 10, y: 20, width: 80, height: 40 } }]));
+      }
+      return baseExecFile(command, args);
+    };
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'tap_element'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'connect_device') return { isError: true };
+        return { structuredContent: {} };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.tapLabel({ platform: 'ios', id: 'device-a' }, 'Continue')).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '50', '40', '--udid', 'device-a'] });
+  });
+
   test('does not report a coordinate action as handled when the receipt did not dispatch input', async () => {
     const runner = fakeRunner();
     const client = {

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -1282,6 +1282,41 @@ describe('native input providers', () => {
     expect(calls).not.toContain('long_press');
   });
 
+  test('does not probe IDB while discovering SimView for Android', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args, options) => {
+      if (command === 'idb' && args.at(-1) === '--version') return new Promise<never>(() => {});
+      return baseExecFile(command, args, options);
+    };
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'long_press'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'android:device-a', pointWidth: 400, pointHeight: 800, capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'find_elements') return { structuredContent: { matches: [{ element: { frame: { points: { x: 10, y: 20, width: 80, height: 40 } } } }] } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+      simviewRequestTimeoutMs: 50,
+    });
+
+    await expect(controller.longPressLabel({ platform: 'android', id: 'device-a' }, 'Continue', 900)).resolves.toMatchObject({
+      backend: 'simview', status: 'handled', dispatched: true,
+    });
+    expect(calls).toContain('long_press');
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args.at(-1) === '--version')).toBe(false);
+    await controller.close();
+  });
+
   test('falls back to IDB long press using the accessibility frame center', async () => {
     const runner = fakeRunner();
     const baseExecFile = runner.execFile;

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -195,7 +195,7 @@ describe('native input providers', () => {
       listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'press_key'].map((name) => ({ name })) }),
       callTool: async ({ name, arguments: args }: { name: string; arguments: Record<string, unknown> }) => {
         calls.push({ name, arguments: args });
-        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:key-device', capabilities: { input: { touch: true } } } } };
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:key-device', capabilities: { input: { touch: true, keys: ['return', 'delete'] } } } } };
         if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
         return { structuredContent: { accepted: true } };
       },
@@ -242,7 +242,36 @@ describe('native input providers', () => {
     expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'key', '40', '--udid', 'key-device'] });
   });
 
-  test('does not fall through after an accepted or ambiguous SimView key receipt', async () => {
+  test('falls through to IDB when SimView excludes a key before dispatch', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === 'idb' && args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{key}');
+      return baseExecFile(command, args);
+    };
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'press_key'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:key-device', capabilities: { input: { touch: true, keys: [] } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    await expect(controller.button({ platform: 'ios', id: 'key-device' }, 'DELETE')).resolves.toMatchObject({ backend: 'idb', status: 'handled', dispatched: true });
+    expect(calls).not.toContain('press_key');
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'key', '42', '--udid', 'key-device'] });
+  });
+
+  test('does not fall through after an accepted SimView key receipt', async () => {
     const runner = fakeRunner();
     const client = {
       connect: async () => {},

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -385,6 +385,37 @@ describe('native input providers', () => {
     expect((await controller.button({ platform: 'ios', id: 'ios-device' }, 'ENTER')).status).toBe('unsupported');
   });
 
+  test('bounds a stalled Android action and reports uncertain dispatch', async () => {
+    let timeout: number | undefined;
+    const runner = {
+      exec: async () => '',
+      execFile: async (
+        _command: string,
+        _args: string[],
+        options?: { maxBuffer?: number; timeout?: number },
+      ) => {
+        timeout = options?.timeout;
+        return new Promise<Buffer>(() => {});
+      },
+    };
+    const controller = new NativeInputController({
+      runner,
+      simviewRequestTimeoutMs: 20,
+    });
+
+    const started = Date.now();
+    await expect(controller.tap({ platform: 'android', id: 'emulator-5556' }, 1, 2))
+      .resolves.toMatchObject({
+        backend: 'adb',
+        status: 'failed',
+        dispatched: false,
+        dispatch: 'unknown',
+      });
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(timeout).toBeGreaterThan(0);
+    expect(timeout).toBeLessThanOrEqual(20);
+  });
+
   test('discovers IDB ui key as a provider capability', async () => {
     const runner = fakeRunner();
     const baseExecFile = runner.execFile;

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -301,6 +301,53 @@ describe('native input providers', () => {
     }
   });
 
+  test('resolves relative configured SimView and IDB executables from the project root', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'metro-mcp-relative-provider-'));
+    try {
+      await mkdir(join(projectRoot, 'tools'));
+      const simviewPath = join(projectRoot, 'tools', 'simview');
+      const idbPath = join(projectRoot, 'tools', 'idb');
+      await writeFile(simviewPath, '#!/bin/sh\nprintf 0.4.0\n');
+      await writeFile(idbPath, '#!/bin/sh\nprintf 1.0.0\n');
+      await chmod(simviewPath, 0o755);
+      await chmod(idbPath, 0o755);
+
+      const discoveryRunner = fakeRunner();
+      const providers = await discoverNativeProviders({
+        projectRoot,
+        config: {
+          nativeBackend: 'auto',
+          simviewCommand: './tools/simview --fixture',
+          idbCommand: 'tools/idb --fixture',
+        },
+        runner: discoveryRunner,
+      });
+
+      expect(providers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ kind: 'simview', command: simviewPath, args: ['--fixture'], available: true }),
+        expect.objectContaining({ kind: 'idb', command: idbPath, args: ['--fixture'], available: true }),
+      ]));
+      expect(discoveryRunner.calls.filter(({ args }) => args.at(-1) === '--version')).toEqual([
+        { command: simviewPath, args: ['--fixture', '--version'] },
+        { command: idbPath, args: ['--fixture', '--version'] },
+      ]);
+
+      const dispatchRunner = fakeRunner();
+      const controller = new NativeInputController({
+        projectRoot,
+        config: { nativeBackend: 'idb', idbCommand: './tools/idb' },
+        runner: dispatchRunner,
+      });
+      await expect(controller.tap({ platform: 'ios', id: 'relative-provider' }, 12, 34)).resolves.toMatchObject({
+        backend: 'idb', status: 'handled', dispatched: true,
+      });
+      expect(dispatchRunner.calls.some(({ command, args }) => command === idbPath && args[0] === 'ui')).toBe(true);
+      await controller.close();
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test('uses supported IDB syntax and concrete simulator UDID', async () => {
     const runner = fakeRunner();
     const controller = new NativeInputController({

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -1317,6 +1317,23 @@ describe('native input providers', () => {
     await controller.close();
   });
 
+  test('does not cache Android provider filtering for a later iOS discovery', async () => {
+    const runner = fakeRunner();
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'idb', idbCommand: '/bin/echo' },
+      runner,
+    });
+
+    // IDB is deliberately filtered from Android provider results, but the
+    // probe must remain available when the same controller handles iOS.
+    expect(await controller.providersFor({ platform: 'android', id: 'emulator-5556' })).toEqual([]);
+    const iosProviders = await controller.providersFor({ platform: 'ios', id: 'ios-device' });
+
+    expect(iosProviders).toHaveLength(1);
+    expect(iosProviders[0]).toMatchObject({ kind: 'idb', available: true });
+    expect(runner.calls.filter(({ command, args }) => command === '/bin/echo' && args.at(-1) === '--version')).toHaveLength(1);
+  });
+
   test('falls back to IDB long press using the accessibility frame center', async () => {
     const runner = fakeRunner();
     const baseExecFile = runner.execFile;

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -482,6 +482,26 @@ describe('native input providers', () => {
     expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '50', '40', '--udid', 'device-a'] });
   });
 
+  test('reports IDB label discovery failures as not-sent before tap dispatch', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args, ...rest) => {
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'describe-all' && !args.includes('--help')) {
+        throw new Error('describe-all failed');
+      }
+      return baseExecFile(command, args, ...rest);
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'idb', idbCommand: 'idb' },
+      runner,
+    });
+
+    await expect(controller.tapLabel({ platform: 'ios', id: 'device-a' }, 'Continue')).resolves.toMatchObject({
+      backend: 'idb', status: 'failed', dispatched: false, dispatch: 'not-sent',
+    });
+    expect(runner.calls.some(({ args }) => args[0] === 'ui' && args[1] === 'tap' && !args.includes('--help'))).toBe(false);
+  });
+
   test('does not report a coordinate action as handled when the receipt did not dispatch input', async () => {
     const runner = fakeRunner();
     const client = {

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -153,6 +153,116 @@ describe('native input providers', () => {
     expect((await controller.button({ platform: 'ios', id: 'ios-device' }, 'ENTER')).status).toBe('unsupported');
   });
 
+  test('discovers IDB ui key as a provider capability', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{key}');
+      return baseExecFile(command, args);
+    };
+    const providers = await discoverNativeProviders({ config: { nativeBackend: 'idb', idbCommand: 'idb' }, runner });
+    expect(providers[0]?.capabilities?.has('key')).toBe(true);
+  });
+
+  test('uses IDB ui key HID codes for iOS enter and delete', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const runner = {
+      calls,
+      exec: async () => '',
+      execFile: async (command: string, args: string[]) => {
+        calls.push({ command, args });
+        if (args.at(-1) === '--version') return Buffer.from('1.0.0');
+        if (args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{key}');
+        if (args.at(-1) === '--help') return Buffer.from('commands: ui');
+        return Buffer.from('ok');
+      },
+    };
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: 'idb' }, runner });
+    const target = { platform: 'ios' as const, id: 'key-udid' };
+    await expect(controller.button(target, 'ENTER')).resolves.toMatchObject({ backend: 'idb', status: 'handled', dispatched: true });
+    await expect(controller.button(target, 'DELETE')).resolves.toMatchObject({ backend: 'idb', status: 'handled', dispatched: true });
+    expect(calls.filter(({ args }) => args.includes('--udid')).map(({ args }) => args)).toEqual([
+      ['ui', 'key', '40', '--udid', target.id],
+      ['ui', 'key', '42', '--udid', target.id],
+    ]);
+  });
+
+  test('dispatches iOS enter and delete through SimView named keys when available', async () => {
+    const runner = fakeRunner();
+    const calls: Array<{ name: string; arguments: Record<string, unknown> }> = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'press_key'].map((name) => ({ name })) }),
+      callTool: async ({ name, arguments: args }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push({ name, arguments: args });
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:key-device', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    const target = { platform: 'ios' as const, id: 'key-device' };
+    await expect(controller.button(target, 'ENTER')).resolves.toMatchObject({ backend: 'simview', status: 'handled', dispatched: true });
+    await expect(controller.button(target, 'DELETE')).resolves.toMatchObject({ backend: 'simview', status: 'handled', dispatched: true });
+    expect(calls.filter(({ name }) => name === 'press_key').map(({ arguments: args }) => args)).toEqual([
+      { key: 'return' },
+      { key: 'delete' },
+    ]);
+    expect(runner.calls.some(({ args }) => args.includes('ui') && args.includes('key'))).toBe(false);
+  });
+
+  test('falls through to IDB when SimView does not advertise press_key', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === 'idb' && args.at(-1) === '--help' && args.at(-2) === 'ui') return Buffer.from('{key}');
+      return baseExecFile(command, args);
+    };
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:key-device', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    await expect(controller.button({ platform: 'ios', id: 'key-device' }, 'ENTER')).resolves.toMatchObject({ backend: 'idb', status: 'handled', dispatched: true });
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'key', '40', '--udid', 'key-device'] });
+  });
+
+  test('does not fall through after an accepted or ambiguous SimView key receipt', async () => {
+    const runner = fakeRunner();
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'press_key'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:key-device', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+    await expect(controller.button({ platform: 'ios', id: 'key-device' }, 'ENTER')).resolves.toMatchObject({ backend: 'simview', status: 'handled', dispatched: true });
+    expect(runner.calls.some(({ command, args }) => command === 'idb' && args.includes('ui') && args.includes('key'))).toBe(false);
+  });
+
   test('normalizes logical points using current device geometry and clamps edges', () => {
     expect(normalizeLogicalPoint({ x: 540, y: 960 }, 1080, 1920)).toEqual({ x: 0.5, y: 0.5 });
     expect(normalizeLogicalPoint({ x: -1, y: 3000 }, 1080, 1920)).toEqual({ x: 0, y: 1 });

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -93,6 +93,51 @@ describe('native input providers', () => {
     expect(directoryReads).toBe(1);
   });
 
+  test('retries unavailable provider discovery so a later installation can recover', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    let simviewInstalled = false;
+    runner.execFile = async (command, args, options) => {
+      if (command === 'which' && args[0] === 'simview') {
+        runner.calls.push({ command, args });
+        if (!simviewInstalled) throw new Error('simview is not installed');
+        return Buffer.from('/usr/local/bin/simview');
+      }
+      if (command === '/usr/local/bin/simview' && args.at(-1) === '--version') return Buffer.from('0.4.0');
+      return baseExecFile(command, args, options);
+    };
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:recoverable-device', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', idbCommand: 'idb' },
+      runner,
+      simviewFileSystem: {
+        executable: async () => false,
+        readDirectory: async () => [],
+        readFile: async () => '',
+      },
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.tap({ platform: 'ios', id: 'recoverable-device' }, 1, 2)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true,
+    });
+    simviewInstalled = true;
+    await expect(controller.tap({ platform: 'ios', id: 'recoverable-device' }, 3, 4)).resolves.toMatchObject({
+      backend: 'simview', status: 'handled', dispatched: true,
+    });
+    expect(runner.calls.filter(({ command, args }) => command === 'which' && args[0] === 'simview')).toHaveLength(2);
+    await controller.close();
+  });
+
   test('keeps a PATH SimView ahead of a stalled plugin cache scan', async () => {
     const runner = fakeRunner();
     const baseExecFile = runner.execFile;
@@ -839,6 +884,34 @@ describe('native input providers', () => {
     await expect(controller.tap({ platform: 'ios', id: 'device-a' }, 1, 2)).resolves.toMatchObject({
       backend: 'simview', status: 'failed', dispatched: false, dispatch: 'not-sent',
     });
+  });
+
+  test('falls through to IDB when SimView explicitly reports that input was not sent', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'tap'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:not-sent-device', capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { accepted: true, inputDispatched: false } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.tap({ platform: 'ios', id: 'not-sent-device' }, 1, 2)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(calls).toContain('tap');
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '1', '2', '--udid', 'not-sent-device'] });
+    await controller.close();
   });
 
   test('uses the public semantic search match element ref and stops on tap uncertainty', async () => {

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -416,6 +416,59 @@ describe('native input providers', () => {
     expect(timeout).toBeLessThanOrEqual(20);
   });
 
+  test('bounds Android label lookup before dispatch and preserves uncertain tap failures', async () => {
+    const target = { platform: 'android' as const, id: 'emulator-5556' };
+
+    const stalledLookup = fakeRunner();
+    const lookupBase = stalledLookup.execFile;
+    stalledLookup.execFile = async (command, args, options) => {
+      if (command === 'adb' && args.includes('uiautomator')) return new Promise<never>(() => {});
+      return lookupBase(command, args, options);
+    };
+    const lookupController = new NativeInputController({
+      runner: stalledLookup,
+      simviewRequestTimeoutMs: 20,
+    });
+    await expect(lookupController.tapLabel(target, 'Continue')).resolves.toMatchObject({
+      backend: 'adb', status: 'failed', dispatched: false, dispatch: 'not-sent',
+    });
+    expect(stalledLookup.calls.some(({ args }) => args.includes('input'))).toBe(false);
+
+    const stalledTap = fakeRunner();
+    const tapBase = stalledTap.execFile;
+    stalledTap.execFile = async (command, args, options) => {
+      if (command === 'adb' && args[2] === 'exec-out') {
+        return Buffer.from('<node text="Continue" bounds="[10,20][90,60]"/>');
+      }
+      if (command === 'adb' && args.includes('input')) return new Promise<never>(() => {});
+      return tapBase(command, args, options);
+    };
+    const tapController = new NativeInputController({
+      runner: stalledTap,
+      simviewRequestTimeoutMs: 20,
+    });
+    await expect(tapController.tapLabel(target, 'Continue')).resolves.toMatchObject({
+      backend: 'adb', status: 'failed', dispatched: false, dispatch: 'unknown',
+    });
+
+    const escapedLabel = fakeRunner();
+    const escapedBase = escapedLabel.execFile;
+    escapedLabel.execFile = async (command, args, options) => {
+      if (command === 'adb' && args[2] === 'exec-out') {
+        return Buffer.from('<node content-desc="R&amp;D &#x1F680;" bounds="[10,20][90,60]"/>');
+      }
+      return escapedBase(command, args, options);
+    };
+    const escapedController = new NativeInputController({ runner: escapedLabel });
+    await expect(escapedController.tapLabel(target, 'R&D 🚀')).resolves.toMatchObject({
+      backend: 'adb', status: 'handled', dispatched: true, dispatch: 'submitted',
+    });
+    expect(escapedLabel.calls).toContainEqual({
+      command: 'adb',
+      args: ['-s', target.id, 'shell', 'input', 'tap', '50', '40'],
+    });
+  });
+
   test('discovers IDB ui key as a provider capability', async () => {
     const runner = fakeRunner();
     const baseExecFile = runner.execFile;

--- a/src/utils/native-input.test.ts
+++ b/src/utils/native-input.test.ts
@@ -393,6 +393,111 @@ describe('native input providers', () => {
     expect(runner.calls.some(({ command, args }) => command === 'idb' && args[0] === 'ui' && args.includes('--udid'))).toBe(false);
   });
 
+  test('long presses the unique SimView semantic match at its normalized frame center', async () => {
+    const runner = fakeRunner();
+    const calls: Array<{ name: string; arguments: Record<string, unknown> }> = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'long_press'].map((name) => ({ name })) }),
+      callTool: async ({ name, arguments: args }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push({ name, arguments: args });
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', pointWidth: 400, pointHeight: 800, capabilities: { input: { touch: true } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        if (name === 'find_elements') return { structuredContent: { matches: [{ element: { frame: { points: { x: 10, y: 20, width: 80, height: 40 }, normalized: { x: 0.25, y: 0.1, width: 0.5, height: 0.2 } } } }] } };
+        return { structuredContent: { accepted: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.longPressLabel({ platform: 'ios', id: 'device-a' }, 'Continue', 900)).resolves.toMatchObject({
+      backend: 'simview', status: 'handled', dispatched: true,
+    });
+    expect(calls.find((call) => call.name === 'long_press')?.arguments).toEqual({ x: 0.5, y: 0.2, durationMs: 900 });
+  });
+
+  test('falls through to IDB when SimView reports no touch capability', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'describe-all') {
+        return Buffer.from(JSON.stringify([{ label: 'Continue', frame: { x: 10, y: 20, width: 80, height: 40 } }]));
+      }
+      return baseExecFile(command, args);
+    };
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'long_press'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'ios:device-a', pointWidth: 400, pointHeight: 800, capabilities: { input: { touch: false } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { connected: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'auto', simviewCommand: '/bin/echo', idbCommand: 'idb' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.longPressLabel({ platform: 'ios', id: 'device-a' }, 'Continue', 900)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true,
+    });
+    expect(calls).not.toContain('find_elements');
+    expect(calls).not.toContain('long_press');
+  });
+
+  test('reports unsupported Android semantic long press before dispatch when touch is unavailable', async () => {
+    const runner = fakeRunner();
+    const calls: string[] = [];
+    const client = {
+      connect: async () => {},
+      listTools: async () => ({ tools: ['connect_device', 'get_simview_state', 'observe_screen', 'find_elements', 'long_press'].map((name) => ({ name })) }),
+      callTool: async ({ name }: { name: string; arguments: Record<string, unknown> }) => {
+        calls.push(name);
+        if (name === 'get_simview_state') return { structuredContent: { device: { id: 'android:device-a', pointWidth: 400, pointHeight: 800, capabilities: { input: { touch: false } } } } };
+        if (name === 'observe_screen') return { structuredContent: { viewport: { width: 400, height: 800 } } };
+        return { structuredContent: { connected: true } };
+      },
+      close: async () => {},
+    };
+    const controller = new NativeInputController({
+      config: { nativeBackend: 'simview', simviewCommand: '/bin/echo' },
+      runner,
+      simviewClientFactory: () => ({ client, transport: { close: async () => {} } }),
+    });
+
+    await expect(controller.longPressLabel({ platform: 'android', id: 'device-a' }, 'Continue', 900)).resolves.toMatchObject({
+      backend: 'simview', status: 'unsupported', dispatched: false, dispatch: 'not-sent',
+    });
+    expect(calls).not.toContain('find_elements');
+    expect(calls).not.toContain('long_press');
+  });
+
+  test('falls back to IDB long press using the accessibility frame center', async () => {
+    const runner = fakeRunner();
+    const baseExecFile = runner.execFile;
+    runner.execFile = async (command, args) => {
+      if (command === 'idb' && args[0] === 'ui' && args[1] === 'describe-all') {
+        return Buffer.from(JSON.stringify([{ label: 'Continue', frame: { x: 10, y: 20, width: 80, height: 40 } }]));
+      }
+      return baseExecFile(command, args);
+    };
+    const controller = new NativeInputController({ config: { nativeBackend: 'idb', idbCommand: 'idb' }, runner });
+
+    await expect(controller.longPressLabel({ platform: 'ios', id: 'device-a' }, 'Continue', 900)).resolves.toMatchObject({
+      backend: 'idb', status: 'handled', dispatched: true,
+    });
+    expect(runner.calls).toContainEqual({ command: 'idb', args: ['ui', 'tap', '50', '40', '--duration', '0.9', '--udid', 'device-a'] });
+  });
+
   test('stops a raw SimView action when safeToContinue is false, even with a dispatch receipt', async () => {
     const runner = fakeRunner();
     const calls: string[] = [];

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -453,7 +453,13 @@ export class NativeInputController {
   }
 
   async providersFor(target: NativeInputTarget, deadline = this.simviewDeadline()): Promise<Provider[]> {
-    if (!this.providers) this.providers = await discoverNativeProviders(this.options, deadline);
+    // Keep successful discovery cheap, but do not make an unavailable
+    // provider permanent for the lifetime of the controller. A provider can
+    // be installed, added to PATH, or recover from a transient probe failure
+    // while the daemon is still running.
+    if (!this.providers || this.providers.some((provider) => !provider.available)) {
+      this.providers = await discoverNativeProviders(this.options, deadline);
+    }
     return this.providers.filter((provider) =>
       this.config.nativeBackend === 'auto' || provider.kind === this.config.nativeBackend,
     ).filter((provider) => target.platform === 'ios' || provider.kind === 'simview');
@@ -569,7 +575,7 @@ export class NativeInputController {
           const interaction = tapped.interaction && typeof tapped.interaction === 'object'
             ? tapped.interaction as Record<string, unknown>
             : undefined;
-          const accepted = interaction?.accepted;
+          const accepted = typeof interaction?.accepted === 'boolean' ? interaction.accepted : tapped.accepted;
           const inputDispatched = typeof interaction?.inputDispatched === 'boolean'
             ? interaction.inputDispatched
             : tapped.inputDispatched;
@@ -585,6 +591,14 @@ export class NativeInputController {
             );
           }
           if (accepted === false) return result('simview', 'failed', dispatched, 'SimView rejected the semantic tap', dispatched ? 'submitted' : 'not-sent');
+          if (accepted === true && inputDispatched === false) {
+            return result(
+              'simview',
+              this.config.nativeBackend === 'auto' ? 'unsupported' : 'failed',
+              false,
+              'SimView accepted the request without dispatching input',
+            );
+          }
           if (accepted !== true || inputDispatched !== true) return result('simview', 'failed', dispatched, 'SimView returned no complete semantic action receipt', dispatched ? 'submitted' : 'unknown');
           return result('simview', 'handled', true);
         });
@@ -665,7 +679,14 @@ export class NativeInputController {
             return result('simview', 'failed', dispatched, 'SimView reported that it is unsafe to continue after the long press', dispatchEvidence(inputDispatched));
           }
           if (accepted === false) return result('simview', 'failed', dispatched, 'SimView rejected the long press', dispatched ? 'submitted' : 'not-sent');
-          if (accepted === true && inputDispatched === false) return result('simview', 'failed', false, 'SimView accepted the request without dispatching input');
+          if (accepted === true && inputDispatched === false) {
+            return result(
+              'simview',
+              this.config.nativeBackend === 'auto' ? 'unsupported' : 'failed',
+              false,
+              'SimView accepted the request without dispatching input',
+            );
+          }
           if (accepted !== true) return result('simview', 'failed', dispatched, 'SimView returned no accepted long press receipt', dispatched ? 'submitted' : 'unknown');
           // SimView's public long_press output schema is `{ accepted: true }`.
           // Newer implementations may add inputDispatched telemetry, but the
@@ -950,7 +971,17 @@ export class NativeInputController {
           );
         }
         if (accepted === false) return result('simview', 'failed', dispatched, 'SimView rejected the action', dispatched ? 'submitted' : 'not-sent');
-        if (accepted === true && inputDispatched === false) return result('simview', 'failed', false, 'SimView accepted the request without dispatching input');
+        if (accepted === true && inputDispatched === false) {
+          // In auto mode SimView has explicitly proved that no input was
+          // dispatched, so another provider may safely take over. Preserve a
+          // terminal failure for explicit SimView selection.
+          return result(
+            'simview',
+            this.config.nativeBackend === 'auto' ? 'unsupported' : 'failed',
+            false,
+            'SimView accepted the request without dispatching input',
+          );
+        }
         if (accepted !== true) return result('simview', 'failed', dispatched, 'SimView returned no accepted action receipt', dispatched ? 'submitted' : 'unknown');
         return result('simview', 'handled', true);
       } catch (error) {

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -1,7 +1,7 @@
 import { access, readFile, readdir } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 import { Client } from '@modelcontextprotocol/client';
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 
@@ -149,6 +149,14 @@ function unquoteCommandToken(value: string): string {
   return value.startsWith('"') || value.startsWith("'") ? value.slice(1, -1) : value;
 }
 
+function resolveConfiguredExecutable(command: string, projectRoot?: string): string {
+  // Bare configured commands are provider names resolved through PATH. Only
+  // path-like values should be rooted at the project, so a project root does
+  // not accidentally shadow an explicitly selected PATH installation.
+  if (!projectRoot || isAbsolute(command) || !command.includes('/')) return command;
+  return resolve(projectRoot, command);
+}
+
 const defaultSimViewFileSystem: SimViewFileSystem = {
   executable: async (path) => {
     try {
@@ -257,11 +265,15 @@ export async function discoverNativeProviders(
       const tokens = commandTokens(candidate.command);
       for (let index = tokens.length; index > 0; index--) {
         const possiblePath = tokens.slice(0, index).map(unquoteCommandToken).join(' ');
-        if (await executable(possiblePath, discoveryDeadline, fileSystem)) {
-          parts = { command: possiblePath, args: tokens.slice(index).map(unquoteCommandToken) };
+        const resolvedPath = resolveConfiguredExecutable(possiblePath, options.projectRoot);
+        if (await executable(resolvedPath, discoveryDeadline, fileSystem)) {
+          parts = { command: resolvedPath, args: tokens.slice(index).map(unquoteCommandToken) };
           break;
         }
       }
+    }
+    if (candidate.explicit) {
+      parts = { ...parts, command: resolveConfiguredExecutable(parts.command, options.projectRoot) };
     }
     const paths = candidate.explicit
       ? [parts.command]

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -814,7 +814,13 @@ export class NativeInputController {
   private async geometry(target: NativeInputTarget, deadline = this.simviewDeadline()): Promise<({ width: number; height: number; simviewUnavailable?: boolean }) | null> {
     if (target.platform === 'android') {
       try {
-        const output = (await this.options.runner.execFile('adb', ['-s', target.id, 'shell', 'wm', 'size'], { maxBuffer: 16 * 1024 })).toString('utf8');
+        const output = (await boundedExecFile(
+          this.options.runner,
+          'adb',
+          ['-s', target.id, 'shell', 'wm', 'size'],
+          { maxBuffer: 16 * 1024 },
+          deadline,
+        )).toString('utf8');
         const matches = [...output.matchAll(/(Override|Physical) size:\s*(\d+)x(\d+)/gi)];
         const match = matches.findLast((entry) => entry[1]?.toLowerCase() === 'override') ?? matches.at(-1);
         return match ? { width: Number(match[2]), height: Number(match[3]) } : null;
@@ -873,7 +879,13 @@ export class NativeInputController {
 
   private async adb(target: NativeInputTarget, args: string[], description: string): Promise<NativeDispatchResult> {
     try {
-      await this.options.runner.execFile('adb', ['-s', target.id, ...args], { maxBuffer: 64 * 1024 });
+      await boundedExecFile(
+        this.options.runner,
+        'adb',
+        ['-s', target.id, ...args],
+        { maxBuffer: 64 * 1024 },
+        this.simviewDeadline(),
+      );
       return result('adb', 'handled', true, `${description} dispatched to ${target.id}`);
     } catch (error) {
       return result('adb', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -394,6 +394,36 @@ export class NativeInputController {
     }
   }
 
+  /** Locate a label through semantic providers and long press its frame center. */
+  async longPressLabel(target: NativeInputTarget, label: string, duration: number): Promise<NativeDispatchResult> {
+    if (this.closed) return result('none', 'unavailable', false, 'Native input controller is closed');
+
+    const providers = await this.providersFor(target);
+    let fallback: NativeDispatchResult | undefined;
+    const simview = providers.find((candidate) => candidate.kind === 'simview' && candidate.available);
+    if (simview) {
+      const semantic = await this.simviewLongPressLabel(target, label, duration, simview);
+      if (semantic.status !== 'unavailable' && semantic.status !== 'unsupported') return semantic;
+      fallback = semantic;
+    }
+
+    // IDB's accessibility dump and UI input commands are iOS-only. SimView
+    // remains available on Android because it can query that device directly.
+    if (target.platform !== 'ios') return fallback ?? result('none', 'unsupported', false, 'Label lookup is only available through SimView on Android');
+    const provider = providers.find((candidate) => candidate.kind === 'idb' && candidate.available);
+    if (!provider) return fallback ?? result('none', 'unavailable', false, 'IDB is not installed for accessibility label lookup');
+    if (!provider.capabilities?.has('describe-all')) return result('idb', 'unsupported', false, 'IDB does not advertise accessibility descriptions');
+    if (!provider.capabilities.has('long_press')) return result('idb', 'unsupported', false, 'IDB does not advertise long press input');
+    try {
+      const dump = await this.options.runner.execFile(provider.command, [...provider.args, 'ui', 'describe-all', '--udid', target.id, '--json'], { maxBuffer: 2 * 1024 * 1024 });
+      const match = findAccessibilityPoint(dump.toString('utf8'), label);
+      if (!match.point) return result('idb', match.ambiguous ? 'failed' : 'unsupported', false, match.ambiguous ? `Element "${label}" is ambiguous` : `Element "${label}" was not found by IDB`);
+      return this.idb(target, 'long_press', { ...match.point, durationMs: duration }, provider);
+    } catch (error) {
+      return result('idb', 'unavailable', false, error instanceof Error ? error.message : String(error), 'not-sent');
+    }
+  }
+
   private async simviewLabel(target: NativeInputTarget, label: string, provider: Provider): Promise<NativeDispatchResult> {
     if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
     let inputAttempted = false;
@@ -450,6 +480,75 @@ export class NativeInputController {
       // Connecting, refreshing, and searching happen before SimView receives
       // the semantic tap. IDB may safely take over in auto mode in those
       // cases; once the tap request was attempted, the dispatch is uncertain.
+      return result(
+        'simview',
+        inputAttempted ? 'failed' : 'unavailable',
+        false,
+        error instanceof Error ? error.message : String(error),
+        inputAttempted ? 'unknown' : 'not-sent',
+      );
+    }
+  }
+
+  private async simviewLongPressLabel(target: NativeInputTarget, label: string, duration: number, provider: Provider): Promise<NativeDispatchResult> {
+    if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
+    let inputAttempted = false;
+    try {
+      return await this.withActionQueue(async () => {
+        const session = await this.getSession(target, provider);
+        return this.withSessionQueue(session, async () => {
+          try {
+            await this.refreshSession(session);
+          } catch (error) {
+            await this.invalidateSession(session);
+            throw error;
+          }
+          if (!session.tools.has('find_elements') || !session.tools.has('long_press')) {
+            return result('simview', 'unsupported', false, 'SimView does not provide semantic long press input');
+          }
+          const input = session.capabilities.input as Record<string, unknown> | undefined;
+          if (input?.touch !== true) {
+            return result('simview', 'unsupported', false, 'SimView does not support touch input');
+          }
+          const searchResponse = await session.client.callTool({ name: 'find_elements', arguments: { name: label, exact: true } });
+          if (searchResponse.isError) return result('simview', 'unavailable', false, 'SimView semantic search is unavailable');
+          const found = readStructuredResult(searchResponse);
+          const matches = Array.isArray(found.matches) ? found.matches : [];
+          if (matches.length === 0) return result('simview', 'unsupported', false, `Element "${label}" was not found by SimView`);
+          if (matches.length !== 1) return result('simview', 'failed', false, `Element "${label}" is ambiguous`);
+          const match = matches[0];
+          const element = match && typeof match === 'object'
+            ? ((match as Record<string, unknown>).element && typeof (match as Record<string, unknown>).element === 'object'
+              ? (match as Record<string, unknown>).element
+              : match)
+            : undefined;
+          const point = simViewFrameCenter(element, session.width, session.height);
+          if (!point) return result('simview', 'unsupported', false, `Element "${label}" has no usable frame`);
+          inputAttempted = true;
+          const response = await session.client.callTool({ name: 'long_press', arguments: { ...point, durationMs: duration } });
+          const structured = readStructuredResult(response);
+          const interaction = structured.interaction && typeof structured.interaction === 'object'
+            ? structured.interaction as Record<string, unknown>
+            : undefined;
+          const accepted = typeof interaction?.accepted === 'boolean' ? interaction.accepted : structured.accepted;
+          const inputDispatched = typeof interaction?.inputDispatched === 'boolean'
+            ? interaction.inputDispatched
+            : typeof structured.inputDispatched === 'boolean' ? structured.inputDispatched : undefined;
+          const dispatched = inputDispatched === true;
+          if (response.isError) return result('simview', 'failed', dispatched, 'SimView long press result is uncertain', dispatchEvidence(inputDispatched));
+          if (interaction?.safeToContinue === false || structured.safeToContinue === false) {
+            return result('simview', 'failed', dispatched, 'SimView reported that it is unsafe to continue after the long press', dispatchEvidence(inputDispatched));
+          }
+          if (accepted === false) return result('simview', 'failed', dispatched, 'SimView rejected the long press', dispatched ? 'submitted' : 'not-sent');
+          if (accepted === true && inputDispatched === false) return result('simview', 'failed', false, 'SimView accepted the request without dispatching input');
+          if (accepted !== true) return result('simview', 'failed', dispatched, 'SimView returned no accepted long press receipt', dispatched ? 'submitted' : 'unknown');
+          // SimView's public long_press output schema is `{ accepted: true }`.
+          // Newer implementations may add inputDispatched telemetry, but the
+          // schema-level acceptance itself is the successful dispatch receipt.
+          return result('simview', 'handled', true);
+        });
+      });
+    } catch (error) {
       return result(
         'simview',
         inputAttempted ? 'failed' : 'unavailable',
@@ -955,4 +1054,27 @@ function findAccessibilityPoint(raw: string, label: string): { point: { x: numbe
     stack.push(...Object.values(object));
   }
   return { point: points.length === 1 ? points[0] : null, ambiguous: points.length > 1 };
+}
+
+function simViewFrameCenter(value: unknown, width: number, height: number): { x: number; y: number } | null {
+  if (!value || typeof value !== 'object') return null;
+  const object = value as Record<string, unknown>;
+  const frame = object.frame && typeof object.frame === 'object' ? object.frame as Record<string, unknown> : object;
+  const normalized = frame.normalized && typeof frame.normalized === 'object' ? frame.normalized as Record<string, unknown> : undefined;
+  const points = frame.points && typeof frame.points === 'object' ? frame.points as Record<string, unknown> : undefined;
+  const center = (candidate: Record<string, unknown> | undefined, scaleX: number, scaleY: number) => {
+    if (!candidate) return null;
+    const x = Number(candidate.x);
+    const y = Number(candidate.y);
+    const frameWidth = Number(candidate.width);
+    const frameHeight = Number(candidate.height);
+    if (![x, y, frameWidth, frameHeight].every(Number.isFinite) || frameWidth < 0 || frameHeight < 0) return null;
+    const centerX = (x + frameWidth / 2) * scaleX;
+    const centerY = (y + frameHeight / 2) * scaleY;
+    if (centerX < 0 || centerX > 1 || centerY < 0 || centerY > 1) return null;
+    return { x: centerX, y: centerY };
+  };
+  // SimView exposes both logical points and normalized frame coordinates. Use
+  // normalized values first so a stale point geometry cannot skew the action.
+  return center(normalized, 1, 1) ?? center(points, 1 / width, 1 / height) ?? center(frame, 1 / width, 1 / height);
 }

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -1,0 +1,943 @@
+import { access, readFile, readdir } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+
+export type NativeBackend = 'auto' | 'simview' | 'idb';
+
+export interface NativeInputConfig {
+  nativeBackend?: NativeBackend;
+  simviewCommand?: string;
+  idbCommand?: string;
+}
+
+export interface NativeCommandRunner {
+  execFile(command: string, args: string[], options?: { maxBuffer?: number }): Promise<Buffer>;
+  exec(command: string): Promise<string>;
+}
+
+export interface NativeInputTarget {
+  platform: 'ios' | 'android';
+  id: string;
+}
+
+export interface NativeDispatchResult {
+  backend: 'simview' | 'idb' | 'adb' | 'none';
+  dispatched: boolean;
+  status: 'handled' | 'unavailable' | 'unsupported' | 'failed';
+  dispatch: 'not-sent' | 'submitted' | 'unknown';
+  message?: string;
+}
+
+interface Provider {
+  kind: 'simview' | 'idb';
+  command: string;
+  args: string[];
+  available: boolean;
+  /** Commands which were advertised by the provider's read-only help. */
+  capabilities?: Set<string>;
+  /** iOS button names advertised by IDB's button help. */
+  buttons?: Set<string>;
+  reason?: string;
+}
+
+interface SimViewSession {
+  client: SimViewClientLike;
+  transport: SimViewTransportLike;
+  resource: SimViewResource;
+  deviceId: string;
+  width: number;
+  height: number;
+  capabilities: Record<string, unknown>;
+  tools: Set<string>;
+  queue: Promise<void>;
+  closed: boolean;
+}
+
+interface SimViewResource {
+  client: SimViewClientLike;
+  transport: SimViewTransportLike;
+  closePromise: Promise<void> | null;
+}
+
+interface SimViewCallResult {
+  isError?: boolean;
+  structuredContent?: unknown;
+  content?: Array<{ type?: string; text?: string }>;
+}
+
+interface SimViewClientLike {
+  connect(transport: unknown): Promise<void>;
+  listTools(): Promise<{ tools: Array<{ name: string }> }>;
+  callTool(params: { name: string; arguments: Record<string, unknown> }): Promise<SimViewCallResult>;
+  close(): Promise<void>;
+}
+
+interface SimViewTransportLike {
+  close(): Promise<void>;
+}
+
+export interface NativeInputOptions {
+  projectRoot?: string;
+  config?: NativeInputConfig;
+  runner: NativeCommandRunner;
+  registerCleanup?: (callback: () => void | Promise<void>) => void;
+  logger?: { debug(message: string, ...args: unknown[]): void; warn(message: string, ...args: unknown[]): void };
+  /** Internal test/runtime discovery roots for validated SimView plugins. */
+  simviewPluginRoots?: string[];
+  /** Injectable MCP client for deterministic provider tests. */
+  simviewClientFactory?: (command: string, args: string[]) => {
+    client: SimViewClientLike;
+    transport: SimViewTransportLike;
+  };
+}
+
+export function normalizeLogicalPoint(
+  point: { x: number; y: number },
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  return {
+    x: Math.max(0, Math.min(1, point.x / width)),
+    y: Math.max(0, Math.min(1, point.y / height)),
+  };
+}
+
+const SIMVIEW_PLUGIN_CACHE_ROOT = resolve(homedir(), '.codex/plugins/cache');
+
+function configValue(config: NativeInputConfig | undefined): Required<NativeInputConfig> {
+  return {
+    nativeBackend: config?.nativeBackend ?? 'auto',
+    simviewCommand: config?.simviewCommand ?? 'simview',
+    idbCommand: config?.idbCommand ?? 'idb',
+  };
+}
+
+function commandTokens(command: string): string[] {
+  return command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+}
+
+function commandParts(command: string): { command: string; args: string[] } {
+  // Commands are executable paths by design. Supporting a small quoted-path
+  // form keeps config useful for paths containing spaces without invoking a shell.
+  const parts = commandTokens(command);
+  return { command: unquoteCommandToken(parts[0] ?? command), args: parts.slice(1).map(unquoteCommandToken) };
+}
+
+function unquoteCommandToken(value: string): string {
+  return value.startsWith('"') || value.startsWith("'") ? value.slice(1, -1) : value;
+}
+
+async function executable(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findSimViewPluginBinaries(roots: string[] = [SIMVIEW_PLUGIN_CACHE_ROOT]): Promise<string[]> {
+  const binaries: string[] = [];
+  const seen = new Set<string>();
+  const visit = async (root: string, depth: number): Promise<void> => {
+    if (seen.has(root) || depth < 0) return;
+    seen.add(root);
+    if (await executable(join(root, 'bin', 'simview')) && await validateSimViewPlugin(root)) {
+      binaries.push(join(root, 'bin', 'simview'));
+      return;
+    }
+    try {
+      const entries = await readdir(root, { withFileTypes: true });
+      for (const entry of entries.filter((item) => item.isDirectory()).sort((a, b) => b.name.localeCompare(a.name, undefined, { numeric: true }))) await visit(join(root, entry.name), depth - 1);
+    } catch { /* An uninstalled plugin is an ordinary unavailable provider. */ }
+  };
+  for (const root of roots.length ? roots : [SIMVIEW_PLUGIN_CACHE_ROOT]) await visit(root, 3);
+  return binaries;
+}
+
+async function validateSimViewPlugin(root: string): Promise<boolean> {
+  try {
+    const manifest = JSON.parse(await readFile(join(root, '.codex-plugin/plugin.json'), 'utf8')) as Record<string, unknown>;
+    const mcp = JSON.parse(await readFile(join(root, '.mcp.json'), 'utf8')) as Record<string, unknown>;
+    const server = (mcp.mcpServers as Record<string, unknown> | undefined)?.simview as Record<string, unknown> | undefined;
+    const command = server?.command;
+    const args = server?.args;
+    const repository = typeof manifest.repository === 'string' ? manifest.repository.replace(/\.git$/, '') : '';
+    return manifest.name === 'simview' && repository === 'https://github.com/toolingtools/SimView' && command === './bin/simview' && Array.isArray(args) && args.length === 1 && args[0] === 'mcp';
+  } catch { return false; }
+}
+
+/**
+ * Resolve providers without downloading or installing anything. Explicit
+ * paths win, followed by project-local binaries, PATH, then the validated
+ * bundled SimView plugin installation.
+ */
+export async function discoverNativeProviders(
+  options: NativeInputOptions,
+): Promise<Provider[]> {
+  const config = configValue(options.config);
+  const result: Provider[] = [];
+  const candidates = ([
+    { kind: 'simview', command: config.simviewCommand, explicit: options.config?.simviewCommand !== undefined },
+    { kind: 'idb', command: config.idbCommand, explicit: options.config?.idbCommand !== undefined },
+  ] as Array<{ kind: 'simview' | 'idb'; command: string; explicit: boolean }>).filter(
+    (candidate) => config.nativeBackend === 'auto' || candidate.kind === config.nativeBackend,
+  );
+
+  for (const candidate of candidates) {
+    let parts = commandParts(candidate.command);
+    if (candidate.explicit) {
+      const tokens = commandTokens(candidate.command);
+      for (let index = tokens.length; index > 0; index--) {
+        const possiblePath = tokens.slice(0, index).map(unquoteCommandToken).join(' ');
+        if (await executable(possiblePath)) {
+          parts = { command: possiblePath, args: tokens.slice(index).map(unquoteCommandToken) };
+          break;
+        }
+      }
+    }
+    const paths = candidate.explicit
+      ? [parts.command]
+      : [
+          ...(options.projectRoot ? [join(options.projectRoot, 'node_modules/.bin', parts.command)] : []),
+          ...(options.projectRoot ? [join(options.projectRoot, parts.command)] : []),
+          parts.command,
+          ...(candidate.kind === 'simview' ? await findSimViewPluginBinaries(options.simviewPluginRoots) : []),
+        ];
+    let selected: string | undefined;
+    for (const path of paths) {
+      if (candidate.explicit || (path.includes('/') ? await executable(path) : await commandExists(options.runner, path))) {
+        selected = path;
+        break;
+      }
+    }
+    if (!selected) {
+      result.push({ kind: candidate.kind, command: parts.command, args: parts.args, available: false, reason: 'not installed' });
+      continue;
+    }
+    try {
+      const probed = await probeProvider(options.runner, candidate.kind, selected, parts.args);
+      result.push({ kind: candidate.kind, command: selected, args: parts.args, available: true, ...probed });
+    } catch (error) {
+      result.push({
+        kind: candidate.kind,
+        command: selected,
+        args: parts.args,
+        available: false,
+        reason: `version probe failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+  return result;
+}
+
+async function probeProvider(
+  runner: NativeCommandRunner,
+  kind: Provider['kind'],
+  command: string,
+  args: string[],
+): Promise<{ capabilities?: Set<string>; buttons?: Set<string> }> {
+  let versionError: unknown;
+  try {
+    await runner.execFile(command, [...args, '--version'], { maxBuffer: 64 * 1024 });
+  } catch (error) {
+    versionError = error;
+  }
+  if (kind !== 'idb') {
+    if (versionError) throw versionError;
+    return {};
+  }
+
+  // IDB releases in the wild do not consistently implement --version. Help
+  // is therefore the source of truth, and is deliberately probed even when
+  // --version succeeds. This also lets an older installation advertise a
+  // partial set of input operations without making the whole provider unusable.
+  let help: string;
+  try {
+    help = (await runner.execFile(command, [...args, '--help'], { maxBuffer: 128 * 1024 })).toString('utf8');
+  } catch (error) {
+    throw new Error(`IDB help probe failed${versionError ? ` after version probe: ${error instanceof Error ? error.message : String(error)}` : `: ${error instanceof Error ? error.message : String(error)}`}`);
+  }
+  if (!hasHelpCommand(help, 'ui')) throw new Error('IDB help does not advertise the ui command');
+
+  let uiHelp: string;
+  try {
+    uiHelp = (await runner.execFile(command, [...args, 'ui', '--help'], { maxBuffer: 128 * 1024 })).toString('utf8');
+  } catch (error) {
+    throw new Error(`IDB ui help probe failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const capabilities = new Set<string>();
+  const buttons = new Set<string>();
+  if (hasHelpCommand(help, 'describe')) capabilities.add('describe');
+  if (hasHelpCommand(uiHelp, 'describe-all')) capabilities.add('describe-all');
+  if (hasHelpCommand(uiHelp, 'tap')) capabilities.add('tap');
+  if (hasHelpCommand(uiHelp, 'text')) capabilities.add('text');
+  if (hasHelpCommand(uiHelp, 'swipe')) capabilities.add('swipe');
+  if (hasHelpCommand(uiHelp, 'button')) capabilities.add('button');
+
+  // Long press and timed swipe depend on their operation-specific option.
+  // Probe these read-only help pages independently so a provider can retain
+  // the capabilities it does support when one command is incomplete.
+  if (capabilities.has('tap')) {
+    const tapHelp = await readOperationHelp(runner, command, args, 'tap');
+    if (tapHelp && /(?:^|\s)--duration(?:\s|$)/m.test(tapHelp)) capabilities.add('long_press');
+  }
+  if (capabilities.has('swipe')) {
+    const swipeHelp = await readOperationHelp(runner, command, args, 'swipe');
+    if (swipeHelp && /(?:^|\s)--duration(?:\s|$)/m.test(swipeHelp)) capabilities.add('swipe-duration');
+  }
+  if (capabilities.has('button')) {
+    const buttonHelp = await readOperationHelp(runner, command, args, 'button');
+    for (const button of ['APPLE_PAY', 'HOME', 'LOCK', 'SIDE_BUTTON', 'SIRI']) {
+      if (buttonHelp && new RegExp(`(?:\\{|,|\\s)${button}(?=,|\\}|\\s|$)`, 'm').test(buttonHelp)) buttons.add(button.toLowerCase());
+    }
+  }
+  return { capabilities, buttons };
+}
+
+function hasHelpCommand(help: string, command: string): boolean {
+  return new RegExp(`(?:\\{|,|\\s)${command.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}(?=,|\\}|\\s|$)`, 'mi').test(help);
+}
+
+async function readOperationHelp(
+  runner: NativeCommandRunner,
+  command: string,
+  args: string[],
+  operation: string,
+): Promise<string | null> {
+  try {
+    return (await runner.execFile(command, [...args, 'ui', operation, '--help'], { maxBuffer: 128 * 1024 })).toString('utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function commandExists(runner: NativeCommandRunner, command: string): Promise<boolean> {
+  try {
+    await runner.execFile('which', [command], { maxBuffer: 16 * 1024 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function result(
+  backend: NativeDispatchResult['backend'],
+  status: NativeDispatchResult['status'],
+  dispatched = false,
+  message?: string,
+  dispatch: NativeDispatchResult['dispatch'] = dispatched ? 'submitted' : 'not-sent',
+): NativeDispatchResult {
+  return { backend, status, dispatched, dispatch, ...(message ? { message } : {}) };
+}
+
+function dispatchEvidence(inputDispatched: unknown): NativeDispatchResult['dispatch'] {
+  return inputDispatched === true ? 'submitted' : inputDispatched === false ? 'not-sent' : 'unknown';
+}
+
+export class NativeInputController {
+  private readonly config: Required<NativeInputConfig>;
+  private session: SimViewSession | null = null;
+  private pendingSession: Promise<SimViewSession> | null = null;
+  private providers: Provider[] | null = null;
+  private cleanupRegistered = false;
+  private cleanupPromise: Promise<void> | null = null;
+  private closed = false;
+  private actionQueue: Promise<void> = Promise.resolve();
+  /** Track resources before connecting so shutdown can abort a pending handshake. */
+  private readonly resources = new Set<SimViewResource>();
+
+  constructor(private readonly options: NativeInputOptions) {
+    this.config = configValue(options.config);
+    this.registerCleanup();
+  }
+
+  async providersFor(target: NativeInputTarget): Promise<Provider[]> {
+    if (!this.providers) this.providers = await discoverNativeProviders(this.options);
+    return this.providers.filter((provider) =>
+      this.config.nativeBackend === 'auto' || provider.kind === this.config.nativeBackend,
+    ).filter((provider) => target.platform === 'ios' || provider.kind === 'simview');
+  }
+
+  async tap(target: NativeInputTarget, x: number, y: number): Promise<NativeDispatchResult> {
+    if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+    if (target.platform === 'android') {
+      return this.adb(target, ['shell', 'input', 'tap', String(x), String(y)], 'tap');
+    }
+    return this.dispatchSimViewOrIdb(target, 'tap', { x, y });
+  }
+
+  /** Locate a label through IDB's supported accessibility dump and tap its center. */
+  async tapLabel(target: NativeInputTarget, label: string): Promise<NativeDispatchResult> {
+    if (this.closed) return result('none', 'unavailable', false, 'Native input controller is closed');
+    if (target.platform !== 'ios') return result('none', 'unsupported', false, 'Label lookup is only available through IDB on iOS');
+    const providers = await this.providersFor(target);
+    const simview = providers.find((candidate) => candidate.kind === 'simview' && candidate.available);
+    if (simview) {
+      const semantic = await this.simviewLabel(target, label, simview);
+      if (semantic.status !== 'unavailable' && semantic.status !== 'unsupported') return semantic;
+    }
+    const provider = providers.find((candidate) => candidate.kind === 'idb' && candidate.available);
+    if (!provider) return result('none', 'unavailable', false, 'IDB is not installed for accessibility label lookup');
+    if (!provider.capabilities?.has('describe-all')) return result('idb', 'unsupported', false, 'IDB does not advertise accessibility descriptions');
+    try {
+      const dump = await this.options.runner.execFile(provider.command, [...provider.args, 'ui', 'describe-all', '--udid', target.id, '--json'], { maxBuffer: 2 * 1024 * 1024 });
+      const match = findAccessibilityPoint(dump.toString('utf8'), label);
+      if (!match.point) return result('idb', 'failed', false, match.ambiguous ? `Element "${label}" is ambiguous` : `Element "${label}" was not found by IDB`);
+      return this.idb(target, 'tap', match.point, provider);
+    } catch (error) {
+      return result('idb', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+    }
+  }
+
+  private async simviewLabel(target: NativeInputTarget, label: string, provider: Provider): Promise<NativeDispatchResult> {
+    if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
+    try {
+      return this.withActionQueue(async () => {
+        const session = await this.getSession(target, provider);
+        return this.withSessionQueue(session, async () => {
+          try {
+            await this.refreshSession(session);
+          } catch (error) {
+            await this.invalidateSession(session);
+            throw error;
+          }
+          if (!session.tools.has('find_elements') || !session.tools.has('tap_element')) return result('simview', 'unsupported', false, 'SimView does not provide semantic label input');
+          const searchResponse = await session.client.callTool({ name: 'find_elements', arguments: { name: label, exact: true } });
+          if (searchResponse.isError) return result('simview', 'unavailable', false, 'SimView semantic search is unavailable');
+          const found = readStructuredResult(searchResponse);
+          const matches = Array.isArray(found.matches) ? found.matches : [];
+          const refs = matches.map((match) => {
+            if (!match || typeof match !== 'object') return undefined;
+            const value = match as Record<string, unknown>;
+            const element = value.element && typeof value.element === 'object' ? value.element as Record<string, unknown> : value;
+            return element.ref;
+          }).filter((ref): ref is string => typeof ref === 'string');
+          if (refs.length === 0) return result('simview', 'unsupported', false, `Element "${label}" was not found by SimView`);
+          if (refs.length !== 1) return result('simview', 'failed', false, `Element "${label}" is ambiguous`);
+          const tapResponse = await session.client.callTool({ name: 'tap_element', arguments: { ref: refs[0] } });
+          const tapped = readStructuredResult(tapResponse);
+          const interaction = tapped.interaction && typeof tapped.interaction === 'object'
+            ? tapped.interaction as Record<string, unknown>
+            : undefined;
+          const accepted = interaction?.accepted;
+          const inputDispatched = typeof interaction?.inputDispatched === 'boolean'
+            ? interaction.inputDispatched
+            : tapped.inputDispatched;
+          const dispatched = inputDispatched === true;
+          if (tapResponse.isError) return result('simview', 'failed', dispatched, 'SimView semantic tap result is uncertain', dispatched ? 'submitted' : 'unknown');
+          if (interaction?.safeToContinue === false || tapped.safeToContinue === false) {
+            return result(
+              'simview',
+              'failed',
+              dispatched,
+              'SimView reported that it is unsafe to continue after the semantic tap',
+              dispatchEvidence(inputDispatched),
+            );
+          }
+          if (accepted === false) return result('simview', 'failed', dispatched, 'SimView rejected the semantic tap', dispatched ? 'submitted' : 'not-sent');
+          if (accepted !== true || inputDispatched !== true) return result('simview', 'failed', dispatched, 'SimView returned no complete semantic action receipt', dispatched ? 'submitted' : 'unknown');
+          return result('simview', 'handled', true);
+        });
+      });
+    } catch (error) {
+      return result('simview', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+    }
+  }
+
+  async typeText(target: NativeInputTarget, text: string): Promise<NativeDispatchResult> {
+    if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+    if (target.platform === 'android') {
+      // ADB parses this argument through the device shell; encode it once here.
+      return this.adb(target, ['shell', 'input', 'text', encodeAdbInputText(text)], 'type text');
+    }
+    return this.dispatchSimViewOrIdb(target, 'type_text', { text });
+  }
+
+  async longPress(target: NativeInputTarget, x: number, y: number, duration: number): Promise<NativeDispatchResult> {
+    if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+    if (target.platform === 'android') {
+      return this.adb(target, ['shell', 'input', 'swipe', String(x), String(y), String(x), String(y), String(duration)], 'long press');
+    }
+    return this.dispatchSimViewOrIdb(target, 'long_press', { x, y, durationMs: duration });
+  }
+
+  async swipe(target: NativeInputTarget, from: { x: number; y: number }, to: { x: number; y: number }, duration: number): Promise<NativeDispatchResult> {
+    if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+    if (target.platform === 'android') {
+      return this.adb(target, ['shell', 'input', 'swipe', String(from.x), String(from.y), String(to.x), String(to.y), String(duration)], 'swipe');
+    }
+    return this.dispatchSimViewOrIdb(target, 'swipe', { from, to, durationMs: duration });
+  }
+
+  async swipeDirection(target: NativeInputTarget, direction: 'up' | 'down' | 'left' | 'right', duration: number): Promise<NativeDispatchResult> {
+    if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+    return this.withActionQueue(async () => {
+      if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+      const geometry = await this.geometry(target);
+      if (!geometry) return result('none', 'unavailable', false, 'Device geometry is unavailable; refusing to guess swipe coordinates');
+      const { width, height } = geometry;
+      const insetX = width * 0.2;
+      const insetY = height * 0.25;
+      let from: { x: number; y: number };
+      let to: { x: number; y: number };
+      if (direction === 'left' || direction === 'right') {
+        from = { x: direction === 'left' ? width * 0.8 : insetX, y: height / 2 };
+        to = { x: direction === 'left' ? insetX : width * 0.8, y: height / 2 };
+      } else {
+        from = { x: width / 2, y: direction === 'up' ? height * 0.75 : insetY };
+        to = { x: width / 2, y: direction === 'up' ? insetY : height * 0.75 };
+      }
+      if (target.platform === 'android') return this.adb(target, ['shell', 'input', 'swipe', String(from.x), String(from.y), String(to.x), String(to.y), String(duration)], 'swipe');
+      return this.dispatchSimViewOrIdb(target, 'swipe', { from, to, durationMs: duration }, true);
+    });
+  }
+
+  private async geometry(target: NativeInputTarget): Promise<{ width: number; height: number } | null> {
+    if (target.platform === 'android') {
+      try {
+        const output = (await this.options.runner.execFile('adb', ['-s', target.id, 'shell', 'wm', 'size'], { maxBuffer: 16 * 1024 })).toString('utf8');
+        const matches = [...output.matchAll(/(Override|Physical) size:\s*(\d+)x(\d+)/gi)];
+        const match = matches.findLast((entry) => entry[1]?.toLowerCase() === 'override') ?? matches.at(-1);
+        return match ? { width: Number(match[2]), height: Number(match[3]) } : null;
+      } catch { return null; }
+    }
+    const providers = await this.providersFor(target);
+    const simview = providers.find((provider) => provider.kind === 'simview' && provider.available);
+    if (simview) {
+      try {
+        const session = await this.getSession(target, simview);
+        await this.refreshSession(session);
+        return { width: session.width, height: session.height };
+      } catch (error) {
+        if (this.session) await this.invalidateSession(this.session);
+        /* Try IDB when SimView is unavailable. */
+      }
+    }
+    const idb = providers.find((provider) => provider.kind === 'idb' && provider.available);
+    if (!idb || !idb.capabilities?.has('describe')) return null;
+    try {
+      const output = await this.options.runner.execFile(idb.command, [...idb.args, 'describe', '--udid', target.id, '--json'], { maxBuffer: 128 * 1024 });
+      const parsed = JSON.parse(output.toString('utf8')) as Record<string, unknown>;
+      const dimensions = (parsed.screen_dimensions ?? parsed.screenDimensions) as Record<string, unknown> | undefined;
+      const width = Number(dimensions?.width_points ?? dimensions?.widthPoints);
+      const height = Number(dimensions?.height_points ?? dimensions?.heightPoints);
+      return Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0 ? { width, height } : null;
+    } catch { return null; }
+  }
+
+  async button(target: NativeInputTarget, button: string): Promise<NativeDispatchResult> {
+    if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+    if (target.platform === 'android') {
+      const keycodes: Record<string, string> = {
+        HOME: '3', BACK: '4', VOLUME_UP: '24', VOLUME_DOWN: '25', POWER: '26', ENTER: '66', DELETE: '67',
+      };
+      const code = keycodes[button];
+      return code ? this.adb(target, ['shell', 'input', 'keyevent', code], `press ${button}`) : result('adb', 'unsupported', false, `Unsupported Android button ${button}`);
+    }
+    const simviewButton: Record<string, string> = { HOME: 'home', POWER: 'lock', VOLUME_UP: 'volume-up', VOLUME_DOWN: 'volume-down' };
+    const selected = simviewButton[button];
+    if (!selected) return result('none', 'unsupported', false, `Unsupported iOS button ${button}`);
+    return this.dispatchSimViewOrIdb(target, 'press_button', { button: selected });
+  }
+
+  private async adb(target: NativeInputTarget, args: string[], description: string): Promise<NativeDispatchResult> {
+    try {
+      await this.options.runner.execFile('adb', ['-s', target.id, ...args], { maxBuffer: 64 * 1024 });
+      return result('adb', 'handled', true, `${description} dispatched to ${target.id}`);
+    } catch (error) {
+      return result('adb', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+    }
+  }
+
+  private async dispatchSimViewOrIdb(target: NativeInputTarget, operation: string, args: Record<string, unknown>, inActionQueue = false): Promise<NativeDispatchResult> {
+    const providers = await this.providersFor(target);
+    let fallback: NativeDispatchResult | undefined;
+    for (const provider of providers) {
+      if (!provider.available) continue;
+      const dispatched = provider.kind === 'simview'
+        ? await this.simview(target, operation, args, provider, inActionQueue)
+        : await this.idb(target, operation, args, provider);
+      if (dispatched.status === 'unavailable' || dispatched.status === 'unsupported') {
+        fallback = dispatched;
+        continue;
+      }
+      return dispatched;
+    }
+    return fallback ?? result('none', 'unavailable', false, 'No supported native input provider is installed');
+  }
+
+  private async idb(target: NativeInputTarget, operation: string, args: Record<string, unknown>, provider: Provider): Promise<NativeDispatchResult> {
+    let capability: string;
+    switch (operation) {
+      case 'long_press': capability = 'long_press'; break;
+      case 'swipe': capability = 'swipe-duration'; break;
+      case 'type_text': capability = 'text'; break;
+      case 'press_button': capability = 'button'; break;
+      default: capability = 'tap'; break;
+    }
+    if (!provider.capabilities?.has(capability)) {
+      return result('idb', 'unsupported', false, `IDB does not advertise ${operation}`);
+    }
+    const common = ['--udid', target.id];
+    // IDB's CLI accepts integer logical device points for taps and swipes.
+    const pointArgument = (value: unknown) => String(Math.round(Number(value)));
+    let command: string[];
+    switch (operation) {
+      case 'tap': command = ['ui', 'tap', pointArgument(args.x), pointArgument(args.y), ...common]; break;
+      case 'long_press': command = ['ui', 'tap', pointArgument(args.x), pointArgument(args.y), '--duration', String(Number(args.durationMs) / 1000), ...common]; break;
+      case 'swipe': {
+        const from = args.from as { x: number; y: number };
+        const to = args.to as { x: number; y: number };
+        command = ['ui', 'swipe', pointArgument(from.x), pointArgument(from.y), pointArgument(to.x), pointArgument(to.y), '--duration', String(Number(args.durationMs) / 1000), ...common]; break;
+      }
+      case 'type_text':
+        if ([...String(args.text)].some((character) => (character.codePointAt(0) ?? 0) > 0x7f)) return result('idb', 'unsupported', false, 'IDB text input only supports ASCII');
+        command = ['ui', 'text', String(args.text), ...common];
+        break;
+      case 'press_button': {
+        const idbButton: Record<string, string> = { home: 'HOME', lock: 'LOCK' };
+        const button = idbButton[String(args.button)];
+        if (!button || !provider.buttons?.has(button.toLowerCase())) return result('idb', 'unsupported', false, `IDB cannot press ${String(args.button)}`);
+        command = ['ui', 'button', button, ...common]; break;
+      }
+      default: return result('idb', 'unsupported');
+    }
+    try {
+      await this.options.runner.execFile(provider.command, [...provider.args, ...command], { maxBuffer: 256 * 1024 });
+      return result('idb', 'handled', true);
+    } catch (error) {
+      return result('idb', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+    }
+  }
+
+  private simview(target: NativeInputTarget, operation: string, args: Record<string, unknown>, provider: Provider, inActionQueue = false): Promise<NativeDispatchResult> {
+    return inActionQueue
+      ? this.simviewInternal(target, operation, args, provider)
+      : this.withActionQueue(() => this.simviewInternal(target, operation, args, provider));
+  }
+
+  private async simviewInternal(target: NativeInputTarget, operation: string, args: Record<string, unknown>, provider: Provider): Promise<NativeDispatchResult> {
+    if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
+    let session: SimViewSession;
+    try {
+      session = await this.getSession(target, provider);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return message.includes('could not connect')
+        ? result('simview', 'failed', false, message, 'unknown')
+        : result('simview', 'unavailable', false, message);
+    }
+    return this.withSessionQueue(session, async () => {
+      if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
+      try {
+        await this.refreshSession(session);
+      } catch (error) {
+        await this.invalidateSession(session);
+        return result('simview', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+      }
+      const tool = operation === 'long_press' ? 'long_press' : operation;
+      const input = session.capabilities.input as Record<string, unknown> | undefined;
+      if (!session.tools.has(tool)) return result('simview', 'unsupported', false, `SimView does not provide ${tool}`);
+      if (operation === 'type_text') {
+        const supportsText = input?.text === 'ascii' || input?.text === 'unicode';
+        const requiresUnicode = /[^\x00-\x7F]/u.test(String(args.text));
+        if (!supportsText || (input?.text === 'ascii' && requiresUnicode)) {
+          return result('simview', 'unsupported', false, 'SimView does not support this text input');
+        }
+      }
+      if ((operation === 'tap' || operation === 'long_press' || operation === 'swipe') && input?.touch !== true) return result('simview', 'unsupported', false, 'SimView does not support touch input');
+      if (operation === 'press_button' && (!Array.isArray(input?.buttons) || !input.buttons.includes(args.button))) return result('simview', 'unsupported', false, `SimView does not support button ${String(args.button)}`);
+      const normalized = this.normalizeArgs(operation, args, session.width, session.height);
+      try {
+        const response = await session.client.callTool({ name: tool, arguments: normalized });
+        const structured = readStructuredResult(response);
+        const interaction = structured.interaction && typeof structured.interaction === 'object'
+          ? structured.interaction as Record<string, unknown>
+          : undefined;
+        const accepted = typeof interaction?.accepted === 'boolean' ? interaction.accepted : structured.accepted;
+        const inputDispatched = typeof interaction?.inputDispatched === 'boolean'
+          ? interaction.inputDispatched
+          : typeof structured.inputDispatched === 'boolean' ? structured.inputDispatched : undefined;
+        const dispatched = inputDispatched === true;
+        if (response.isError) return result('simview', 'failed', dispatched, 'SimView action result is uncertain', dispatched ? 'submitted' : 'unknown');
+        if (interaction?.safeToContinue === false || structured.safeToContinue === false) {
+          return result(
+            'simview',
+            'failed',
+            dispatched,
+            'SimView reported that it is unsafe to continue after the action',
+            dispatchEvidence(inputDispatched),
+          );
+        }
+        if (accepted === false) return result('simview', 'failed', dispatched, 'SimView rejected the action', dispatched ? 'submitted' : 'not-sent');
+        if (accepted === true && inputDispatched === false) return result('simview', 'failed', false, 'SimView accepted the request without dispatching input');
+        if (accepted !== true) return result('simview', 'failed', dispatched, 'SimView returned no accepted action receipt', dispatched ? 'submitted' : 'unknown');
+        return result('simview', 'handled', true);
+      } catch (error) {
+        return result('simview', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+      }
+    });
+  }
+
+  private normalizeArgs(operation: string, args: Record<string, unknown>, width: number, height: number): Record<string, unknown> {
+    const point = (x: number, y: number) => normalizeLogicalPoint({ x, y }, width, height);
+    if (operation === 'tap' || operation === 'long_press') return { ...point(Number(args.x), Number(args.y)), ...(operation === 'long_press' ? { durationMs: args.durationMs } : {}) };
+    if (operation === 'swipe') {
+      const from = args.from as { x: number; y: number }; const to = args.to as { x: number; y: number };
+      return { from: point(from.x, from.y), to: point(to.x, to.y), durationMs: args.durationMs };
+    }
+    return args;
+  }
+
+  private async getSession(target: NativeInputTarget, provider: Provider): Promise<SimViewSession> {
+    if (this.closed) throw new Error('Native input controller is closed');
+    const deviceId = `${target.platform}:${target.id}`;
+    if (this.session) {
+      if (this.session.closed) this.session = null;
+      else if (this.session.deviceId === deviceId) return this.session;
+    }
+    if (this.session) {
+      const session = this.session;
+      return this.withSessionQueue(session, async () => {
+        if (this.closed) throw new Error('Native input controller is closed');
+        const switched = await session.client.callTool({ name: 'connect_device', arguments: { deviceId, observationMode: 'semantic' } });
+        if (switched.isError) throw new Error(`SimView could not connect to ${deviceId}`);
+        session.deviceId = deviceId;
+        try {
+          await this.refreshSession(session);
+          return session;
+        } catch (error) {
+          await this.invalidateSession(session);
+          throw error;
+        }
+      });
+    }
+    if (this.pendingSession) return this.pendingSession.then(() => this.getSession(target, provider));
+    this.pendingSession = this.createSession(target, provider);
+    try { return await this.pendingSession; } finally { this.pendingSession = null; }
+  }
+
+  private async createSession(target: NativeInputTarget, provider: Provider): Promise<SimViewSession> {
+    const deviceId = `${target.platform}:${target.id}`;
+    const mcpArgs = provider.args.at(-1) === 'mcp' ? provider.args : [...provider.args, 'mcp'];
+    const created = this.options.simviewClientFactory?.(provider.command, mcpArgs);
+    const transport = created?.transport ?? new StdioClientTransport({ command: provider.command, args: mcpArgs, stderr: 'pipe' });
+    const client: SimViewClientLike = created?.client ?? new Client({ name: 'metro-mcp', version: '0.15.0' }, { capabilities: {} });
+    const resource: SimViewResource = { client, transport, closePromise: null };
+    this.resources.add(resource);
+    try {
+      await client.connect(transport);
+      if (this.closed) throw new Error('Native input controller is closed');
+      const tools = await client.listTools();
+      if (this.closed) throw new Error('Native input controller is closed');
+      if (!tools.tools.some((tool) => tool.name === 'connect_device')) throw new Error('SimView MCP server does not provide connect_device');
+      const connected = await client.callTool({ name: 'connect_device', arguments: { deviceId, observationMode: 'semantic' } });
+      if (this.closed) throw new Error('Native input controller is closed');
+      if (connected.isError) throw new Error('SimView could not connect to the selected device');
+      const state = await client.callTool({ name: 'get_simview_state', arguments: {} });
+      if (this.closed) throw new Error('Native input controller is closed');
+      const session = await this.sessionFromState(resource, deviceId, tools.tools.map((tool) => tool.name), state);
+      if (this.closed) throw new Error('Native input controller is closed');
+      this.session = session;
+      return session;
+    } catch (error) {
+      await settleWithin(this.closeResource(resource));
+      throw error;
+    }
+  }
+
+  private async sessionFromState(
+    resource: SimViewResource,
+    deviceId: string,
+    toolNames: string[],
+    state: SimViewCallResult,
+  ): Promise<SimViewSession> {
+    const { client, transport } = resource;
+    if (this.closed) throw new Error('Native input controller is closed');
+    const structured = readStructuredResult(state);
+    const device = structured.device as Record<string, unknown> | undefined;
+    if (!device || device.id !== deviceId) {
+      throw new Error(`SimView selected unexpected device ${String(device?.id ?? 'unknown')}`);
+    }
+    const stateWidth = positiveNumber(device.pointWidth, 0);
+    const stateHeight = positiveNumber(device.pointHeight, 0);
+    const capabilities = device?.capabilities as Record<string, unknown> | undefined;
+    if (!capabilities) throw new Error('SimView did not report device capabilities');
+    let width = stateWidth;
+    let height = stateHeight;
+    if (toolNames.includes('observe_screen')) {
+      if (this.closed) throw new Error('Native input controller is closed');
+      const observation = await client.callTool({ name: 'observe_screen', arguments: { mode: 'semantic' } });
+      if (observation.isError) throw new Error('SimView did not report a semantic observation for device geometry');
+      const observed = extractObservationGeometry(readStructuredResult(observation));
+      if (observed) {
+        width = observed.width;
+        height = observed.height;
+      }
+    }
+    if (!width || !height) throw new Error('SimView did not report logical device geometry');
+    return { client, transport, resource, deviceId, width, height, capabilities, tools: new Set(toolNames), queue: Promise.resolve(), closed: false };
+  }
+
+  private async refreshSession(session: SimViewSession): Promise<void> {
+    if (session.closed) throw new Error('SimView session is closed');
+    const state = await session.client.callTool({ name: 'get_simview_state', arguments: {} });
+    if (state.isError) throw new Error('SimView could not refresh the selected device state');
+    const refreshed = await this.sessionFromState(session.resource, session.deviceId, [...session.tools], state);
+    session.width = refreshed.width;
+    session.height = refreshed.height;
+    session.capabilities = refreshed.capabilities;
+  }
+
+  private async invalidateSession(session: SimViewSession): Promise<void> {
+    if (session.closed) return;
+    session.closed = true;
+    if (this.session === session) this.session = null;
+    await this.closeResource(session.resource);
+  }
+
+  private async withSessionQueue<T>(session: SimViewSession, operation: () => Promise<T>): Promise<T> {
+    const prior = session.queue;
+    let release!: () => void;
+    session.queue = new Promise<void>((resolve) => { release = resolve; });
+    await prior;
+    try { return await operation(); } finally { release(); }
+  }
+
+  private async withActionQueue<T>(operation: () => Promise<T>): Promise<T> {
+    const prior = this.actionQueue;
+    let release!: () => void;
+    this.actionQueue = new Promise<void>((resolve) => { release = resolve; });
+    await prior;
+    try { return await operation(); } finally { release(); }
+  }
+
+  private registerCleanup(): void {
+    if (this.cleanupRegistered || !this.options.registerCleanup) return;
+    this.cleanupRegistered = true;
+    this.options.registerCleanup(() => this.close());
+  }
+
+  async close(): Promise<void> {
+    if (this.cleanupPromise) return this.cleanupPromise;
+    this.closed = true;
+    const session = this.session;
+    const resources = [...this.resources];
+    if (session) {
+      session.closed = true;
+      this.session = null;
+    }
+    this.cleanupPromise = (async () => {
+      // Mark the session closed before starting transport teardown. This lets
+      // an invalidateSession racing with cleanup observe the guard and avoid a
+      // second close while the client call that is being interrupted drains.
+      // Close every owned client first, including a client still blocked in
+      // connect/listTools/callTool. The bounded wait keeps plugin shutdown
+      // from inheriting a provider that never settles.
+      await Promise.all(resources.map((resource) => settleWithin(this.closeResource(resource))));
+      await settleWithin(this.actionQueue.catch(() => {}));
+      if (session) await settleWithin(session.queue.catch(() => {}));
+    })();
+    return this.cleanupPromise;
+  }
+
+  private async closeResource(resource: SimViewResource): Promise<void> {
+    if (!resource.closePromise) {
+      resource.closePromise = closeSimView(resource.client, resource.transport);
+      void resource.closePromise.then(
+        () => this.resources.delete(resource),
+        () => this.resources.delete(resource),
+      );
+    }
+    await resource.closePromise;
+  }
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Encode one argument for Android's remote `input text` shell parser. */
+function encodeAdbInputText(text: string): string {
+  const encoded = text.replace(/ /g, '%s');
+  return `'${encoded.replace(/'/g, `'\\''`)}'`;
+}
+
+function extractObservationGeometry(structured: Record<string, unknown>): { width: number; height: number } | null {
+  const candidates: unknown[] = [
+    structured.viewport,
+    structured.screen,
+    (structured.snapshot as Record<string, unknown> | undefined)?.screen,
+    (structured.elements as Record<string, unknown> | undefined)?.screen,
+    (structured.screenContext as Record<string, unknown> | undefined)?.viewport,
+    (structured.screenContext as Record<string, unknown> | undefined)?.screen,
+  ];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const value = candidate as Record<string, unknown>;
+    const width = positiveNumber(value.width ?? value.pointWidth, 0);
+    const height = positiveNumber(value.height ?? value.pointHeight, 0);
+    if (width > 0 && height > 0) return { width, height };
+  }
+  return null;
+}
+
+async function closeSimView(client: SimViewClientLike, transport: SimViewTransportLike): Promise<void> {
+  // Resolve each call in its own microtask so a synchronous close failure
+  // cannot prevent the transport from receiving its abort signal.
+  await Promise.allSettled([
+    Promise.resolve().then(() => client.close()),
+    Promise.resolve().then(() => transport.close()),
+  ]);
+}
+
+async function settleWithin(promise: Promise<unknown>, timeoutMs = 500): Promise<void> {
+  await Promise.race([promise.then(() => undefined, () => undefined), new Promise<void>((resolve) => setTimeout(resolve, timeoutMs))]);
+}
+
+function readStructuredResult(value: SimViewCallResult): Record<string, unknown> {
+  if (value.structuredContent && typeof value.structuredContent === 'object')
+    return value.structuredContent as Record<string, unknown>;
+  const text = value.content?.find((block) => block.type === 'text')?.text;
+  if (!text) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function findAccessibilityPoint(raw: string, label: string): { point: { x: number; y: number } | null; ambiguous: boolean } {
+  let values: unknown[];
+  try { values = [JSON.parse(raw)]; } catch {
+    values = raw.split(/\r?\n/).flatMap((line) => { try { return [JSON.parse(line)]; } catch { return []; } });
+  }
+  const stack: unknown[] = [...values];
+  const points: Array<{ x: number; y: number }> = [];
+  while (stack.length) {
+    const value = stack.pop();
+    if (!value || typeof value !== 'object') continue;
+    if (Array.isArray(value)) { stack.push(...value); continue; }
+    const object = value as Record<string, unknown>;
+    const names = [object.label, object.name, object.title, object.value, object.accessibilityLabel];
+    if (names.some((name) => name === label)) {
+      const frame = object.frame ?? object.bounds ?? object.rect;
+      if (frame && typeof frame === 'object') {
+        const f = frame as Record<string, unknown>;
+        const x = Number(f.x ?? f.minX); const y = Number(f.y ?? f.minY);
+        const width = Number(f.width ?? f.w ?? (Number(f.maxX) - x));
+        const height = Number(f.height ?? f.h ?? (Number(f.maxY) - y));
+        if ([x, y, width, height].every(Number.isFinite)) points.push({ x: x + width / 2, y: y + height / 2 });
+      }
+    }
+    stack.push(...Object.values(object));
+  }
+  return { point: points.length === 1 ? points[0] : null, ambiguous: points.length > 1 };
+}

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -394,7 +394,10 @@ export class NativeInputController {
       if (!match.point) return result('idb', 'failed', false, match.ambiguous ? `Element "${label}" is ambiguous` : `Element "${label}" was not found by IDB`);
       return this.idb(target, 'tap', match.point, provider);
     } catch (error) {
-      return result('idb', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+      // The accessibility dump is performed before the tap command. A failed
+      // describe-all therefore cannot have dispatched input and is safe to
+      // report as not-sent for callers deciding whether to retry or fall back.
+      return result('idb', 'failed', false, error instanceof Error ? error.message : String(error), 'not-sent');
     }
   }
 

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -778,6 +778,10 @@ export class NativeInputController {
       }
       if ((operation === 'tap' || operation === 'long_press' || operation === 'swipe') && input?.touch !== true) return result('simview', 'unsupported', false, 'SimView does not support touch input');
       if (operation === 'press_button' && (!Array.isArray(input?.buttons) || !input.buttons.includes(args.button))) return result('simview', 'unsupported', false, `SimView does not support button ${String(args.button)}`);
+      // SimView 0.4.0 exposes press_key without a per-device key list. Newer
+      // versions advertise one, so honor it when present while retaining
+      // compatibility with that public release.
+      if (operation === 'press_key' && Array.isArray(input?.keys) && !input.keys.includes(args.key)) return result('simview', 'unsupported', false, `SimView does not support key ${String(args.key)}`);
       const normalized = this.normalizeArgs(operation, args, session.width, session.height);
       try {
         const response = await session.client.callTool({ name: tool, arguments: normalized });

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -447,6 +447,7 @@ export class NativeInputController {
   private cleanupPromise: Promise<void> | null = null;
   private closed = false;
   private actionQueue: Promise<void> = Promise.resolve();
+  private nextAndroidDumpId = 0;
   /** Track resources before connecting so shutdown can abort a pending handshake. */
   private readonly resources = new Set<SimViewResource>();
   private readonly simviewRequestTimeoutMs: number;
@@ -496,10 +497,10 @@ export class NativeInputController {
     return this.dispatchSimViewOrIdb(target, 'tap', { x, y });
   }
 
-  /** Locate a label through IDB's supported accessibility dump and tap its center. */
+  /** Locate a label through a native accessibility dump and tap its center. */
   async tapLabel(target: NativeInputTarget, label: string): Promise<NativeDispatchResult> {
-    if (this.closed) return result('none', 'unavailable', false, 'Native input controller is closed');
-    if (target.platform !== 'ios') return result('none', 'unsupported', false, 'Label lookup is only available through IDB on iOS');
+    if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
+    if (target.platform === 'android') return this.androidTapLabel(target, label);
     const deadline = this.simviewDeadline();
     const providers = await this.providersFor(target, deadline);
     const simview = providers.find((candidate) => candidate.kind === 'simview' && candidate.available);
@@ -528,6 +529,69 @@ export class NativeInputController {
       // report as not-sent for callers deciding whether to retry or fall back.
       return result('idb', 'failed', false, error instanceof Error ? error.message : String(error), 'not-sent');
     }
+  }
+
+  private async androidTapLabel(
+    target: NativeInputTarget,
+    label: string,
+  ): Promise<NativeDispatchResult> {
+    const deadline = this.simviewDeadline();
+    const dumpPath = `/sdcard/metro-mcp-uidump-${process.pid}-${++this.nextAndroidDumpId}.xml`;
+    let dump: Buffer;
+    try {
+      await boundedExecFile(
+        this.options.runner,
+        'adb',
+        ['-s', target.id, 'shell', 'uiautomator', 'dump', dumpPath],
+        { maxBuffer: 64 * 1024 },
+        deadline,
+      );
+      dump = await boundedExecFile(
+        this.options.runner,
+        'adb',
+        ['-s', target.id, 'exec-out', 'cat', dumpPath],
+        { maxBuffer: 2 * 1024 * 1024 },
+        deadline,
+      );
+    } catch (error) {
+      return result(
+        'adb',
+        'failed',
+        false,
+        error instanceof Error ? error.message : String(error),
+        'not-sent',
+      );
+    } finally {
+      // The dump is no longer needed once the read completes. Start bounded
+      // cleanup without making an unrelated cleanup delay consume tap time.
+      void boundedExecFile(
+        this.options.runner,
+        'adb',
+        ['-s', target.id, 'shell', 'rm', '-f', dumpPath],
+        { maxBuffer: 16 * 1024 },
+        Date.now() + 500,
+      ).catch(() => {});
+    }
+
+    const match = findAndroidAccessibilityPoint(dump.toString('utf8'), label);
+    if (!match.point) {
+      return result(
+        'adb',
+        'failed',
+        false,
+        match.ambiguous ? `Element "${label}" is ambiguous` : `Element "${label}" was not found by uiautomator`,
+        'not-sent',
+      );
+    }
+    if (Date.now() >= deadline) {
+      return result('adb', 'failed', false, 'Android label lookup timed out before tap dispatch', 'not-sent');
+    }
+    return this.adb(
+      target,
+      ['shell', 'input', 'tap', String(match.point.x), String(match.point.y)],
+      `tap "${label}"`,
+      deadline,
+    );
   }
 
   /** Locate a label through semantic providers and long press its frame center. */
@@ -877,14 +941,19 @@ export class NativeInputController {
     return this.dispatchSimViewOrIdb(target, 'press_button', { button: selected });
   }
 
-  private async adb(target: NativeInputTarget, args: string[], description: string): Promise<NativeDispatchResult> {
+  private async adb(
+    target: NativeInputTarget,
+    args: string[],
+    description: string,
+    deadline = this.simviewDeadline(),
+  ): Promise<NativeDispatchResult> {
     try {
       await boundedExecFile(
         this.options.runner,
         'adb',
         ['-s', target.id, ...args],
         { maxBuffer: 64 * 1024 },
-        this.simviewDeadline(),
+        deadline,
       );
       return result('adb', 'handled', true, `${description} dispatched to ${target.id}`);
     } catch (error) {
@@ -1398,6 +1467,56 @@ function findAccessibilityPoint(raw: string, label: string): { point: { x: numbe
     stack.push(...Object.values(object));
   }
   return { point: points.length === 1 ? points[0] : null, ambiguous: points.length > 1 };
+}
+
+function findAndroidAccessibilityPoint(
+  raw: string,
+  label: string,
+): { point: { x: number; y: number } | null; ambiguous: boolean } {
+  const points: Array<{ x: number; y: number }> = [];
+  for (const match of raw.matchAll(/<node\b[^>]*>/gi)) {
+    const node = match[0];
+    const rawText = node.match(/\btext="([^"]*)"/i)?.[1];
+    const rawDescription = node.match(/\bcontent-desc="([^"]*)"/i)?.[1];
+    const text = rawText === undefined ? undefined : decodeXmlAttribute(rawText);
+    const description = rawDescription === undefined
+      ? undefined
+      : decodeXmlAttribute(rawDescription);
+    if (text !== label && description !== label) continue;
+    const bounds = node.match(/\bbounds="\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]"/i);
+    if (!bounds) continue;
+    const left = Number(bounds[1]);
+    const top = Number(bounds[2]);
+    const right = Number(bounds[3]);
+    const bottom = Number(bounds[4]);
+    if (![left, top, right, bottom].every(Number.isFinite)) continue;
+    points.push({
+      x: Math.round((left + right) / 2),
+      y: Math.round((top + bottom) / 2),
+    });
+  }
+  return { point: points.length === 1 ? points[0] : null, ambiguous: points.length > 1 };
+}
+
+function decodeXmlAttribute(value: string): string {
+  return value.replace(
+    /&(amp|lt|gt|quot|apos|#\d+|#x[\da-f]+);/gi,
+    (entity, code: string) => {
+      const named: Record<string, string> = {
+        amp: '&', lt: '<', gt: '>', quot: '"', apos: "'",
+      };
+      const normalized = code.toLowerCase();
+      if (named[normalized] !== undefined) return named[normalized];
+      const numeric = normalized.startsWith('#x')
+        ? Number.parseInt(normalized.slice(2), 16)
+        : Number.parseInt(normalized.slice(1), 10);
+      try {
+        return Number.isInteger(numeric) ? String.fromCodePoint(numeric) : entity;
+      } catch {
+        return entity;
+      }
+    },
+  );
 }
 
 function simViewFrameCenter(value: unknown, width: number, height: number): { x: number; y: number } | null {

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -396,8 +396,9 @@ export class NativeInputController {
 
   private async simviewLabel(target: NativeInputTarget, label: string, provider: Provider): Promise<NativeDispatchResult> {
     if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
+    let inputAttempted = false;
     try {
-      return this.withActionQueue(async () => {
+      return await this.withActionQueue(async () => {
         const session = await this.getSession(target, provider);
         return this.withSessionQueue(session, async () => {
           try {
@@ -419,6 +420,7 @@ export class NativeInputController {
           }).filter((ref): ref is string => typeof ref === 'string');
           if (refs.length === 0) return result('simview', 'unsupported', false, `Element "${label}" was not found by SimView`);
           if (refs.length !== 1) return result('simview', 'failed', false, `Element "${label}" is ambiguous`);
+          inputAttempted = true;
           const tapResponse = await session.client.callTool({ name: 'tap_element', arguments: { ref: refs[0] } });
           const tapped = readStructuredResult(tapResponse);
           const interaction = tapped.interaction && typeof tapped.interaction === 'object'
@@ -445,7 +447,16 @@ export class NativeInputController {
         });
       });
     } catch (error) {
-      return result('simview', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+      // Connecting, refreshing, and searching happen before SimView receives
+      // the semantic tap. IDB may safely take over in auto mode in those
+      // cases; once the tap request was attempted, the dispatch is uncertain.
+      return result(
+        'simview',
+        inputAttempted ? 'failed' : 'unavailable',
+        false,
+        error instanceof Error ? error.message : String(error),
+        inputAttempted ? 'unknown' : 'not-sent',
+      );
     }
   }
 
@@ -628,9 +639,11 @@ export class NativeInputController {
       session = await this.getSession(target, provider);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      return message.includes('could not connect')
-        ? result('simview', 'failed', false, message, 'unknown')
-        : result('simview', 'unavailable', false, message);
+      // A failed handshake happens before SimView receives an input action.
+      // In auto mode this is safe to fall through to IDB; reporting an
+      // unknown dispatch would stop the chain and could strand a working
+      // native backend behind a transient SimView connection failure.
+      return result('simview', 'unavailable', false, message, 'not-sent');
     }
     return this.withSessionQueue(session, async () => {
       if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
@@ -638,7 +651,9 @@ export class NativeInputController {
         await this.refreshSession(session);
       } catch (error) {
         await this.invalidateSession(session);
-        return result('simview', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
+        // Refresh only reads the session/device state and precedes the actual
+        // input call, so a refresh failure cannot have dispatched input.
+        return result('simview', 'unavailable', false, error instanceof Error ? error.message : String(error), 'not-sent');
       }
       const tool = operation === 'long_press' ? 'long_press' : operation;
       const input = session.capabilities.input as Record<string, unknown> | undefined;

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -442,7 +442,11 @@ export class NativeInputController {
   private readonly config: Required<NativeInputConfig>;
   private session: SimViewSession | null = null;
   private pendingSession: Promise<SimViewSession> | null = null;
-  private providers: Provider[] | null = null;
+  // Provider availability is independent of the concrete device, but the
+  // supported provider set depends on the target platform. Keep those
+  // discoveries separate so an Android lookup (where IDB is filtered out)
+  // cannot cache an empty result for a later iOS action.
+  private readonly providers = new Map<NativeInputTarget['platform'], Provider[]>();
   private cleanupRegistered = false;
   private cleanupPromise: Promise<void> | null = null;
   private closed = false;
@@ -483,14 +487,17 @@ export class NativeInputController {
     // provider permanent for the lifetime of the controller. A provider can
     // be installed, added to PATH, or recover from a transient probe failure
     // while the daemon is still running.
-    if (!this.providers || this.providers.some((provider) => !provider.available)) {
-      this.providers = await this.discoverProviders(target, deadline);
+    let providers = this.providers.get(target.platform);
+    if (!providers || providers.some((provider) => !provider.available)) {
+      providers = await this.discoverProviders(target, deadline);
+      this.providers.set(target.platform, providers);
     }
     if (includeFallback && this.config.nativeBackend === 'auto' && target.platform === 'ios'
-      && !this.providers.some((provider) => provider.kind === 'idb')) {
-      this.providers = [...this.providers, ...await discoverNativeProviders(this.options, this.simviewDeadline(), ['idb'])];
+      && !providers.some((provider) => provider.kind === 'idb')) {
+      providers = [...providers, ...await discoverNativeProviders(this.options, this.simviewDeadline(), ['idb'])];
+      this.providers.set(target.platform, providers);
     }
-    return this.providers.filter((provider) =>
+    return providers.filter((provider) =>
       this.config.nativeBackend === 'auto' || provider.kind === this.config.nativeBackend,
     ).filter((provider) => target.platform === 'ios' || provider.kind === 'simview');
   }

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -106,6 +106,9 @@ export function normalizeLogicalPoint(
 }
 
 const SIMVIEW_PLUGIN_CACHE_ROOT = resolve(homedir(), '.codex/plugins/cache');
+// IDB's `ui key` takes USB HID usage IDs. These are the usages for Return and
+// Backspace/Delete in the keyboard page (the same values used by IDB text).
+const IOS_HID_KEY_CODES = { ENTER: 40, DELETE: 42 } as const;
 
 function configValue(config: NativeInputConfig | undefined): Required<NativeInputConfig> {
   return {
@@ -278,6 +281,7 @@ async function probeProvider(
   if (hasHelpCommand(uiHelp, 'text')) capabilities.add('text');
   if (hasHelpCommand(uiHelp, 'swipe')) capabilities.add('swipe');
   if (hasHelpCommand(uiHelp, 'button')) capabilities.add('button');
+  if (hasHelpCommand(uiHelp, 'key')) capabilities.add('key');
 
   // Long press and timed swipe depend on their operation-specific option.
   // Probe these read-only help pages independently so a provider can retain
@@ -650,6 +654,11 @@ export class NativeInputController {
       return code ? this.adb(target, ['shell', 'input', 'keyevent', code], `press ${button}`) : result('adb', 'unsupported', false, `Unsupported Android button ${button}`);
     }
     const simviewButton: Record<string, string> = { HOME: 'home', POWER: 'lock', VOLUME_UP: 'volume-up', VOLUME_DOWN: 'volume-down' };
+    if (button === 'ENTER' || button === 'DELETE') {
+      const key = button === 'ENTER' ? 'return' : 'delete';
+      const hidCode = IOS_HID_KEY_CODES[button];
+      return this.dispatchSimViewOrIdb(target, 'press_key', { key, hidCode });
+    }
     const selected = simviewButton[button];
     if (!selected) return result('none', 'unsupported', false, `Unsupported iOS button ${button}`);
     return this.dispatchSimViewOrIdb(target, 'press_button', { button: selected });
@@ -688,6 +697,7 @@ export class NativeInputController {
       case 'swipe': capability = 'swipe-duration'; break;
       case 'type_text': capability = 'text'; break;
       case 'press_button': capability = 'button'; break;
+      case 'press_key': capability = 'key'; break;
       default: capability = 'tap'; break;
     }
     if (!provider.capabilities?.has(capability)) {
@@ -715,6 +725,8 @@ export class NativeInputController {
         if (!button || !provider.buttons?.has(button.toLowerCase())) return result('idb', 'unsupported', false, `IDB cannot press ${String(args.button)}`);
         command = ['ui', 'button', button, ...common]; break;
       }
+      case 'press_key':
+        command = ['ui', 'key', String(args.hidCode), ...common]; break;
       default: return result('idb', 'unsupported');
     }
     try {
@@ -805,6 +817,7 @@ export class NativeInputController {
       const from = args.from as { x: number; y: number }; const to = args.to as { x: number; y: number };
       return { from: point(from.x, from.y), to: point(to.x, to.y), durationMs: args.durationMs };
     }
+    if (operation === 'press_key') return { key: args.key };
     return args;
   }
 

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -14,8 +14,19 @@ export interface NativeInputConfig {
 }
 
 export interface NativeCommandRunner {
-  execFile(command: string, args: string[], options?: { maxBuffer?: number }): Promise<Buffer>;
+  execFile(command: string, args: string[], options?: { maxBuffer?: number; timeout?: number }): Promise<Buffer>;
   exec(command: string): Promise<string>;
+}
+
+interface SimViewDirectoryEntry {
+  name: string;
+  directory: boolean;
+}
+
+interface SimViewFileSystem {
+  executable(path: string): Promise<boolean>;
+  readDirectory(path: string): Promise<SimViewDirectoryEntry[]>;
+  readFile(path: string): Promise<string>;
 }
 
 export interface NativeInputTarget {
@@ -92,6 +103,10 @@ export interface NativeInputOptions {
     client: SimViewClientLike;
     transport: SimViewTransportLike;
   };
+  /** Internal timeout override for deterministic provider tests. */
+  simviewRequestTimeoutMs?: number;
+  /** Internal filesystem override for deterministic provider discovery tests. */
+  simviewFileSystem?: SimViewFileSystem;
 }
 
 export function normalizeLogicalPoint(
@@ -106,6 +121,7 @@ export function normalizeLogicalPoint(
 }
 
 const SIMVIEW_PLUGIN_CACHE_ROOT = resolve(homedir(), '.codex/plugins/cache');
+const DEFAULT_SIMVIEW_REQUEST_TIMEOUT_MS = 2000;
 // IDB's `ui key` takes USB HID usage IDs. These are the usages for Return and
 // Backspace/Delete in the keyboard page (the same values used by IDB text).
 const IOS_HID_KEY_CODES = { ENTER: 40, DELETE: 42 } as const;
@@ -133,38 +149,76 @@ function unquoteCommandToken(value: string): string {
   return value.startsWith('"') || value.startsWith("'") ? value.slice(1, -1) : value;
 }
 
-async function executable(path: string): Promise<boolean> {
+const defaultSimViewFileSystem: SimViewFileSystem = {
+  executable: async (path) => {
+    try {
+      await access(path, constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  readDirectory: async (path) => (await readdir(path, { withFileTypes: true })).map((entry) => ({ name: entry.name, directory: entry.isDirectory() })),
+  readFile: (path) => readFile(path, 'utf8'),
+};
+
+async function boundedFileSystemOperation<T>(operation: () => Promise<T>, deadline?: number): Promise<T> {
+  const remaining = deadline === undefined ? undefined : deadline - Date.now();
+  if (remaining !== undefined && remaining <= 0) throw new Error('SimView provider discovery timed out');
+  const pending = operation();
+  if (remaining === undefined) return pending;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('SimView provider discovery timed out')), remaining);
+  });
   try {
-    await access(path, constants.X_OK);
-    return true;
+    return await Promise.race([pending, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function executable(path: string, deadline?: number, fileSystem = defaultSimViewFileSystem): Promise<boolean> {
+  try {
+    return await boundedFileSystemOperation(() => fileSystem.executable(path), deadline);
   } catch {
     return false;
   }
 }
 
-async function findSimViewPluginBinaries(roots: string[] = [SIMVIEW_PLUGIN_CACHE_ROOT]): Promise<string[]> {
+async function findSimViewPluginBinaries(
+  roots: string[] = [SIMVIEW_PLUGIN_CACHE_ROOT],
+  deadline?: number,
+  fileSystem = defaultSimViewFileSystem,
+): Promise<string[]> {
   const binaries: string[] = [];
   const seen = new Set<string>();
   const visit = async (root: string, depth: number): Promise<void> => {
-    if (seen.has(root) || depth < 0) return;
+    if (seen.has(root) || depth < 0 || (deadline !== undefined && deadline <= Date.now())) return;
     seen.add(root);
-    if (await executable(join(root, 'bin', 'simview')) && await validateSimViewPlugin(root)) {
+    if (await executable(join(root, 'bin', 'simview'), deadline, fileSystem) && await validateSimViewPlugin(root, deadline, fileSystem)) {
       binaries.push(join(root, 'bin', 'simview'));
       return;
     }
     try {
-      const entries = await readdir(root, { withFileTypes: true });
-      for (const entry of entries.filter((item) => item.isDirectory()).sort((a, b) => b.name.localeCompare(a.name, undefined, { numeric: true }))) await visit(join(root, entry.name), depth - 1);
+      const entries = await boundedFileSystemOperation(() => fileSystem.readDirectory(root), deadline);
+      for (const entry of entries.filter((item) => item.directory).sort((a, b) => b.name.localeCompare(a.name, undefined, { numeric: true }))) {
+        if (deadline !== undefined && deadline <= Date.now()) return;
+        await visit(join(root, entry.name), depth - 1);
+      }
     } catch { /* An uninstalled plugin is an ordinary unavailable provider. */ }
   };
-  for (const root of roots.length ? roots : [SIMVIEW_PLUGIN_CACHE_ROOT]) await visit(root, 3);
+  for (const root of roots.length ? roots : [SIMVIEW_PLUGIN_CACHE_ROOT]) {
+    if (deadline !== undefined && deadline <= Date.now()) break;
+    await visit(root, 3);
+  }
   return binaries;
 }
 
-async function validateSimViewPlugin(root: string): Promise<boolean> {
+async function validateSimViewPlugin(root: string, deadline?: number, fileSystem = defaultSimViewFileSystem): Promise<boolean> {
   try {
-    const manifest = JSON.parse(await readFile(join(root, '.codex-plugin/plugin.json'), 'utf8')) as Record<string, unknown>;
-    const mcp = JSON.parse(await readFile(join(root, '.mcp.json'), 'utf8')) as Record<string, unknown>;
+    const manifest = JSON.parse(await boundedFileSystemOperation(() => fileSystem.readFile(join(root, '.codex-plugin/plugin.json')), deadline)) as Record<string, unknown>;
+    const mcp = JSON.parse(await boundedFileSystemOperation(() => fileSystem.readFile(join(root, '.mcp.json')), deadline)) as Record<string, unknown>;
     const server = (mcp.mcpServers as Record<string, unknown> | undefined)?.simview as Record<string, unknown> | undefined;
     const command = server?.command;
     const args = server?.args;
@@ -180,6 +234,7 @@ async function validateSimViewPlugin(root: string): Promise<boolean> {
  */
 export async function discoverNativeProviders(
   options: NativeInputOptions,
+  deadline?: number,
 ): Promise<Provider[]> {
   const config = configValue(options.config);
   const result: Provider[] = [];
@@ -192,11 +247,13 @@ export async function discoverNativeProviders(
 
   for (const candidate of candidates) {
     let parts = commandParts(candidate.command);
+    const fileSystem = candidate.kind === 'simview' ? options.simviewFileSystem ?? defaultSimViewFileSystem : defaultSimViewFileSystem;
+    const discoveryDeadline = candidate.kind === 'simview' ? deadline : undefined;
     if (candidate.explicit) {
       const tokens = commandTokens(candidate.command);
       for (let index = tokens.length; index > 0; index--) {
         const possiblePath = tokens.slice(0, index).map(unquoteCommandToken).join(' ');
-        if (await executable(possiblePath)) {
+        if (await executable(possiblePath, discoveryDeadline, fileSystem)) {
           parts = { command: possiblePath, args: tokens.slice(index).map(unquoteCommandToken) };
           break;
         }
@@ -208,11 +265,21 @@ export async function discoverNativeProviders(
           ...(options.projectRoot ? [join(options.projectRoot, 'node_modules/.bin', parts.command)] : []),
           ...(options.projectRoot ? [join(options.projectRoot, parts.command)] : []),
           parts.command,
-          ...(candidate.kind === 'simview' ? await findSimViewPluginBinaries(options.simviewPluginRoots) : []),
         ];
     let selected: string | undefined;
+    const selectPath = async (path: string): Promise<boolean> => {
+      if (candidate.explicit || (path.includes('/') ? await executable(path) : await commandExists(options.runner, path, candidate.kind === 'simview' ? deadline : undefined))) {
+        selected = path;
+        return true;
+      }
+      return false;
+    };
     for (const path of paths) {
-      if (candidate.explicit || (path.includes('/') ? await executable(path) : await commandExists(options.runner, path))) {
+      if (await selectPath(path)) break;
+    }
+    if (!selected && candidate.kind === 'simview' && (deadline === undefined || deadline > Date.now())) {
+      const pluginPaths = await findSimViewPluginBinaries(options.simviewPluginRoots, discoveryDeadline, fileSystem);
+      for (const path of pluginPaths) {
         selected = path;
         break;
       }
@@ -222,7 +289,7 @@ export async function discoverNativeProviders(
       continue;
     }
     try {
-      const probed = await probeProvider(options.runner, candidate.kind, selected, parts.args);
+      const probed = await probeProvider(options.runner, candidate.kind, selected, parts.args, deadline);
       result.push({ kind: candidate.kind, command: selected, args: parts.args, available: true, ...probed });
     } catch (error) {
       result.push({
@@ -242,10 +309,11 @@ async function probeProvider(
   kind: Provider['kind'],
   command: string,
   args: string[],
+  deadline?: number,
 ): Promise<{ capabilities?: Set<string>; buttons?: Set<string> }> {
   let versionError: unknown;
   try {
-    await runner.execFile(command, [...args, '--version'], { maxBuffer: 64 * 1024 });
+    await boundedExecFile(runner, command, [...args, '--version'], { maxBuffer: 64 * 1024 }, kind === 'simview' ? deadline : undefined);
   } catch (error) {
     versionError = error;
   }
@@ -320,12 +388,34 @@ async function readOperationHelp(
   }
 }
 
-async function commandExists(runner: NativeCommandRunner, command: string): Promise<boolean> {
+async function commandExists(runner: NativeCommandRunner, command: string, deadline?: number): Promise<boolean> {
   try {
-    await runner.execFile('which', [command], { maxBuffer: 16 * 1024 });
+    await boundedExecFile(runner, 'which', [command], { maxBuffer: 16 * 1024 }, deadline);
     return true;
   } catch {
     return false;
+  }
+}
+
+async function boundedExecFile(
+  runner: NativeCommandRunner,
+  command: string,
+  args: string[],
+  options: { maxBuffer?: number },
+  deadline?: number,
+): Promise<Buffer> {
+  const remaining = deadline === undefined ? undefined : deadline - Date.now();
+  if (remaining !== undefined && remaining <= 0) throw new Error(`Timed out running ${command}`);
+  const operation = runner.execFile(command, args, { ...options, ...(remaining === undefined ? {} : { timeout: remaining }) });
+  if (remaining === undefined) return operation;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out running ${command}`)), remaining);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -354,14 +444,16 @@ export class NativeInputController {
   private actionQueue: Promise<void> = Promise.resolve();
   /** Track resources before connecting so shutdown can abort a pending handshake. */
   private readonly resources = new Set<SimViewResource>();
+  private readonly simviewRequestTimeoutMs: number;
 
   constructor(private readonly options: NativeInputOptions) {
     this.config = configValue(options.config);
+    this.simviewRequestTimeoutMs = Math.max(1, Math.floor(options.simviewRequestTimeoutMs ?? DEFAULT_SIMVIEW_REQUEST_TIMEOUT_MS));
     this.registerCleanup();
   }
 
-  async providersFor(target: NativeInputTarget): Promise<Provider[]> {
-    if (!this.providers) this.providers = await discoverNativeProviders(this.options);
+  async providersFor(target: NativeInputTarget, deadline = this.simviewDeadline()): Promise<Provider[]> {
+    if (!this.providers) this.providers = await discoverNativeProviders(this.options, deadline);
     return this.providers.filter((provider) =>
       this.config.nativeBackend === 'auto' || provider.kind === this.config.nativeBackend,
     ).filter((provider) => target.platform === 'ios' || provider.kind === 'simview');
@@ -379,10 +471,11 @@ export class NativeInputController {
   async tapLabel(target: NativeInputTarget, label: string): Promise<NativeDispatchResult> {
     if (this.closed) return result('none', 'unavailable', false, 'Native input controller is closed');
     if (target.platform !== 'ios') return result('none', 'unsupported', false, 'Label lookup is only available through IDB on iOS');
-    const providers = await this.providersFor(target);
+    const deadline = this.simviewDeadline();
+    const providers = await this.providersFor(target, deadline);
     const simview = providers.find((candidate) => candidate.kind === 'simview' && candidate.available);
     if (simview) {
-      const semantic = await this.simviewLabel(target, label, simview);
+      const semantic = await this.simviewLabel(target, label, simview, deadline);
       if (semantic.status !== 'unavailable' && semantic.status !== 'unsupported') return semantic;
     }
     const provider = providers.find((candidate) => candidate.kind === 'idb' && candidate.available);
@@ -405,11 +498,12 @@ export class NativeInputController {
   async longPressLabel(target: NativeInputTarget, label: string, duration: number): Promise<NativeDispatchResult> {
     if (this.closed) return result('none', 'unavailable', false, 'Native input controller is closed');
 
-    const providers = await this.providersFor(target);
+    const deadline = this.simviewDeadline();
+    const providers = await this.providersFor(target, deadline);
     let fallback: NativeDispatchResult | undefined;
     const simview = providers.find((candidate) => candidate.kind === 'simview' && candidate.available);
     if (simview) {
-      const semantic = await this.simviewLongPressLabel(target, label, duration, simview);
+      const semantic = await this.simviewLongPressLabel(target, label, duration, simview, deadline);
       if (semantic.status !== 'unavailable' && semantic.status !== 'unsupported') return semantic;
       fallback = semantic;
     }
@@ -431,21 +525,32 @@ export class NativeInputController {
     }
   }
 
-  private async simviewLabel(target: NativeInputTarget, label: string, provider: Provider): Promise<NativeDispatchResult> {
+  private async simviewLabel(target: NativeInputTarget, label: string, provider: Provider, requestDeadline?: number): Promise<NativeDispatchResult> {
     if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
     let inputAttempted = false;
     try {
       return await this.withActionQueue(async () => {
-        const session = await this.getSession(target, provider);
+        const deadline = requestDeadline ?? this.simviewDeadline();
+        const session = await this.getSession(target, provider, deadline);
         return this.withSessionQueue(session, async () => {
           try {
-            await this.refreshSession(session);
+            await this.refreshSession(session, deadline);
           } catch (error) {
-            await this.invalidateSession(session);
+            await this.invalidateSession(session, deadline);
             throw error;
           }
           if (!session.tools.has('find_elements') || !session.tools.has('tap_element')) return result('simview', 'unsupported', false, 'SimView does not provide semantic label input');
-          const searchResponse = await session.client.callTool({ name: 'find_elements', arguments: { name: label, exact: true } });
+          let searchResponse: SimViewCallResult;
+          try {
+            searchResponse = await this.simviewRequest(
+              () => session.client.callTool({ name: 'find_elements', arguments: { name: label, exact: true } }),
+              `find element "${label}"`,
+              deadline,
+            );
+          } catch (error) {
+            await this.invalidateSession(session, deadline);
+            throw error;
+          }
           if (searchResponse.isError) return result('simview', 'unavailable', false, 'SimView semantic search is unavailable');
           const found = readStructuredResult(searchResponse);
           const matches = Array.isArray(found.matches) ? found.matches : [];
@@ -457,6 +562,7 @@ export class NativeInputController {
           }).filter((ref): ref is string => typeof ref === 'string');
           if (refs.length === 0) return result('simview', 'unsupported', false, `Element "${label}" was not found by SimView`);
           if (refs.length !== 1) return result('simview', 'failed', false, `Element "${label}" is ambiguous`);
+          if (Date.now() >= deadline) return result('simview', 'unavailable', false, 'SimView setup timed out before input dispatch', 'not-sent');
           inputAttempted = true;
           const tapResponse = await session.client.callTool({ name: 'tap_element', arguments: { ref: refs[0] } });
           const tapped = readStructuredResult(tapResponse);
@@ -497,17 +603,18 @@ export class NativeInputController {
     }
   }
 
-  private async simviewLongPressLabel(target: NativeInputTarget, label: string, duration: number, provider: Provider): Promise<NativeDispatchResult> {
+  private async simviewLongPressLabel(target: NativeInputTarget, label: string, duration: number, provider: Provider, requestDeadline?: number): Promise<NativeDispatchResult> {
     if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
     let inputAttempted = false;
     try {
       return await this.withActionQueue(async () => {
-        const session = await this.getSession(target, provider);
+        const deadline = requestDeadline ?? this.simviewDeadline();
+        const session = await this.getSession(target, provider, deadline);
         return this.withSessionQueue(session, async () => {
           try {
-            await this.refreshSession(session);
+            await this.refreshSession(session, deadline);
           } catch (error) {
-            await this.invalidateSession(session);
+            await this.invalidateSession(session, deadline);
             throw error;
           }
           if (!session.tools.has('find_elements') || !session.tools.has('long_press')) {
@@ -517,7 +624,17 @@ export class NativeInputController {
           if (input?.touch !== true) {
             return result('simview', 'unsupported', false, 'SimView does not support touch input');
           }
-          const searchResponse = await session.client.callTool({ name: 'find_elements', arguments: { name: label, exact: true } });
+          let searchResponse: SimViewCallResult;
+          try {
+            searchResponse = await this.simviewRequest(
+              () => session.client.callTool({ name: 'find_elements', arguments: { name: label, exact: true } }),
+              `find element "${label}"`,
+              deadline,
+            );
+          } catch (error) {
+            await this.invalidateSession(session, deadline);
+            throw error;
+          }
           if (searchResponse.isError) return result('simview', 'unavailable', false, 'SimView semantic search is unavailable');
           const found = readStructuredResult(searchResponse);
           const matches = Array.isArray(found.matches) ? found.matches : [];
@@ -531,6 +648,7 @@ export class NativeInputController {
             : undefined;
           const point = simViewFrameCenter(element, session.width, session.height);
           if (!point) return result('simview', 'unsupported', false, `Element "${label}" has no usable frame`);
+          if (Date.now() >= deadline) return result('simview', 'unavailable', false, 'SimView setup timed out before input dispatch', 'not-sent');
           inputAttempted = true;
           const response = await session.client.callTool({ name: 'long_press', arguments: { ...point, durationMs: duration } });
           const structured = readStructuredResult(response);
@@ -595,7 +713,8 @@ export class NativeInputController {
     if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
     return this.withActionQueue(async () => {
       if (this.closed) return result(target.platform === 'android' ? 'adb' : 'none', 'unavailable', false, 'Native input controller is closed');
-      const geometry = await this.geometry(target);
+      const deadline = this.simviewDeadline();
+      const geometry = await this.geometry(target, deadline);
       if (!geometry) return result('none', 'unavailable', false, 'Device geometry is unavailable; refusing to guess swipe coordinates');
       const { width, height } = geometry;
       const insetX = width * 0.2;
@@ -610,11 +729,11 @@ export class NativeInputController {
         to = { x: width / 2, y: direction === 'up' ? insetY : height * 0.75 };
       }
       if (target.platform === 'android') return this.adb(target, ['shell', 'input', 'swipe', String(from.x), String(from.y), String(to.x), String(to.y), String(duration)], 'swipe');
-      return this.dispatchSimViewOrIdb(target, 'swipe', { from, to, durationMs: duration }, true);
+      return this.dispatchSimViewOrIdb(target, 'swipe', { from, to, durationMs: duration }, true, deadline, geometry.simviewUnavailable);
     });
   }
 
-  private async geometry(target: NativeInputTarget): Promise<{ width: number; height: number } | null> {
+  private async geometry(target: NativeInputTarget, deadline = this.simviewDeadline()): Promise<({ width: number; height: number; simviewUnavailable?: boolean }) | null> {
     if (target.platform === 'android') {
       try {
         const output = (await this.options.runner.execFile('adb', ['-s', target.id, 'shell', 'wm', 'size'], { maxBuffer: 16 * 1024 })).toString('utf8');
@@ -623,15 +742,15 @@ export class NativeInputController {
         return match ? { width: Number(match[2]), height: Number(match[3]) } : null;
       } catch { return null; }
     }
-    const providers = await this.providersFor(target);
+    const providers = await this.providersFor(target, deadline);
     const simview = providers.find((provider) => provider.kind === 'simview' && provider.available);
     if (simview) {
       try {
-        const session = await this.getSession(target, simview);
-        await this.refreshSession(session);
+        const session = await this.getSession(target, simview, deadline);
+        await this.refreshSession(session, deadline);
         return { width: session.width, height: session.height };
       } catch (error) {
-        if (this.session) await this.invalidateSession(this.session);
+        if (this.session) await this.invalidateSession(this.session, deadline);
         /* Try IDB when SimView is unavailable. */
       }
     }
@@ -643,7 +762,7 @@ export class NativeInputController {
       const dimensions = (parsed.screen_dimensions ?? parsed.screenDimensions) as Record<string, unknown> | undefined;
       const width = Number(dimensions?.width_points ?? dimensions?.widthPoints);
       const height = Number(dimensions?.height_points ?? dimensions?.heightPoints);
-      return Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0 ? { width, height } : null;
+      return Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0 ? { width, height, simviewUnavailable: Boolean(simview) } : null;
     } catch { return null; }
   }
 
@@ -676,13 +795,21 @@ export class NativeInputController {
     }
   }
 
-  private async dispatchSimViewOrIdb(target: NativeInputTarget, operation: string, args: Record<string, unknown>, inActionQueue = false): Promise<NativeDispatchResult> {
-    const providers = await this.providersFor(target);
+  private async dispatchSimViewOrIdb(
+    target: NativeInputTarget,
+    operation: string,
+    args: Record<string, unknown>,
+    inActionQueue = false,
+    deadline = this.simviewDeadline(),
+    skipSimView = false,
+  ): Promise<NativeDispatchResult> {
+    const providers = await this.providersFor(target, deadline);
     let fallback: NativeDispatchResult | undefined;
     for (const provider of providers) {
       if (!provider.available) continue;
+      if (skipSimView && provider.kind === 'simview') continue;
       const dispatched = provider.kind === 'simview'
-        ? await this.simview(target, operation, args, provider, inActionQueue)
+        ? await this.simview(target, operation, args, provider, inActionQueue, deadline)
         : await this.idb(target, operation, args, provider);
       if (dispatched.status === 'unavailable' || dispatched.status === 'unsupported') {
         fallback = dispatched;
@@ -740,17 +867,31 @@ export class NativeInputController {
     }
   }
 
-  private simview(target: NativeInputTarget, operation: string, args: Record<string, unknown>, provider: Provider, inActionQueue = false): Promise<NativeDispatchResult> {
+  private simview(
+    target: NativeInputTarget,
+    operation: string,
+    args: Record<string, unknown>,
+    provider: Provider,
+    inActionQueue = false,
+    deadline?: number,
+  ): Promise<NativeDispatchResult> {
     return inActionQueue
-      ? this.simviewInternal(target, operation, args, provider)
-      : this.withActionQueue(() => this.simviewInternal(target, operation, args, provider));
+      ? this.simviewInternal(target, operation, args, provider, deadline)
+      : this.withActionQueue(() => this.simviewInternal(target, operation, args, provider, deadline));
   }
 
-  private async simviewInternal(target: NativeInputTarget, operation: string, args: Record<string, unknown>, provider: Provider): Promise<NativeDispatchResult> {
+  private async simviewInternal(
+    target: NativeInputTarget,
+    operation: string,
+    args: Record<string, unknown>,
+    provider: Provider,
+    requestDeadline?: number,
+  ): Promise<NativeDispatchResult> {
     if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
+    const deadline = requestDeadline ?? this.simviewDeadline();
     let session: SimViewSession;
     try {
-      session = await this.getSession(target, provider);
+      session = await this.getSession(target, provider, deadline);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // A failed handshake happens before SimView receives an input action.
@@ -762,9 +903,9 @@ export class NativeInputController {
     return this.withSessionQueue(session, async () => {
       if (this.closed) return result('simview', 'unavailable', false, 'Native input controller is closed');
       try {
-        await this.refreshSession(session);
+        await this.refreshSession(session, deadline);
       } catch (error) {
-        await this.invalidateSession(session);
+        await this.invalidateSession(session, deadline);
         // Refresh only reads the session/device state and precedes the actual
         // input call, so a refresh failure cannot have dispatched input.
         return result('simview', 'unavailable', false, error instanceof Error ? error.message : String(error), 'not-sent');
@@ -785,6 +926,7 @@ export class NativeInputController {
       // versions advertise one, so honor it when present while retaining
       // compatibility with that public release.
       if (operation === 'press_key' && Array.isArray(input?.keys) && !input.keys.includes(args.key)) return result('simview', 'unsupported', false, `SimView does not support key ${String(args.key)}`);
+      if (Date.now() >= deadline) return result('simview', 'unavailable', false, 'SimView setup timed out before input dispatch', 'not-sent');
       const normalized = this.normalizeArgs(operation, args, session.width, session.height);
       try {
         const response = await session.client.callTool({ name: tool, arguments: normalized });
@@ -828,7 +970,7 @@ export class NativeInputController {
     return args;
   }
 
-  private async getSession(target: NativeInputTarget, provider: Provider): Promise<SimViewSession> {
+  private async getSession(target: NativeInputTarget, provider: Provider, deadline = this.simviewDeadline()): Promise<SimViewSession> {
     if (this.closed) throw new Error('Native input controller is closed');
     const deviceId = `${target.platform}:${target.id}`;
     if (this.session) {
@@ -838,25 +980,29 @@ export class NativeInputController {
     if (this.session) {
       const session = this.session;
       return this.withSessionQueue(session, async () => {
-        if (this.closed) throw new Error('Native input controller is closed');
-        const switched = await session.client.callTool({ name: 'connect_device', arguments: { deviceId, observationMode: 'semantic' } });
-        if (switched.isError) throw new Error(`SimView could not connect to ${deviceId}`);
-        session.deviceId = deviceId;
         try {
-          await this.refreshSession(session);
+          if (this.closed) throw new Error('Native input controller is closed');
+          const switched = await this.simviewRequest(
+            () => session.client.callTool({ name: 'connect_device', arguments: { deviceId, observationMode: 'semantic' } }),
+            `connect to ${deviceId}`,
+            deadline,
+          );
+          if (switched.isError) throw new Error(`SimView could not connect to ${deviceId}`);
+          session.deviceId = deviceId;
+          await this.refreshSession(session, deadline);
           return session;
         } catch (error) {
-          await this.invalidateSession(session);
+          await this.invalidateSession(session, deadline);
           throw error;
         }
       });
     }
-    if (this.pendingSession) return this.pendingSession.then(() => this.getSession(target, provider));
-    this.pendingSession = this.createSession(target, provider);
+    if (this.pendingSession) return this.pendingSession.then(() => this.getSession(target, provider, deadline));
+    this.pendingSession = this.createSession(target, provider, deadline);
     try { return await this.pendingSession; } finally { this.pendingSession = null; }
   }
 
-  private async createSession(target: NativeInputTarget, provider: Provider): Promise<SimViewSession> {
+  private async createSession(target: NativeInputTarget, provider: Provider, deadline = this.simviewDeadline()): Promise<SimViewSession> {
     const deviceId = `${target.platform}:${target.id}`;
     const mcpArgs = provider.args.at(-1) === 'mcp' ? provider.args : [...provider.args, 'mcp'];
     const created = this.options.simviewClientFactory?.(provider.command, mcpArgs);
@@ -865,22 +1011,26 @@ export class NativeInputController {
     const resource: SimViewResource = { client, transport, closePromise: null };
     this.resources.add(resource);
     try {
-      await client.connect(transport);
+      await this.simviewRequest(() => client.connect(transport), 'connect', deadline);
       if (this.closed) throw new Error('Native input controller is closed');
-      const tools = await client.listTools();
+      const tools = await this.simviewRequest(() => client.listTools(), 'list tools', deadline);
       if (this.closed) throw new Error('Native input controller is closed');
       if (!tools.tools.some((tool) => tool.name === 'connect_device')) throw new Error('SimView MCP server does not provide connect_device');
-      const connected = await client.callTool({ name: 'connect_device', arguments: { deviceId, observationMode: 'semantic' } });
+      const connected = await this.simviewRequest(
+        () => client.callTool({ name: 'connect_device', arguments: { deviceId, observationMode: 'semantic' } }),
+        `connect to ${deviceId}`,
+        deadline,
+      );
       if (this.closed) throw new Error('Native input controller is closed');
       if (connected.isError) throw new Error('SimView could not connect to the selected device');
-      const state = await client.callTool({ name: 'get_simview_state', arguments: {} });
+      const state = await this.simviewRequest(() => client.callTool({ name: 'get_simview_state', arguments: {} }), 'read device state', deadline);
       if (this.closed) throw new Error('Native input controller is closed');
-      const session = await this.sessionFromState(resource, deviceId, tools.tools.map((tool) => tool.name), state);
+      const session = await this.sessionFromState(resource, deviceId, tools.tools.map((tool) => tool.name), state, deadline);
       if (this.closed) throw new Error('Native input controller is closed');
       this.session = session;
       return session;
     } catch (error) {
-      await settleWithin(this.closeResource(resource));
+      await this.closeResourceBeforeDeadline(resource, deadline);
       throw error;
     }
   }
@@ -890,6 +1040,7 @@ export class NativeInputController {
     deviceId: string,
     toolNames: string[],
     state: SimViewCallResult,
+    deadline = this.simviewDeadline(),
   ): Promise<SimViewSession> {
     const { client, transport } = resource;
     if (this.closed) throw new Error('Native input controller is closed');
@@ -906,7 +1057,11 @@ export class NativeInputController {
     let height = stateHeight;
     if (toolNames.includes('observe_screen')) {
       if (this.closed) throw new Error('Native input controller is closed');
-      const observation = await client.callTool({ name: 'observe_screen', arguments: { mode: 'semantic' } });
+      const observation = await this.simviewRequest(
+        () => client.callTool({ name: 'observe_screen', arguments: { mode: 'semantic' } }),
+        'observe screen geometry',
+        deadline,
+      );
       if (observation.isError) throw new Error('SimView did not report a semantic observation for device geometry');
       const observed = extractObservationGeometry(readStructuredResult(observation));
       if (observed) {
@@ -918,21 +1073,59 @@ export class NativeInputController {
     return { client, transport, resource, deviceId, width, height, capabilities, tools: new Set(toolNames), queue: Promise.resolve(), closed: false };
   }
 
-  private async refreshSession(session: SimViewSession): Promise<void> {
+  private async refreshSession(session: SimViewSession, deadline = this.simviewDeadline()): Promise<void> {
     if (session.closed) throw new Error('SimView session is closed');
-    const state = await session.client.callTool({ name: 'get_simview_state', arguments: {} });
+    const state = await this.simviewRequest(() => session.client.callTool({ name: 'get_simview_state', arguments: {} }), 'refresh device state', deadline);
     if (state.isError) throw new Error('SimView could not refresh the selected device state');
-    const refreshed = await this.sessionFromState(session.resource, session.deviceId, [...session.tools], state);
+    const refreshed = await this.sessionFromState(session.resource, session.deviceId, [...session.tools], state, deadline);
     session.width = refreshed.width;
     session.height = refreshed.height;
     session.capabilities = refreshed.capabilities;
   }
 
-  private async invalidateSession(session: SimViewSession): Promise<void> {
+  /**
+   * Bound every SimView request made before native input dispatch. The MCP
+   * client cannot cancel a stalled call, so callers invalidate and close its
+   * resource after this deadline before considering a fallback provider.
+   */
+  private simviewDeadline(): number {
+    return Date.now() + this.simviewRequestTimeoutMs;
+  }
+
+  private async simviewRequest<T>(operation: () => Promise<T>, description: string, deadline = this.simviewDeadline()): Promise<T> {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error(`SimView ${description} timed out before the request started`);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`SimView ${description} timed out after ${this.simviewRequestTimeoutMs}ms`)), remaining);
+    });
+    try {
+      return await Promise.race([Promise.resolve().then(operation), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private async invalidateSession(session: SimViewSession, deadline = this.simviewDeadline()): Promise<void> {
     if (session.closed) return;
     session.closed = true;
     if (this.session === session) this.session = null;
-    await this.closeResource(session.resource);
+    await this.closeResourceBeforeDeadline(session.resource, deadline);
+  }
+
+  private async closeResourceBeforeDeadline(resource: SimViewResource, deadline: number): Promise<void> {
+    const close = this.closeResource(resource);
+    const remaining = Math.max(0, deadline - Date.now());
+    if (remaining > 0) {
+      await settleWithin(close, remaining);
+    } else {
+      // The resource is detached above and closeResource has already claimed
+      // its closePromise. Consume late failures without extending fallback.
+      void close.catch(() => {});
+    }
+    // Do not retain a resource whose bounded cleanup has already been handed
+    // off. Its closePromise remains the once-only guard for late completion.
+    this.resources.delete(resource);
   }
 
   private async withSessionQueue<T>(session: SimViewSession, operation: () => Promise<T>): Promise<T> {

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -459,6 +459,12 @@ export class NativeInputController {
   }
 
   private async discoverProviders(target: NativeInputTarget, deadline: number): Promise<Provider[]> {
+    // IDB's CLI and accessibility model are iOS-only. Keep it out of Android
+    // discovery entirely so a stalled installation cannot consume the budget
+    // before SimView gets a chance to handle the action.
+    if (target.platform === 'android') {
+      return discoverNativeProviders(this.options, deadline, ['simview']);
+    }
     if (this.config.nativeBackend !== 'auto' || target.platform !== 'ios') {
       return discoverNativeProviders(this.options, deadline);
     }

--- a/src/utils/native-input.ts
+++ b/src/utils/native-input.ts
@@ -235,6 +235,7 @@ async function validateSimViewPlugin(root: string, deadline?: number, fileSystem
 export async function discoverNativeProviders(
   options: NativeInputOptions,
   deadline?: number,
+  providerKinds?: Array<Provider['kind']>,
 ): Promise<Provider[]> {
   const config = configValue(options.config);
   const result: Provider[] = [];
@@ -243,12 +244,15 @@ export async function discoverNativeProviders(
     { kind: 'idb', command: config.idbCommand, explicit: options.config?.idbCommand !== undefined },
   ] as Array<{ kind: 'simview' | 'idb'; command: string; explicit: boolean }>).filter(
     (candidate) => config.nativeBackend === 'auto' || candidate.kind === config.nativeBackend,
-  );
+  ).filter((candidate) => !providerKinds || providerKinds.includes(candidate.kind));
 
   for (const candidate of candidates) {
     let parts = commandParts(candidate.command);
     const fileSystem = candidate.kind === 'simview' ? options.simviewFileSystem ?? defaultSimViewFileSystem : defaultSimViewFileSystem;
-    const discoveryDeadline = candidate.kind === 'simview' ? deadline : undefined;
+    // Provider discovery is part of the same pre-dispatch budget as the
+    // eventual native action. A broken IDB installation must not leave its
+    // version or help process running indefinitely while SimView is ready.
+    const discoveryDeadline = deadline;
     if (candidate.explicit) {
       const tokens = commandTokens(candidate.command);
       for (let index = tokens.length; index > 0; index--) {
@@ -268,7 +272,7 @@ export async function discoverNativeProviders(
         ];
     let selected: string | undefined;
     const selectPath = async (path: string): Promise<boolean> => {
-      if (candidate.explicit || (path.includes('/') ? await executable(path) : await commandExists(options.runner, path, candidate.kind === 'simview' ? deadline : undefined))) {
+      if (candidate.explicit || (path.includes('/') ? await executable(path, discoveryDeadline, fileSystem) : await commandExists(options.runner, path, discoveryDeadline))) {
         selected = path;
         return true;
       }
@@ -313,7 +317,7 @@ async function probeProvider(
 ): Promise<{ capabilities?: Set<string>; buttons?: Set<string> }> {
   let versionError: unknown;
   try {
-    await boundedExecFile(runner, command, [...args, '--version'], { maxBuffer: 64 * 1024 }, kind === 'simview' ? deadline : undefined);
+    await boundedExecFile(runner, command, [...args, '--version'], { maxBuffer: 64 * 1024 }, deadline);
   } catch (error) {
     versionError = error;
   }
@@ -328,7 +332,7 @@ async function probeProvider(
   // partial set of input operations without making the whole provider unusable.
   let help: string;
   try {
-    help = (await runner.execFile(command, [...args, '--help'], { maxBuffer: 128 * 1024 })).toString('utf8');
+    help = (await boundedExecFile(runner, command, [...args, '--help'], { maxBuffer: 128 * 1024 }, deadline)).toString('utf8');
   } catch (error) {
     throw new Error(`IDB help probe failed${versionError ? ` after version probe: ${error instanceof Error ? error.message : String(error)}` : `: ${error instanceof Error ? error.message : String(error)}`}`);
   }
@@ -336,7 +340,7 @@ async function probeProvider(
 
   let uiHelp: string;
   try {
-    uiHelp = (await runner.execFile(command, [...args, 'ui', '--help'], { maxBuffer: 128 * 1024 })).toString('utf8');
+    uiHelp = (await boundedExecFile(runner, command, [...args, 'ui', '--help'], { maxBuffer: 128 * 1024 }, deadline)).toString('utf8');
   } catch (error) {
     throw new Error(`IDB ui help probe failed: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -355,15 +359,15 @@ async function probeProvider(
   // Probe these read-only help pages independently so a provider can retain
   // the capabilities it does support when one command is incomplete.
   if (capabilities.has('tap')) {
-    const tapHelp = await readOperationHelp(runner, command, args, 'tap');
+    const tapHelp = await readOperationHelp(runner, command, args, 'tap', deadline);
     if (tapHelp && /(?:^|\s)--duration(?:\s|$)/m.test(tapHelp)) capabilities.add('long_press');
   }
   if (capabilities.has('swipe')) {
-    const swipeHelp = await readOperationHelp(runner, command, args, 'swipe');
+    const swipeHelp = await readOperationHelp(runner, command, args, 'swipe', deadline);
     if (swipeHelp && /(?:^|\s)--duration(?:\s|$)/m.test(swipeHelp)) capabilities.add('swipe-duration');
   }
   if (capabilities.has('button')) {
-    const buttonHelp = await readOperationHelp(runner, command, args, 'button');
+    const buttonHelp = await readOperationHelp(runner, command, args, 'button', deadline);
     for (const button of ['APPLE_PAY', 'HOME', 'LOCK', 'SIDE_BUTTON', 'SIRI']) {
       if (buttonHelp && new RegExp(`(?:\\{|,|\\s)${button}(?=,|\\}|\\s|$)`, 'm').test(buttonHelp)) buttons.add(button.toLowerCase());
     }
@@ -380,9 +384,10 @@ async function readOperationHelp(
   command: string,
   args: string[],
   operation: string,
+  deadline?: number,
 ): Promise<string | null> {
   try {
-    return (await runner.execFile(command, [...args, 'ui', operation, '--help'], { maxBuffer: 128 * 1024 })).toString('utf8');
+    return (await boundedExecFile(runner, command, [...args, 'ui', operation, '--help'], { maxBuffer: 128 * 1024 }, deadline)).toString('utf8');
   } catch {
     return null;
   }
@@ -452,13 +457,31 @@ export class NativeInputController {
     this.registerCleanup();
   }
 
-  async providersFor(target: NativeInputTarget, deadline = this.simviewDeadline()): Promise<Provider[]> {
+  private async discoverProviders(target: NativeInputTarget, deadline: number): Promise<Provider[]> {
+    if (this.config.nativeBackend !== 'auto' || target.platform !== 'ios') {
+      return discoverNativeProviders(this.options, deadline);
+    }
+
+    // SimView is the preferred iOS backend. Do not make a ready SimView wait
+    // for a broken IDB installation; IDB is discovered lazily when SimView
+    // cannot handle the action. If SimView itself is unavailable, give IDB a
+    // fresh bounded discovery window so the existing fallback remains useful.
+    const simview = await discoverNativeProviders(this.options, deadline, ['simview']);
+    if (simview.some((provider) => provider.available)) return simview;
+    return [...simview, ...await discoverNativeProviders(this.options, this.simviewDeadline(), ['idb'])];
+  }
+
+  async providersFor(target: NativeInputTarget, deadline = this.simviewDeadline(), includeFallback = false): Promise<Provider[]> {
     // Keep successful discovery cheap, but do not make an unavailable
     // provider permanent for the lifetime of the controller. A provider can
     // be installed, added to PATH, or recover from a transient probe failure
     // while the daemon is still running.
     if (!this.providers || this.providers.some((provider) => !provider.available)) {
-      this.providers = await discoverNativeProviders(this.options, deadline);
+      this.providers = await this.discoverProviders(target, deadline);
+    }
+    if (includeFallback && this.config.nativeBackend === 'auto' && target.platform === 'ios'
+      && !this.providers.some((provider) => provider.kind === 'idb')) {
+      this.providers = [...this.providers, ...await discoverNativeProviders(this.options, this.simviewDeadline(), ['idb'])];
     }
     return this.providers.filter((provider) =>
       this.config.nativeBackend === 'auto' || provider.kind === this.config.nativeBackend,
@@ -484,11 +507,18 @@ export class NativeInputController {
       const semantic = await this.simviewLabel(target, label, simview, deadline);
       if (semantic.status !== 'unavailable' && semantic.status !== 'unsupported') return semantic;
     }
-    const provider = providers.find((candidate) => candidate.kind === 'idb' && candidate.available);
+    const provider = (await this.providersFor(target, deadline, true)).find((candidate) => candidate.kind === 'idb' && candidate.available);
     if (!provider) return result('none', 'unavailable', false, 'IDB is not installed for accessibility label lookup');
     if (!provider.capabilities?.has('describe-all')) return result('idb', 'unsupported', false, 'IDB does not advertise accessibility descriptions');
     try {
-      const dump = await this.options.runner.execFile(provider.command, [...provider.args, 'ui', 'describe-all', '--udid', target.id, '--json'], { maxBuffer: 2 * 1024 * 1024 });
+      const idbDeadline = this.simviewDeadline();
+      const dump = await boundedExecFile(
+        this.options.runner,
+        provider.command,
+        [...provider.args, 'ui', 'describe-all', '--udid', target.id, '--json'],
+        { maxBuffer: 2 * 1024 * 1024 },
+        idbDeadline,
+      );
       const match = findAccessibilityPoint(dump.toString('utf8'), label);
       if (!match.point) return result('idb', 'failed', false, match.ambiguous ? `Element "${label}" is ambiguous` : `Element "${label}" was not found by IDB`);
       return this.idb(target, 'tap', match.point, provider);
@@ -517,12 +547,19 @@ export class NativeInputController {
     // IDB's accessibility dump and UI input commands are iOS-only. SimView
     // remains available on Android because it can query that device directly.
     if (target.platform !== 'ios') return fallback ?? result('none', 'unsupported', false, 'Label lookup is only available through SimView on Android');
-    const provider = providers.find((candidate) => candidate.kind === 'idb' && candidate.available);
+    const provider = (await this.providersFor(target, deadline, true)).find((candidate) => candidate.kind === 'idb' && candidate.available);
     if (!provider) return fallback ?? result('none', 'unavailable', false, 'IDB is not installed for accessibility label lookup');
     if (!provider.capabilities?.has('describe-all')) return result('idb', 'unsupported', false, 'IDB does not advertise accessibility descriptions');
     if (!provider.capabilities.has('long_press')) return result('idb', 'unsupported', false, 'IDB does not advertise long press input');
     try {
-      const dump = await this.options.runner.execFile(provider.command, [...provider.args, 'ui', 'describe-all', '--udid', target.id, '--json'], { maxBuffer: 2 * 1024 * 1024 });
+      const idbDeadline = this.simviewDeadline();
+      const dump = await boundedExecFile(
+        this.options.runner,
+        provider.command,
+        [...provider.args, 'ui', 'describe-all', '--udid', target.id, '--json'],
+        { maxBuffer: 2 * 1024 * 1024 },
+        idbDeadline,
+      );
       const match = findAccessibilityPoint(dump.toString('utf8'), label);
       if (!match.point) return result('idb', match.ambiguous ? 'failed' : 'unsupported', false, match.ambiguous ? `Element "${label}" is ambiguous` : `Element "${label}" was not found by IDB`);
       return this.idb(target, 'long_press', { ...match.point, durationMs: duration }, provider);
@@ -570,7 +607,17 @@ export class NativeInputController {
           if (refs.length !== 1) return result('simview', 'failed', false, `Element "${label}" is ambiguous`);
           if (Date.now() >= deadline) return result('simview', 'unavailable', false, 'SimView setup timed out before input dispatch', 'not-sent');
           inputAttempted = true;
-          const tapResponse = await session.client.callTool({ name: 'tap_element', arguments: { ref: refs[0] } });
+          let tapResponse: SimViewCallResult;
+          try {
+            tapResponse = await this.simviewRequest(
+              () => session.client.callTool({ name: 'tap_element', arguments: { ref: refs[0] } }),
+              `tap element "${label}"`,
+              this.simviewDeadline(),
+            );
+          } catch (error) {
+            await this.invalidateSession(session, deadline);
+            throw error;
+          }
           const tapped = readStructuredResult(tapResponse);
           const interaction = tapped.interaction && typeof tapped.interaction === 'object'
             ? tapped.interaction as Record<string, unknown>
@@ -664,7 +711,17 @@ export class NativeInputController {
           if (!point) return result('simview', 'unsupported', false, `Element "${label}" has no usable frame`);
           if (Date.now() >= deadline) return result('simview', 'unavailable', false, 'SimView setup timed out before input dispatch', 'not-sent');
           inputAttempted = true;
-          const response = await session.client.callTool({ name: 'long_press', arguments: { ...point, durationMs: duration } });
+          let response: SimViewCallResult;
+          try {
+            response = await this.simviewRequest(
+              () => session.client.callTool({ name: 'long_press', arguments: { ...point, durationMs: duration } }),
+              `long press element "${label}"`,
+              this.simviewDeadline(),
+            );
+          } catch (error) {
+            await this.invalidateSession(session, deadline);
+            throw error;
+          }
           const structured = readStructuredResult(response);
           const interaction = structured.interaction && typeof structured.interaction === 'object'
             ? structured.interaction as Record<string, unknown>
@@ -775,10 +832,17 @@ export class NativeInputController {
         /* Try IDB when SimView is unavailable. */
       }
     }
-    const idb = providers.find((provider) => provider.kind === 'idb' && provider.available);
+    const idb = (await this.providersFor(target, deadline, true)).find((provider) => provider.kind === 'idb' && provider.available);
     if (!idb || !idb.capabilities?.has('describe')) return null;
     try {
-      const output = await this.options.runner.execFile(idb.command, [...idb.args, 'describe', '--udid', target.id, '--json'], { maxBuffer: 128 * 1024 });
+      const idbDeadline = this.simviewDeadline();
+      const output = await boundedExecFile(
+        this.options.runner,
+        idb.command,
+        [...idb.args, 'describe', '--udid', target.id, '--json'],
+        { maxBuffer: 128 * 1024 },
+        idbDeadline,
+      );
       const parsed = JSON.parse(output.toString('utf8')) as Record<string, unknown>;
       const dimensions = (parsed.screen_dimensions ?? parsed.screenDimensions) as Record<string, unknown> | undefined;
       const width = Number(dimensions?.width_points ?? dimensions?.widthPoints);
@@ -824,9 +888,10 @@ export class NativeInputController {
     deadline = this.simviewDeadline(),
     skipSimView = false,
   ): Promise<NativeDispatchResult> {
-    const providers = await this.providersFor(target, deadline);
+    let providers = await this.providersFor(target, deadline);
     let fallback: NativeDispatchResult | undefined;
-    for (const provider of providers) {
+    for (let index = 0; index < providers.length; index += 1) {
+      const provider = providers[index];
       if (!provider.available) continue;
       if (skipSimView && provider.kind === 'simview') continue;
       const dispatched = provider.kind === 'simview'
@@ -834,6 +899,7 @@ export class NativeInputController {
         : await this.idb(target, operation, args, provider);
       if (dispatched.status === 'unavailable' || dispatched.status === 'unsupported') {
         fallback = dispatched;
+        if (provider.kind === 'simview') providers = await this.providersFor(target, deadline, true);
         continue;
       }
       return dispatched;
@@ -841,7 +907,13 @@ export class NativeInputController {
     return fallback ?? result('none', 'unavailable', false, 'No supported native input provider is installed');
   }
 
-  private async idb(target: NativeInputTarget, operation: string, args: Record<string, unknown>, provider: Provider): Promise<NativeDispatchResult> {
+  private async idb(
+    target: NativeInputTarget,
+    operation: string,
+    args: Record<string, unknown>,
+    provider: Provider,
+    deadline = this.simviewDeadline(),
+  ): Promise<NativeDispatchResult> {
     let capability: string;
     switch (operation) {
       case 'long_press': capability = 'long_press'; break;
@@ -881,7 +953,13 @@ export class NativeInputController {
       default: return result('idb', 'unsupported');
     }
     try {
-      await this.options.runner.execFile(provider.command, [...provider.args, ...command], { maxBuffer: 256 * 1024 });
+      await boundedExecFile(
+        this.options.runner,
+        provider.command,
+        [...provider.args, ...command],
+        { maxBuffer: 256 * 1024 },
+        deadline,
+      );
       return result('idb', 'handled', true);
     } catch (error) {
       return result('idb', 'failed', false, error instanceof Error ? error.message : String(error), 'unknown');
@@ -950,7 +1028,17 @@ export class NativeInputController {
       if (Date.now() >= deadline) return result('simview', 'unavailable', false, 'SimView setup timed out before input dispatch', 'not-sent');
       const normalized = this.normalizeArgs(operation, args, session.width, session.height);
       try {
-        const response = await session.client.callTool({ name: tool, arguments: normalized });
+        let response: SimViewCallResult;
+        try {
+          response = await this.simviewRequest(
+            () => session.client.callTool({ name: tool, arguments: normalized }),
+            `${tool} input`,
+            this.simviewDeadline(),
+          );
+        } catch (error) {
+          await this.invalidateSession(session, deadline);
+          throw error;
+        }
         const structured = readStructuredResult(response);
         const interaction = structured.interaction && typeof structured.interaction === 'object'
           ? structured.interaction as Record<string, unknown>

--- a/src/utils/tool-results.test.ts
+++ b/src/utils/tool-results.test.ts
@@ -41,6 +41,27 @@ test('serializes nested BigInts without throwing', () => {
   });
 });
 
+test('serializes boxed BigInts without throwing', () => {
+  expect(normalizeToolResult(Object(4n))).toEqual({
+    content: [{ type: 'text', text: '4n' }],
+  });
+  expect(normalizeToolResult({ count: Object(5n) })).toEqual({
+    content: [{ type: 'text', text: '{"count":"5n"}' }],
+  });
+});
+
+test('does not treat a spoofed BigInt tag as a boxed BigInt', () => {
+  const result = {
+    [Symbol.toStringTag]: 'BigInt',
+    valueOf: () => {
+      throw new Error('must not be called');
+    },
+  };
+  expect(normalizeToolResult(result)).toEqual({
+    content: [{ type: 'text', text: '{}' }],
+  });
+});
+
 test('preserves existing JSON handling for non-BigInt primitives', () => {
   expect(normalizeToolResult({
     nan: Number.NaN,

--- a/src/utils/tool-results.test.ts
+++ b/src/utils/tool-results.test.ts
@@ -23,6 +23,38 @@ test('serializes ordinary plugin results as text', () => {
   });
 });
 
+test('serializes a BigInt scalar using its JavaScript literal spelling', () => {
+  expect(normalizeToolResult(1n)).toEqual({
+    content: [{ type: 'text', text: '1n' }],
+  });
+});
+
+test('serializes nested BigInts without throwing', () => {
+  expect(normalizeToolResult({
+    count: 1n,
+    values: [2n, { total: 3n }],
+  })).toEqual({
+    content: [{
+      type: 'text',
+      text: '{"count":"1n","values":["2n",{"total":"3n"}]}',
+    }],
+  });
+});
+
+test('preserves existing JSON handling for non-BigInt primitives', () => {
+  expect(normalizeToolResult({
+    nan: Number.NaN,
+    positiveInfinity: Number.POSITIVE_INFINITY,
+    negativeInfinity: Number.NEGATIVE_INFINITY,
+    negativeZero: -0,
+  })).toEqual({
+    content: [{
+      type: 'text',
+      text: '{"nan":null,"positiveInfinity":null,"negativeInfinity":null,"negativeZero":0}',
+    }],
+  });
+});
+
 test('serializes content-shaped objects that are not valid MCP results', () => {
   const result = { content: [{ type: 'custom', value: 42 }] };
 

--- a/src/utils/tool-results.ts
+++ b/src/utils/tool-results.ts
@@ -4,15 +4,26 @@ import {
   type ToolHandlerResult,
 } from '../plugin.js';
 
+function serializeBigInt(value: unknown): string | undefined {
+  if (typeof value === 'bigint') return `${value}n`;
+  if (typeof value !== 'object' || value === null) return undefined;
+  try {
+    // Use the intrinsic method as the brand check. Symbol.toStringTag and an
+    // object's own valueOf() can both be overridden by ordinary plugin data.
+    return `${BigInt.prototype.valueOf.call(value)}n`;
+  } catch {}
+  return undefined;
+}
+
 function serializeToolValue(result: unknown): string {
   // BigInt is a valid evaluation result, but JSON.stringify throws before it
   // can produce the text response used by ordinary plugin tools. Keep the
   // familiar JavaScript literal spelling while making nested values JSON safe.
-  if (typeof result === 'bigint') return `${result}n`;
+  const bigint = serializeBigInt(result);
+  if (bigint !== undefined) return bigint;
   return JSON.stringify(
     result,
-    (_key, value: unknown) =>
-      typeof value === 'bigint' ? `${value}n` : value,
+    (_key, value: unknown) => serializeBigInt(value) ?? value,
   ) ?? String(result);
 }
 

--- a/src/utils/tool-results.ts
+++ b/src/utils/tool-results.ts
@@ -4,11 +4,23 @@ import {
   type ToolHandlerResult,
 } from '../plugin.js';
 
+function serializeToolValue(result: unknown): string {
+  // BigInt is a valid evaluation result, but JSON.stringify throws before it
+  // can produce the text response used by ordinary plugin tools. Keep the
+  // familiar JavaScript literal spelling while making nested values JSON safe.
+  if (typeof result === 'bigint') return `${result}n`;
+  return JSON.stringify(
+    result,
+    (_key, value: unknown) =>
+      typeof value === 'bigint' ? `${value}n` : value,
+  ) ?? String(result);
+}
+
 export function normalizeToolResult(result: ToolHandlerResult): CallToolResult {
   if (isNativeToolResult(result)) return result;
   const text =
     typeof result === 'string'
       ? result
-      : (JSON.stringify(result) ?? String(result));
+      : serializeToolValue(result);
   return { content: [{ type: 'text', text }] };
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -115,4 +115,16 @@ describe('project-root configuration', () => {
     expect(second.cwd).toBe(projectRoot);
     expect(getDaemonKey([], first)).toBe(getDaemonKey([], second));
   });
+
+  test('separates daemon identities when native input providers differ', () => {
+    const first = createDaemonIdentity([], {
+      projectRoot: '/tmp/project-a',
+      input: { nativeBackend: 'simview', simviewCommand: '/tmp/simview-a' },
+    });
+    const second = createDaemonIdentity([], {
+      projectRoot: '/tmp/project-a',
+      input: { nativeBackend: 'idb', idbCommand: '/tmp/idb' },
+    });
+    expect(getDaemonKey([], first)).not.toBe(getDaemonKey([], second));
+  });
 });

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import {
   cleanupStaleDaemonRecords,
   createDaemonIdentity,
@@ -141,6 +143,109 @@ describe('daemon identity', () => {
 
     expect(getDaemonKey(installed.args, installed)).not.toBe(getDaemonKey(local.args, local));
     expect(getDaemonKey(installed.args, installed)).not.toBe(getDaemonKey(node.args, node));
+  });
+
+  test('starts and reuses a daemon with the loaded input identity', async () => {
+    const configFile = path.join(tempDir, 'metro-mcp.shared.config.ts');
+    fs.writeFileSync(
+      configFile,
+      "export default { metro: { host: '127.0.0.1', port: 65535, autoDiscover: false }, proxy: { enabled: false }, input: { nativeBackend: 'simview', simviewCommand: '/tmp/uninstalled-simview' } };\n",
+    );
+    const args = ['--project-root', tempDir, '--config', configFile];
+    const entrypoint = path.resolve(import.meta.dir, '../src/index.ts');
+    const config = await loadConfig(args);
+    const identity = createDaemonIdentity(args, {
+      projectRoot: config.projectRoot,
+      input: config.input,
+      entrypoint,
+      runtime: fs.realpathSync(process.execPath),
+    });
+    const key = getDaemonKey(args, identity);
+    const environment = Object.fromEntries(
+      Object.entries(process.env).filter((entry): entry is [string, string] =>
+        entry[1] !== undefined,
+      ),
+    );
+    for (const variable of [
+      'METRO_HOST',
+      'METRO_PORT',
+      'METRO_MCP_CONFIG',
+      'METRO_MCP_PLUGINS',
+      'METRO_MCP_PROJECT_ROOT',
+      'METRO_MCP_PROXY_PORT',
+      'METRO_MCP_PROXY_ENABLED',
+      'METRO_MCP_DAEMON_KEY',
+      'METRO_MCP_MULTIPLEX',
+    ]) delete environment[variable];
+    environment.METRO_MCP_DAEMON_CONFIG_DIR = tempDir;
+
+    const clients: Client[] = [];
+    const transports: StdioClientTransport[] = [];
+    let daemonPid: number | undefined;
+    try {
+      for (const name of ['first', 'second']) {
+        const transport = new StdioClientTransport({
+          command: process.execPath,
+          args: [entrypoint, ...args],
+          cwd: tempDir,
+          env: environment,
+          stderr: 'pipe',
+        });
+        const client = new Client({ name: `daemon-${name}`, version: '1.0.0' });
+        transports.push(transport);
+        clients.push(client);
+        await client.connect(transport);
+        const tools = await client.listTools();
+        expect(tools.tools.some((tool) => tool.name === 'list_devices')).toBe(true);
+
+        const record = JSON.parse(
+          fs.readFileSync(getDaemonRecordPath(key), 'utf8'),
+        ) as DaemonRecord;
+        expect(record.key).toBe(key);
+        expect(record.identity).toEqual(identity);
+        if (daemonPid === undefined) daemonPid = record.pid;
+        expect(record.pid).toBe(daemonPid);
+        expect(transport.pid).not.toBe(daemonPid);
+      }
+    } finally {
+      for (const client of clients) await client.close().catch(() => {});
+      for (const transport of transports) await transport.close().catch(() => {});
+      if (daemonPid === undefined) {
+        try {
+          const record = JSON.parse(
+            fs.readFileSync(getDaemonRecordPath(key), 'utf8'),
+          ) as DaemonRecord;
+          if (record.cwd === tempDir && Number.isInteger(record.pid)) {
+            daemonPid = record.pid;
+          }
+        } catch {
+          // The proxy may have failed before its owned daemon wrote a record.
+        }
+      }
+      if (daemonPid !== undefined) {
+        try {
+          process.kill(daemonPid, 'SIGTERM');
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+        }
+        const deadline = Date.now() + 2_000;
+        while (Date.now() < deadline) {
+          try {
+            process.kill(daemonPid, 0);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ESRCH') break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        try {
+          process.kill(daemonPid, 0);
+          process.kill(daemonPid, 'SIGKILL');
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+        }
+        removeDaemonRecordForProcess(key, daemonPid);
+      }
+    }
   });
 });
 

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -246,7 +246,7 @@ describe('daemon identity', () => {
         removeDaemonRecordForProcess(key, daemonPid);
       }
     }
-  });
+  }, 15_000);
 });
 
 describe('daemon records', () => {

--- a/tests/reconnect.test.ts
+++ b/tests/reconnect.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  waitForReconnect,
+  type ReconnectWaitTimers,
+} from '../src/server.js';
+
+function timerHarness() {
+  let intervalCallback: (() => void) | undefined;
+  let timeoutCallback: (() => void) | undefined;
+  let intervalActive = false;
+  let timeoutActive = false;
+  let intervalCleared = 0;
+  let timeoutCleared = 0;
+
+  const timers: ReconnectWaitTimers = {
+    setInterval(callback) {
+      intervalCallback = callback;
+      intervalActive = true;
+      return 1 as ReturnType<typeof setInterval>;
+    },
+    clearInterval() {
+      intervalActive = false;
+      intervalCleared += 1;
+    },
+    setTimeout(callback) {
+      timeoutCallback = callback;
+      timeoutActive = true;
+      return 1 as ReturnType<typeof setTimeout>;
+    },
+    clearTimeout() {
+      timeoutActive = false;
+      timeoutCleared += 1;
+    },
+  };
+
+  return {
+    timers,
+    fireInterval() {
+      if (intervalActive) intervalCallback?.();
+    },
+    fireTimeout() {
+      if (timeoutActive) timeoutCallback?.();
+    },
+    state() {
+      return { intervalActive, timeoutActive, intervalCleared, timeoutCleared };
+    },
+  };
+}
+
+describe('reconnect waits', () => {
+  test('clears caller polling when its deadline expires', async () => {
+    const harness = timerHarness();
+    const wait = waitForReconnect(
+      () => true,
+      Date.now() + 1000,
+      harness.timers,
+    );
+
+    expect(harness.state()).toMatchObject({
+      intervalActive: true,
+      timeoutActive: true,
+    });
+    harness.fireTimeout();
+
+    await expect(wait).rejects.toThrow('App evaluation timed out');
+    expect(harness.state()).toMatchObject({
+      intervalActive: false,
+      timeoutActive: false,
+      intervalCleared: 1,
+      timeoutCleared: 1,
+    });
+    harness.fireInterval();
+    expect(harness.state().intervalCleared).toBe(1);
+  });
+});


### PR DESCRIPTION
Native input now resolves the connected concrete simulator before dispatch and uses React handlers first, then an installed SimView MCP provider, then installed IDB. Explicit coordinates go directly to native input. Provider discovery honors configured commands, project binaries, PATH, and validated SimView plugin installations without downloading tools. Explicit relative provider commands resolve from the configured project root for both discovery and dispatch, independent of the launcher's working directory.

SimView sessions are lazily connected to the verified iOS UDID, serialized, refreshed for current geometry, and cleaned up once. Receipt handling prevents fallback after a possible dispatch, and IDB commands use advertised capabilities, concrete UDIDs, integer logical points, and supported input syntax. Text-input traversal uses the shared bounded Fiber walker through depth 255. Focused controlled Paper and Fabric inputs invoke React handlers with their exact value; uncontrolled inputs use SimView `press_key` or IDB `ui key` for Return and Delete. Optional SimView per-device key capabilities are honored while remaining compatible with SimView 0.4.0.

Explicit iOS and Android requests invoke React handlers only when the connected logical ID uniquely matches the requested platform across both available inventories. Cross-platform ID collisions, offline or unauthorized Android matches, and unavailable opposite inventories skip app-side dispatch while preserving the already resolved native target. Complete coordinate pairs remain native-direct, partial-coordinate labels retain semantic handling, and `auto` remains React-first.

Fixes #80. Depends on #91 and #93; prerequisite commits are included with merge ancestry while targeting main.

All SimView work before input dispatch shares a bounded setup deadline, including provider discovery, initial handshake, cached state and observation refresh, semantic lookup, and geometry. A clearly unavailable or timed-out pre-dispatch provider can fall through to IDB, and unavailable discovery is retried so a provider installed later can recover without restarting Metro MCP. Provider discovery is cached per platform, so an Android-only probe cannot suppress later iOS IDB discovery. Android discovery filters out the iOS-only IDB backend before any command probe, so a stalled IDB installation cannot block a ready SimView session. In auto mode a provider receipt that explicitly reports accepted input with no dispatch can safely fall through; explicit-provider selection, semantic rejection, and dispatch uncertainty remain terminal. IDB discovery, capability probes, accessibility and geometry reads, and action processes are independently bounded; a timeout after possible dispatch is terminal and cannot duplicate input. Android label lookup now uses bounded, literal-argument `uiautomator` and ADB calls through the same controller, including XML-escaped labels; lookup failure is `not-sent`, while uncertain tap completion is terminal with `dispatch=unknown`.

Validation: Bun 1.3.10, 352 tests, typecheck, package build, docs build, and diff checks pass. The packaged server passed every supported MCP protocol version in direct stdio mode and two simultaneous modern/legacy clients reused one isolated configured daemon; that integration test now has a scoped 15-second timeout covering its bounded startup and cleanup path. SimView and IDB each dispatched real swipes and long presses on the dedicated simulator; IDB also dispatched Home. Fixtures cover project-root resolution for configured SimView and IDB commands during discovery and dispatch, platform-scoped provider discovery, Android SimView selection with a stalled IDB installation, later iOS IDB discovery, partial capabilities, target switching, cleanup, point conversion, deep handlers, controlled caret/range deletion and native fallback when selection is unavailable, uncontrolled Paper/Fabric text fields on iOS and Android, selected-serial key dispatch, bounded Android label lookup and dispatch, escaped accessibility labels, cross-platform target mismatches and ID collisions, unavailable inventories, coordinate behavior, exact pre-dispatch timeout fallback, receipt uncertainty, and duplicate-input prevention. The inherited evaluator passed the direct connected-Hermes completion matrix. Three simplification passes used AGENTS.md, followed by a clean independent local review.

Final integration validation (2026-09-04), head `d88cd66`: 352 full tests, typecheck, production build, and diff checks pass. All eleven PR heads combine in the original local worktree; the combined build passes 459 tests, live Hermes comparisons, modern/legacy MCP HTTP and stdio checks, 27 functional tool calls, and a generated Appium sign-in round trip on the dedicated iOS simulator. Simplify and independent local review completed.
